### PR TITLE
OK, so it turns out ZIP file importing was far from being fixed in my…

### DIFF
--- a/artwork_uploader.py
+++ b/artwork_uploader.py
@@ -236,7 +236,7 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
         filename:       The filename of the bulk import file being processed.
     """
 
-    # Track successful poster uploads (those with ✓)
+    # Track successful poster uploads (those with ✅ or ♻️)
     success_counter = [0]
 
     try:
@@ -270,10 +270,11 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
                 except Exception:
                     pass
 
-            notify_web(instance, "progress_bar", {"message": f"{i + 1} of {len(parsed_urls)}", "percent" : ((i + 1) / len(parsed_urls)) * 100})
+            percent = ((i + 1) / len(parsed_urls)) * 100
+            notify_web(instance, "progress_bar", {"message": f"{i + 1} / {len(parsed_urls)} ({percent.__round__()}%)", "percent" : percent})
 
         # All done, update the UI
-        notify_web(instance, "progress_bar", {"message": f"{len(parsed_urls)} of {len(parsed_urls)}", "percent" : 100})
+        notify_web(instance, "progress_bar", {"message": f"{len(parsed_urls)} of {len(parsed_urls)} (100%)", "percent" : 100})
         update_status(instance, "Bulk import scraping completed.", color="success")
 
         # Log the completion of the bulk import process
@@ -343,7 +344,7 @@ def scrape_and_upload(instance: Instance, url, options, success_counter=None):
 
 def process_uploaded_artwork(instance: Instance, file_list, options, filters, plex_title = None, plex_year = None):
     """
-    Process uploaded artwork files and upload to Plex.
+    Process uploaded artwork files and upload to Plex or save to Kometa asset directory.
 
     This is now a thin wrapper around ArtworkProcessor that handles
     UI updates via callbacks.
