### PR TITLE
Added support for square art assets from Mediux

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ There are also a couple of new options for thePosterDb, which will allow you to 
 And there are other options such as per-URL filtering, fixing missing things that I found while I was using the tool (where I wanted to apply episode title cards but didn't like the season artwork for example).  And if you don't like a particular piece of artwork or poster from a set, you can now exclude it. You can also exclude entire seasons or individual episodes, that way the app doesn't have to provess all the previous seasons for which you already have artwork applied.
 
 ### Kometa support
-Kometa support is offered in two different ways. The simple way is for the script to reset Kometa's overlay label so the next time Kometa runs the overlay gets added to the new artwork (`reset_overlay` set to `true` in config.json). Alternatively, if you're using Kometa's [asset directory](https://kometa.wiki/en/latest/kometa/guides/assets/) to manage all your Plex custom art, you can check the option to save the artwork to the Kometa asset directory instead of applying it direectly to Plex (either in the GUI or by setting `save_to_kometa` to `true` in the config.json file). In that case, whenever Kometa runs again it will apply all new or updated artwork with its corresponding overlays. If this option is enabled, you will have to set the Kometa base directory (`kometa_base` in the config file, or with the appropriate text field in the GUI) to the base asset directory.
+Kometa support is offered in two different ways. The simple way is for the script to reset Kometa's overlay label so the next time Kometa runs the overlay gets added to the new artwork (`reset_overlay` set to `true` in config.json). Alternatively, if you're using Kometa's [asset directory](https://kometa.wiki/en/latest/kometa/guides/assets/) to manage all your Plex custom art, you can check the option to save the artwork to the Kometa asset directory instead of applying it directly to Plex (either in the GUI or by setting `save_to_kometa` to `true` in the config.json file). In that case, whenever Kometa runs again it will apply all new or updated artwork with its corresponding overlays. If this option is enabled, you will have to set the Kometa base directory (`kometa_base` in the config file, or with the appropriate text field in the GUI) to the base asset directory.
 
 Kometa asset directory support works on the following assumptions:
 
@@ -249,13 +249,14 @@ This is optional - if you don't do this, a new config.json will be created when 
 - Provide a comma-separated list of Apprise service URLs to send notifications upong completion of scheduled bulk imports. Check [the Apprise service list](https://appriseit.com/services/) for details on the supported services and how to set them up and generate a notification URL for your favorite services.
 
 ### Filter options
-Both mediux_filters and tpdb_filters specify which artwork types to upload by including the flags below.  Specify one or more in an array ["show_cover, "title_card"]. TPDb does not provide title cards or backgrounds so these filters are not available in the web UI.
-      - show_cover
-      - background
-      - season_cover
-      - title_card
-      - movie_poster
-      - collection_poster
+Both mediux_filters and tpdb_filters specify which artwork types to upload by including the flags below.  Specify one or more in an array ["show_cover, "title_card"]. TPDb does not provide title cards, backgrounds or square art so these filters are not available in the web UI.
+- show_cover
+- background
+- square_art
+- season_cover
+- title_card
+- movie_poster
+- collection_poster
 
 ---
 # Usage
@@ -356,9 +357,10 @@ The script supports various command-line arguments for flexible use.
   - ```--exclude s00e01 s02``` - Excludes specials episode 1 and all of season 2
   - You can mix artwork IDs and episode/season patterns in the same command
     
-```--filters <filter1> [<filter2> <filter3> ...]``` will **only** upload the selected artwork types, based on the options below
+```--filters <filter1> [<filter2> <filter3> ...]``` will **only** upload the selected artwork types, based on the options below:
 - show_cover
 - background
+- square_art
 - season_cover
 - title_card 
 - movie_poster
@@ -584,6 +586,8 @@ Both the ```mediux_filters``` and ```tvdb_filters``` options in **config.json** 
 ```show_cover``` - Upload a cover for the TV show
 
 ```background``` - Upload background images
+
+```square_art``` - Upload square art background images for mobile platforms
 
 ```season_cover``` - Upload covers for each individual season
 

--- a/artwork_uploader.py
+++ b/artwork_uploader.py
@@ -367,8 +367,6 @@ def process_uploaded_artwork(instance: Instance, file_list, skipped, zip_title, 
 
     def progress_callback(current: int, total: int, title: str, bar_type:str = "main", bar_speed:str = "smooth"):
         percent = (current / total * 100) if total > 0 else 0
-        #message = f"{current} / {total} ({percent.__round__()}%)" if current > 0 else ""
-        #message = f"{title} • {percent.__round__()}%" #if current > 0 else ""
         notify_web(instance, "progress_bar", {"message": title, "percent": percent, "bar_type": bar_type, "bar_speed": bar_speed})
 
     def debug_callback(message: str, context: str = None):

--- a/core/__version__.py
+++ b/core/__version__.py
@@ -5,8 +5,8 @@ This module provides version metadata for the application.
 Import version information from here rather than hardcoding it elsewhere.
 """
 
-__version__ = "0.8.3"
-__version_info__ = (0, 8, 3, "patch")
+__version__ = "0.8.4"
+__version_info__ = (0, 8, 4, "patch")
 __author__ = "mscodemonkey"
 __license__ = "MIT"
 __url__ = "https://github.com/mscodemonkey/artwork-uploader-plex"

--- a/core/config.py
+++ b/core/config.py
@@ -109,7 +109,7 @@ class Config:
             "bulk_txt": "bulk_import.txt",
             "tv_library": ["TV Shows"],
             "movie_library": ["Movies"],
-            "mediux_filters": ["title_card", "background", "season_cover", "show_cover", "movie_poster", "collection_poster"],
+            "mediux_filters": ["title_card", "background", "season_cover", "show_cover", "movie_poster", "collection_poster", "square_art"],
             "tpdb_filters": ["season_cover", "show_cover", "movie_poster", "collection_poster"],
             "kometa_base": "",
             "temp_dir": "",

--- a/core/enums.py
+++ b/core/enums.py
@@ -13,6 +13,7 @@ class FilterType(str, Enum):
     SHOW_COVER = "show_cover"
     MOVIE_POSTER = "movie_poster"
     COLLECTION_POSTER = "collection_poster"
+    SQUARE_ART = "square_art"
 
 
 class MediaType(str, Enum):
@@ -69,3 +70,5 @@ class FileType(str, Enum):
     TITLE_CARD = "title_card"
     BACKDROP = "backdrop"
     POSTER = "poster"
+    MOVIE_POSTER = "movie_poster"
+    SQUARE_ART = "album_art"

--- a/models/arguments.py
+++ b/models/arguments.py
@@ -7,7 +7,7 @@ import argparse
 # --add-sets        Adds ALL the "additional set" sections from TPDb page as well as the main posters
 # --add-posters     Adds the "additional posters" section from TPDb page as well as the main posters
 # --force           Forces each poster to upload even, if the same artwork is already there according to the label.
-# --filters         Specify one or more filters, only these types will be applied (e.g., title_card, background, season_cover, show_cover, movie_poster, collection_poster)
+# --filters         Specify one or more filters, only these types will be applied (e.g., title_card, background, square_art, season_cover, show_cover, movie_poster, collection_poster)
 # --exclude         Specify one or more IDs to exclude from any uploads
 # --year            Override the year for matching (use the year in Plex)
 # --debug           Spits out debugging information
@@ -26,7 +26,7 @@ def parse_arguments():
     parser.add_argument('--add-sets', action='store_true', help="Scrape additional sets from same page - TPDb only")
     parser.add_argument('--add-posters', action='store_true', help="Scrape additional posters from same page - TPDb only")
     parser.add_argument('--force', action='store_true', help="Force upload/save even if its the same artwork or artwork already exists")
-    parser.add_argument("--filters", nargs='+', help="Only these artwork types will be applied (e.g., title_card, background, season_cover, show_cover, movie_poster, collection_poster).")
+    parser.add_argument("--filters", nargs='+', help="Only these artwork types will be applied (e.g., title_card, background, square_art, season_cover, show_cover, movie_poster, collection_poster).")
     parser.add_argument("--exclude", nargs='+', help="Specify one or more IDs to exclude from any uploads.")
     parser.add_argument("--year", type=int, help="Override the year for matching (use the year in Plex)")
     parser.add_argument("--debug", action='store_true', help="Spits out debugging information")

--- a/plex/plex_uploader.py
+++ b/plex/plex_uploader.py
@@ -22,7 +22,7 @@ class PlexUploader:
     ) -> None:
         self.upload_target: Union[Movie, Show, Season, Episode, Collection] = upload_target
         self.artwork_type: str = artwork_type
-        self.artwork_id: str = artwork_id.upper() + "ID:"  # This will be BID, CID, PID, SID or EID - for [B]ackgrounds, show [C]overs, [P]osters, [S]eason covers or [T]itle cards for [E]pisodes
+        self.artwork_id: str = artwork_id.upper() + "ID:"  # This will be BID, SAID, CID, PID, SID or EID - for [B]ackgrounds, [S]quare[A]rt, show [C]overs, [P]osters, [S]eason covers or [T]itle cards for [E]pisodes
         self.description: str = "item"
         self.label: Optional[str] = None
         self.artwork: Optional[AnyArtwork] = None
@@ -62,16 +62,25 @@ class PlexUploader:
 
                 if self.artwork_id == "BID:":
                     if self.type == "file":
-                        self.upload_target.uploadArt( filepath = self.artwork['path'])
+                        self.upload_target.uploadArt(filepath = self.artwork['path'])
                     else:
-                        self.upload_target.uploadArt( url = self.artwork["url"])
+                        self.upload_target.uploadArt(url = self.artwork["url"])
                     if self.track_artwork_ids:
                         self.upload_target.addLabel(self.label)
+
+                elif self.artwork_id == "SAID:":
+                    if self.type == "file":
+                        self.upload_target.uploadSquareArt(filepath = self.artwork['path'])
+                    else:
+                        self.upload_target.uploadSquareArt(url = self.artwork["url"])
+                    if self.track_artwork_ids:
+                        self.upload_target.addLabel(self.label)
+
                 else:
                     if self.type == "file":
-                        self.upload_target.uploadPoster( filepath = self.artwork['path'])
+                        self.upload_target.uploadPoster(filepath = self.artwork['path'])
                     else:
-                        self.upload_target.uploadPoster( url = self.artwork["url"])
+                        self.upload_target.uploadPoster(url = self.artwork["url"])
                     if self.track_artwork_ids:
                         self.upload_target.addLabel(self.label)
                 if self.artwork["source"] == ScraperSource.THEPOSTERDB.value and self.type == "url":

--- a/processors/media_metadata.py
+++ b/processors/media_metadata.py
@@ -55,6 +55,8 @@ def parse_title(title: str):
 
     movie_or_show_pattern = r"^(?P<title>.+)\s\((?P<year>\d{4})\)"
     background_pattern = r"^(?P<title>.+)\s\((?P<year>\d{4})\)\s-\sBackdrop"
+    tv_sq_art_pattern = r"^(?P<title>.+)\s\((?P<year>\d{4})\)\s-\sS\d+\sOST" # Mediux square art for season 1 OSTs have this unique format so we can use it to identify them
+    movie_sq_art_pattern = r"^(?P<title>.+)\s\((?P<year>\d{4})\)\s-\sOST"
     collection_pattern = r"^(?!.*\(\d{4}\))(?P<title>.+)$" # Collections don't have a year in their name and some collection poster files don't have the word "Collection" in them
 
     # If it matches the episode pattern (SxxExx), it's a TV show title card
@@ -134,6 +136,36 @@ def parse_title(title: str):
             "author": None
         }
         debug_me(f"Matched '{title}' as either movie, TV show or collection background for '{artwork['title']} ({artwork['year']})'", "media_metadata/parse_title")
+        return artwork
+    
+    # Check if it's a Mediux square art for TV Show
+    tv_sq_art_match = re.match(tv_sq_art_pattern, title, re.IGNORECASE)
+    if tv_sq_art_match:
+        artwork = {
+            "media": "TV Show",
+            "title": tv_sq_art_match.group('title').strip(),
+            "year": tv_sq_art_match.group('year'),
+            "season": "SquareArt",
+            "episode": None,
+            "type": "square_art",
+            "author": None
+        }
+        debug_me(f"Matched '{title}' as square art for TV Show '{artwork['title']} ({artwork['year']})'", "media_metadata/parse_title")
+        return artwork
+    
+    # Check if it's a Mediux square art for Movie
+    movie_sq_art_match = re.match(movie_sq_art_pattern, title, re.IGNORECASE)
+    if movie_sq_art_match:
+        artwork = {
+            "media": "Movie",
+            "title": movie_sq_art_match.group('title').strip(),
+            "year": movie_sq_art_match.group('year'),
+            "season": None,
+            "episode": None,
+            "type": "square_art",
+            "author": None
+        }
+        debug_me(f"Matched '{title}' as square art for Movie '{artwork['title']} ({artwork['year']})'", "media_metadata/parse_title")
         return artwork
 
     # If we got to this point and it doesn't contain "Backdrop", it could still be a background or a movie ot tv show poster

--- a/processors/upload_processor.py
+++ b/processors/upload_processor.py
@@ -24,10 +24,11 @@ class UploadProcessor:
         self.options: Options = Options()
         self.config: Config = Config()
         self.config.load()
-        self.kometa: bool = self.options.kometa or globals.config.save_to_kometa
+
 
     def set_options(self, options: Options) -> None:
         self.options = options
+        self.kometa: bool = self.options.kometa or globals.config.save_to_kometa
 
     def process_collection_artwork(self, artwork: CollectionArtwork) -> Optional[str]:
 
@@ -44,20 +45,20 @@ class UploadProcessor:
         result = None
         results = []
         description = f"{artwork["title"]} • {artwork["author"]}"
-        artwork_type = "Poster" if artwork["type"] == "collection_poster" else "Background"
-        artwork_id = artwork_type[0]
+        artwork_type = "Poster" if artwork["type"] == "collection_poster" else "Square art" if artwork["type"] == "square_art" else "Background"
+        artwork_id = "SA" if artwork["type"] == "square_art" else artwork_type[0]
 
         if collection_items:
             debug_me(f"Found collection '{artwork['title']}' in {len(libraries)} libraries.", "UploadProcessor/process_collection_artwork")
             for collection_item, library in zip(collection_items, libraries):
-                if self.options.kometa or globals.config.save_to_kometa:
+                if self.kometa:
                     asset_folder = collection_item.title.replace("/", "").replace(":", "")
                     saver = KometaSaver(artwork_type, library)
                     saver.set_artwork(artwork)
                     base_dir = ("/temp" if self.options.temp else "/assets") if globals.docker else getattr(globals.config, "temp_dir" if self.options.temp else "kometa_base", None)
                     saver.dest_dir = os.path.join(base_dir, library, asset_folder)
                     debug_me(f"Destination directory is {saver.dest_dir}", "UploadProcessor/process_collection_artwork")
-                    saver.dest_file_name = artwork_type.lower()
+                    saver.dest_file_name = "square" if artwork_type.lower() == "square art" else artwork_type.lower()
                     saver.dest_file_ext = ".jpg"
                     saver.set_description(description)
                     saver.set_options(self.options)
@@ -83,8 +84,8 @@ class UploadProcessor:
         result = None
         results = []
         description = f"{artwork['title']} ({artwork['year']}) • {artwork['author']}"
-        artwork_type = "Poster" if artwork.get("type") == "movie_poster" else "Background"
-        artwork_id = artwork_type[0]
+        artwork_type = "Poster" if artwork.get("type") == "movie_poster" else "Square art" if artwork.get("type") == "square_art" else "Background"
+        artwork_id = "SA" if artwork.get("type") == "square_art" else artwork_type[0]
 
         # Since the TBDb scraper doesn't fetch the TMDb ID up front for each poster, we need to get it here
         if not artwork.get("tmdb_id") and artwork.get("source") == ScraperSource.THEPOSTERDB.value and artwork.get("id") != "Upload":
@@ -115,7 +116,7 @@ class UploadProcessor:
             for movie_item, library in zip(movie_items, libraries):
                 # Use the actual movie title from Plex in case it differs from the artwork title (if it's a foreign title, etc.)
                 desc = description.replace(artwork["title"], movie_item.title) if movie_item.title != artwork["title"] else description
-                if self.options.kometa or globals.config.save_to_kometa:
+                if self.kometa:
                     item_path = movie_item.media[0].parts[0].file
                     path_parts = []
                     path_parts = get_path_parts(item_path)
@@ -125,7 +126,7 @@ class UploadProcessor:
                     base_dir = ("/temp" if self.options.temp else "/assets") if globals.docker else getattr(globals.config, "temp_dir" if self.options.temp else "kometa_base", None)
                     saver.dest_dir = os.path.join(base_dir, library, asset_folder)
                     debug_me(f"Destination directory is {saver.dest_dir}", "UploadProcessor/process_movie_artwork")
-                    saver.dest_file_name = artwork_type.lower()
+                    saver.dest_file_name = "square" if artwork.get("type") == "square_art" else artwork_type.lower()
                     saver.dest_file_ext = ".jpg"
                     saver.set_description(desc)
                     saver.set_options(self.options)
@@ -165,7 +166,7 @@ class UploadProcessor:
             description = f"{artwork['title']} ({artwork['year']}) • {artwork['author']} • {season} • Episode {artwork['episode']:02}"
         elif (artwork['episode'] is None or artwork['episode'] == "Cover") and is_numeric(artwork['season']):
             description = f"{artwork['title']} ({artwork['year']}) • {artwork['author']} • {season}"
-        elif artwork['season'] is None or artwork["season"] == "Cover" or artwork["season"] == "Backdrop":
+        elif artwork['season'] is None or artwork["season"] == "Cover" or artwork["season"] == "Backdrop" or artwork["season"] == "SquareArt":
             description = f"{artwork['title']} ({artwork['year']}) • {artwork['author']}"
 
         artwork["year"] = self.options.year if self.options.year else artwork["year"]
@@ -217,6 +218,11 @@ class UploadProcessor:
                         artwork_id = "B"
                         artwork_type = "Background"
                         file_name = "background"
+                    elif artwork["season"] == "SquareArt":
+                        upload_target = tv_show
+                        artwork_id = "SA"
+                        artwork_type = "Square art"
+                        file_name = "square"
                     elif artwork["season"] >= 0:
                         if artwork["episode"] == "Cover" or artwork["episode"] is None:
                             if artwork["season"] in [S.index for S in tv_show.seasons()] or (self.staging and season != "Specials"):
@@ -251,28 +257,27 @@ class UploadProcessor:
                     raise ShowNotFound(f"{desc} | Not available on Plex in {library}: {e}") from e
                     
                 try:
-                    if upload_target or (self.options.kometa or globals.config.save_to_kometa):
-                        if self.kometa:
-                            saver = KometaSaver(artwork_type, library)
-                            saver.set_artwork(artwork)
-                            base_dir = ("/temp" if self.options.temp else "/assets") if globals.docker else getattr(globals.config, "temp_dir" if self.options.temp else "kometa_base", None)
-                            saver.dest_dir = os.path.join(base_dir, library, asset_folder)
-                            debug_me(f"Destination directory is {saver.dest_dir}", "UploadProcessor/process_tv_artwork")
-                            saver.dest_file_name = file_name
-                            saver.dest_file_ext = ".jpg"
-                            saver.set_description(desc)
-                            saver.set_options(self.options)
-                            result = saver.save_to_kometa()
-                            results.append(result)
-                        else:
-                            uploader = PlexUploader(upload_target, artwork_type, artwork_id)
-                            uploader.set_artwork(artwork)
-                            uploader.track_artwork_ids = self.config.track_artwork_ids
-                            uploader.reset_overlay = self.config.reset_overlay
-                            uploader.set_description(desc)
-                            uploader.set_options(self.options)
-                            result = uploader.upload_to_plex()
-                            results.append(result)
+                    if self.kometa:
+                        saver = KometaSaver(artwork_type, library)
+                        saver.set_artwork(artwork)
+                        base_dir = ("/temp" if self.options.temp else "/assets") if globals.docker else getattr(globals.config, "temp_dir" if self.options.temp else "kometa_base", None)
+                        saver.dest_dir = os.path.join(base_dir, library, asset_folder)
+                        debug_me(f"Destination directory is {saver.dest_dir}", "UploadProcessor/process_tv_artwork")
+                        saver.dest_file_name = file_name
+                        saver.dest_file_ext = ".jpg"
+                        saver.set_description(desc)
+                        saver.set_options(self.options)
+                        result = saver.save_to_kometa()
+                        results.append(result)
+                    elif upload_target:
+                        uploader = PlexUploader(upload_target, artwork_type, artwork_id)
+                        uploader.set_artwork(artwork)
+                        uploader.track_artwork_ids = self.config.track_artwork_ids
+                        uploader.reset_overlay = self.config.reset_overlay
+                        uploader.set_description(desc)
+                        uploader.set_options(self.options)
+                        result = uploader.upload_to_plex()
+                        results.append(result)
                 except Exception:
                     raise
         else:

--- a/scrapers/mediux_scraper.py
+++ b/scrapers/mediux_scraper.py
@@ -289,6 +289,12 @@ class MediuxScraper:
                         self.errored += 1
                         continue
 
+                elif data["fileType"] == FileType.SQUARE_ART.value:
+                    self.callbacks.debug(f"Square art detected for set id: {data.get('set_id', {}).get('id', "unknown")}", "MediuxScraper/_process_set")
+                    season = "SquareArt"
+                    episode = None
+                    file_type = "square_art" 
+
                 else:
                     # Unknown file type or structure, skip
                     self.callbacks.debug(f"⏩ Skipping unknown TV show file type: {data.get('fileType')}", "MediuxScraper/_process_set")
@@ -298,7 +304,6 @@ class MediuxScraper:
                     continue
 
             elif media_type == MediaType.MOVIE.value:
-
                 if data["movie_id"]:
                     movie_id = data["movie_id"]["id"]
                     if set_data.get("movie"):
@@ -318,11 +323,25 @@ class MediuxScraper:
                     title = set_data["collection"]["collection_name"]
                     file_type = "collection_poster"
                 else:
-                    if data["fileType"] == "movie_poster":
+                    if data["fileType"] == FileType.MOVIE_POSTER.value:
                         # This is a collection poster
                         file_type = "collection_poster"
                         title = set_data["collection"]["collection_name"]
-                    elif data["fileType"] == "backdrop":
+
+                    elif data["fileType"] == FileType.SQUARE_ART.value:
+                        # This is a square art
+                        if data["movie_id_ost"]:
+                            movie_id = data["movie_id_ost"]["id"]
+                            if set_data.get("collection") is not None:
+                                movies = set_data["collection"]["movies"]
+                                movie_data = [movie for movie in movies if movie["id"] == movie_id][0]
+                            else:
+                                movie_data = set_data["movie"]
+                            title = movie_data["title"]
+                            year = int(movie_data["release_date"][:4])
+                            file_type = "square_art"
+
+                    elif data["fileType"] == FileType.BACKDROP.value:
                         # This is a movie background
                         if data["movie_id_backdrop"]:
                             movie_id = data["movie_id_backdrop"]["id"]

--- a/templates/web_interface.html
+++ b/templates/web_interface.html
@@ -307,6 +307,7 @@
                                                     <label for="p_filter-movie_poster" class="form-check-label">Movie poster</label>
                                                 </div>
                                             </div>
+                                            <div class="col-12 mb-2"><strong>General</strong></div>
                                             <div class="col-6 col-md-4 col-xl-4">
                                                 <div class="form-check form-switch mb-2">
                                                     <input class="form-check-input" type="checkbox" checked value="collection_poster" id="p_filter-collection_poster"/>
@@ -340,12 +341,6 @@
                                             </div>
                                             <div class="col-6 col-md-4 col-xl-3">
                                                 <div class="form-check form-switch mb-2">
-                                                    <input class="form-check-input" type="checkbox" value="background" id="m_filter-background"/>
-                                                    <label for="m_filter-background" class="form-check-label">Background</label>
-                                                </div>
-                                            </div>
-                                            <div class="col-6 col-md-4 col-xl-3">
-                                                <div class="form-check form-switch mb-2">
                                                     <input class="form-check-input" type="checkbox" value="title_card" id="m_filter-title_card"/>
                                                     <label for="m_filter-title_card" class="form-check-label">Title cards</label>
                                                 </div>
@@ -357,6 +352,19 @@
                                                 <div class="form-check form-switch mb-2">
                                                     <input class="form-check-input" type="checkbox" value="movie_poster" id="m_filter-movie_poster"/>
                                                     <label for="m_filter-movie_poster" class="form-check-label">Movie poster</label>
+                                                </div>
+                                            </div>
+                                            <div class="col-12 mb-2"><strong>General</strong></div>
+                                            <div class="col-6 col-md-4 col-xl-3">
+                                                <div class="form-check form-switch mb-2">
+                                                    <input class="form-check-input" type="checkbox" value="background" id="m_filter-background"/>
+                                                    <label for="m_filter-background" class="form-check-label">Background</label>
+                                                </div>
+                                            </div>
+                                            <div class="col-6 col-md-4 col-xl-3">
+                                                <div class="form-check form-switch mb-2">
+                                                    <input class="form-check-input" type="checkbox" value="square_art" id="m_filter-square_art"/>
+                                                    <label for="m_filter-square_art" class="form-check-label">Square art</label>
                                                 </div>
                                             </div>
                                             <div class="col-6 col-md-4 col-xl-4 mb-3">
@@ -600,12 +608,6 @@
                                             </div>
                                         </div>
                                         <div class="col-6 col-md-4 col-lg-3">
-                                            <div class="form-check form-switch mb-2" id="tpdb-background" style="display: block;">
-                                                <input class="form-check-input" type="checkbox" checked value="background" name="filter" id="filter-background"/>
-                                                <label for="filter-background" class="form-check-label">Background</label>
-                                            </div>
-                                        </div>
-                                        <div class="col-6 col-md-4 col-lg-3">
                                             <div class="form-check form-switch mb-2" id="tpdb-card" style="display: block;">
                                                 <input class="form-check-input" type="checkbox" checked value="title_card" name="filter" id="filter-title_card"/>
                                                 <label for="filter-title_card" class="form-check-label">Title cards</label>
@@ -621,12 +623,25 @@
                                                 <label for="filter-movie_poster" class="form-check-label">Movie poster</label>
                                             </div>
                                         </div>
+                                        <div class="col-12 mb-2"><strong>General</strong></div>
                                         <div class="col-6 col-md-8 col-lg-3">
                                             <div class="form-check form-switch mb-2">
                                                 <input class="form-check-input" type="checkbox" checked
                                                     value="collection_poster" id="filter-collection_poster"/>
                                                 <label for="filter-collection_poster" class="form-check-label">Collection
                                                     poster</label>
+                                            </div>
+                                        </div>
+                                        <div class="col-6 col-md-4 col-lg-3">
+                                            <div class="form-check form-switch mb-2" id="tpdb-background" style="display: block;">
+                                                <input class="form-check-input" type="checkbox" checked value="background" name="filter" id="filter-background"/>
+                                                <label for="filter-background" class="form-check-label">Background</label>
+                                            </div>
+                                        </div>
+                                        <div class="col-6 col-md-4 col-lg-3">
+                                            <div class="form-check form-switch mb-2" id="tpdb-square" style="display: block;">
+                                                <input class="form-check-input" type="checkbox" checked value="square_art" name="filter" id="filter-square_art"/>
+                                                <label for="filter-square_art" class="form-check-label">Square art</label>
                                             </div>
                                         </div>
                                     </div>
@@ -739,12 +754,6 @@
                                     </div>
                                     <div class="col-6 col-md-4 col-lg-3">
                                         <div class="form-check form-switch mb-2">
-                                            <input class="form-check-input" type="checkbox" checked value="background" name="filter" id="upload-filter-background"/>
-                                            <label for="upload-filter-background" class="form-check-label">Background</label>
-                                        </div>
-                                    </div>
-                                    <div class="col-6 col-md-4 col-lg-3">
-                                        <div class="form-check form-switch mb-2">
                                             <input class="form-check-input" type="checkbox" checked value="title_card" name="filter" id="upload-filter-title_card"/>
                                             <label for="upload-filter-title_card" class="form-check-label">Title cards</label>
                                         </div>
@@ -758,10 +767,23 @@
                                             <label for="upload-filter-movie_poster" class="form-check-label">Movie poster</label>
                                         </div>
                                     </div>
+                                    <div class="col-12 mb-2"><strong>General</strong></div>
                                     <div class="col-6 col-md-8 col-lg-3">
                                         <div class="form-check form-switch mb-2">
                                             <input class="form-check-input" type="checkbox" checked value="collection_poster" id="upload-filter-collection_poster"/>
                                             <label for="upload-filter-collection_poster" class="form-check-label">Collection poster</label>
+                                        </div>
+                                    </div>
+                                    <div class="col-6 col-md-4 col-lg-3">
+                                        <div class="form-check form-switch mb-2">
+                                            <input class="form-check-input" type="checkbox" checked value="background" name="filter" id="upload-filter-background"/>
+                                            <label for="upload-filter-background" class="form-check-label">Background</label>
+                                        </div>
+                                    </div>
+                                    <div class="col-6 col-md-4 col-lg-3">
+                                        <div class="form-check form-switch mb-2">
+                                            <input class="form-check-input" type="checkbox" checked value="square_art" name="filter" id="upload-filter-square_art"/>
+                                            <label for="upload-filter-square_art" class="form-check-label">Square art</label>
                                         </div>
                                     </div>
                                 </div>

--- a/web_routes.py
+++ b/web_routes.py
@@ -949,14 +949,20 @@ def extract_and_list_zip(
                 if artwork['media'] == "Movie":
                     if check_image_orientation_func(artwork["path"]) == "landscape":
                         artwork['type'] = "background"
+                    elif artwork['type'] == "square_art" or check_image_orientation_func(artwork["path"]) == "square":
+                        artwork['type'] = "square_art"
                     else:
                         artwork['type'] = "movie_poster"
                 if artwork['media'] == "Collection":
                     if check_image_orientation_func(artwork["path"]) == "landscape":
                         artwork['type'] = "background"
+                    if check_image_orientation_func(artwork["path"]) == "square":
+                        artwork['type'] = "square_art"
                 if artwork['media'] == "unavailable":
                     if check_image_orientation_func(artwork["path"]) == "landscape":
                         artwork['type'] = "background"
+                    if check_image_orientation_func(artwork["path"]) == "square":
+                        artwork['type'] = "square_art"
                     if artwork['type'] == "season_cover":
                         artwork['media'] = "TV Show"
                     else:


### PR DESCRIPTION
v0.8.4
- Bumped version to v0.8.4
- Added support for setting square art assets from Mediux directly to Plex
- Added support for downloading square art assets from Mediux to the Kometa asset directory as square.jpg/png (note: Kometa does not yet support setting these assets)
- Updated data structures and UI to support square art asset
- Fixed a bug where the --kometa CLI argument was being ignored