@@ -357,7 +358,7 @@ def process_uploaded_artwork(instance: Instance, file_list, options, filters, pl
 
     def progress_callback(current: int, total: int):
         percent = (current / total * 100) if total > 0 else 0
-        message = f"{current} of {total}" if current > 0 else ""
+        message = f"{current} / {total} ({percent.__round__()}%)" if current > 0 else ""
         notify_web(instance, "progress_bar", {"message": message, "percent": percent})
 
     def debug_callback(message: str, context: str):

--- a/core/__version__.py
+++ b/core/__version__.py
@@ -5,8 +5,8 @@ This module provides version metadata for the application.
 Import version information from here rather than hardcoding it elsewhere.
 """
 
-__version__ = "0.6.4"
-__version_info__ = (0, 6, 4, "patch")
+__version__ = "0.6.5"
+__version_info__ = (0, 6, 5, "patch")
 __author__ = "mscodemonkey"
 __license__ = "MIT"
 __url__ = "https://github.com/mscodemonkey/artwork-uploader-plex"

--- a/processors/upload_processor.py
+++ b/processors/upload_processor.py
@@ -103,12 +103,12 @@ class UploadProcessor:
         results = []
         artwork_source = artwork["source"]
         description = f"{artwork['title']} ({artwork['year']}) : {artwork['author']}"
-        filter_type = FilterType.MOVIE_POSTER.value if artwork["type"] == "poster" else FilterType.BACKGROUND.value
-        artwork_type = "Poster" if artwork["type"] == "poster" else "Background"
+        filter_type = FilterType.MOVIE_POSTER.value if artwork.get("type") == "poster" else FilterType.BACKGROUND.value
+        artwork_type = "Poster" if artwork.get("type") == "poster" else "Background"
         artwork_id = artwork_type[0]
 
         if movie_items:
-            debug_me(f"Found TMDb ID '{artwork['tmdb_id']}' in {len(libraries)} libraries.", "UploadProcessor/process_movie_artwork")
+            debug_me(f"Found TMDb ID '{artwork.get('tmdb_id')}' in {len(libraries)} libraries.", "UploadProcessor/process_movie_artwork")
             for movie_item, library in zip(movie_items, libraries):
                 # Use the actual movie title from Plex in case it differs from the artwork title (if it's a foreign title, etc.)
                 desc = description.replace(artwork["title"], movie_item.title) if movie_item.title != artwork["title"] else description
@@ -156,11 +156,11 @@ class UploadProcessor:
         filter_type = None
         artwork_id = None
         artwork_source = artwork["source"]
-        result = "none"
+        result = None
         results = []
         self.staging: bool = self.kometa and (globals.config.stage_assets or self.options.stage)
 
-        season = artwork['season']
+        season = artwork.get('season')
         if is_numeric(season) and season == 0:
             season = "Specials"
         else:
@@ -193,7 +193,7 @@ class UploadProcessor:
                 item_path = tv_show.seasons()[0].episodes()[0].media[0].parts[0].file
                 path_parts = []
                 path_parts = get_path_parts(item_path)
-                asset_folder = path_parts[-3] if path_parts[-2].lower().startswith("season") else path_parts[-2]
+                asset_folder = path_parts[-3] if path_parts[-2].lower().startswith("season") or path_parts[-2].lower().startswith("specials") else path_parts[-2]
                 try:
                     if artwork["season"] == "Cover":
                         upload_target = tv_show

--- a/scrapers/scraper.py
+++ b/scrapers/scraper.py
@@ -33,6 +33,7 @@ class Scraper:
         self.source: Optional[str] = None
         self.title: Optional[str] = None
         self.author: Optional[str] = None
+        self.exclusions: int = 0
 
         # Set source based on the contents of the URL
         parsed_url = urlparse(url)
@@ -75,7 +76,7 @@ class Scraper:
         try:
             theposterdb_scraper = ThePosterDBScraper(self.url)
             theposterdb_scraper.set_options(self.options)
-            theposterdb_scraper.scrape()
+            self.exclusions = theposterdb_scraper.scrape()
 
             self.title = theposterdb_scraper.title
             self.author = theposterdb_scraper.author
@@ -104,7 +105,7 @@ class Scraper:
 
             mediux_scraper = MediuxScraper(self.url)
             mediux_scraper.set_options(self.options)
-            mediux_scraper.scrape()
+            self.exclusions = mediux_scraper.scrape()
 
             self.title = mediux_scraper.title
             self.author = mediux_scraper.author

--- a/static/web_interface.js
+++ b/static/web_interface.js
@@ -30,7 +30,7 @@ const bulkFileSwitcher = document.getElementById("switch_bulk_file");
 
 // Event listeners
 document.addEventListener("DOMContentLoaded", function () {
-    updateLog("> New session started with ID: " + instanceId)
+    updateLog("📍 New session started with ID: " + instanceId)
     loadConfig()
     toggleThePosterDBElements();
 });
@@ -1240,6 +1240,8 @@ function uploadFile(file) {
     const logTab = document.querySelector('#scraping-log-tab');
     bootstrap.Tab.getOrCreateInstance(logTab).show();
 
+    socket.emit("display_message", {"message": `Uploading '${file.name}'...`, "title": "uploadFile"});
+
     const reader = new FileReader();
 
     let offset = 0;
@@ -1281,7 +1283,9 @@ function uploadFile(file) {
                 const plex_year = document.getElementById("plex_year").value;
                 const plex_title = document.getElementById("plex_title").value;
 
+                socket.emit("display_message", {"message": `Successfully uploaded '${file.name}'`, "title": "uploadFile"});
                 socket.emit("upload_complete", {instance_id: instanceId, fileName: file.name, options: options, filters: filters, plex_title: plex_title, plex_year: plex_year });
+                progress_bar(100, "Upload complete!");
 
                 return; // Ensure no further execution in this function
             }
@@ -1299,6 +1303,8 @@ function uploadFile(file) {
 
                 offset += CHUNK_SIZE;
                 let progress = Math.round((offset / arrayBuffer.byteLength) * 100);
+                updateStatus(`Uploading '${file.name}'...`, "info", false, false, "cloud-upload");
+                progress_bar(progress, `${progress}%`);
 
                 if (offset < arrayBuffer.byteLength) {
                     setTimeout(sendChunk, 10);

--- a/utils/notifications.py
+++ b/utils/notifications.py
@@ -47,5 +47,5 @@ def notify_web(instance: Instance, event, data_to_include = None):
     if instance.mode == "web":
         instance_data = {"instance_id": instance.id, "broadcast": instance.broadcast}
         merged_arguments = data_to_include | instance_data
-        debug_me(merged_arguments, "notify_web")
+        debug_me(f"{ANSI_BOLD}{BOOTSTRAP_COLORS.get('info').get('ansi')}[{event}]{ANSI_RESET} {merged_arguments}", "notify_web")
         globals.web_socket.emit(event, merged_arguments)


### PR DESCRIPTION
… last update. I've put a lot more thought into it and made the following changes:

* Refactored the file name parsing logic to better determine, for each artwork file in a ZIP file, if it's a show cover or title card (if it contains season and/or episode information), a movie or show, a background or a collection poster
* The script assumed the ZIP contained assets for a single TV show or movie, however that's not always the case. If you download a ZIP file for an author's assets or for a collection it can contain a mix of assets for TV shows or movies. So I implemented a function to search Plex for the title (and year of available) of each asset to determine if it's a Show or Movie, fetch the TMDB ID in the process for later use and skip the asset if the show or movie is not on Plex.
* So now the search by title and year is only in this new function and not needed anymore in the find_in_library function where the TMDB ID will already have been obtained and therefore it only needs to support search by ID.
* Added some additional logic to determine whether an asset is a background or poster based on orientation (it was already there but only for TV shows, now it's there for any kind of asset)
* Fixed the upload progress indicator when uploading ZIP files and tweaked the artwork processing progress indicator.
* The feature has now been extensively tested with a variety of ZIP files from Mediux and TPDB containing assets for TV shows, movies, collections (with mix of movie and show assets) and entire author assets. Some bugs may still be present but it's much more robust than before.

In addition to these changes related to ZIP file importing, I also changed:

* Bumped version to 0.6.5
* I noticed that the --exclude option still required iterating through all the excluded artworks and skipping them one by one, which could be very slow (I learned this by trying to download artwork for a single season for a TV show with 11 seasons), so I implemented the exclusion logic in the scraper itself, and provided logging indicating how many assets were skipped base on exclusions, so now the corresponding artworks are not included in the iterative process and it speeds things up a lot
* Fixed a bug where the asset folder was being incorrectly obtained when there was a Specials season named "Specials" instead of "Season 0"