### PR TITLE
Fix UnboundLocalError on movie collections not named "…Collection" (#53)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -16,6 +16,9 @@ addopts =
 # Test paths
 testpaths = .
 
+# Make the project root importable (e.g. `from scrapers.mediux_scraper import ...`)
+pythonpath = .
+
 # Markers for categorizing tests
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')

--- a/scrapers/mediux_scraper.py
+++ b/scrapers/mediux_scraper.py
@@ -304,6 +304,11 @@ class MediuxScraper:
                     continue
 
             elif media_type == MediaType.MOVIE.value:
+                # Classify by branch, not by whether the title happens to contain the
+                # word "Collection": collection artwork never sets `year`, so routing a
+                # collection whose name lacks "Collection" into the movie branch below
+                # raised UnboundLocalError on `year`.
+                is_collection = False
                 if data["movie_id"]:
                     movie_id = data["movie_id"]["id"]
                     if set_data.get("movie"):
@@ -322,11 +327,13 @@ class MediuxScraper:
                     # This is a collection poster
                     title = set_data["collection"]["collection_name"]
                     file_type = "collection_poster"
+                    is_collection = True
                 else:
                     if data["fileType"] == FileType.MOVIE_POSTER.value:
                         # This is a collection poster
                         file_type = "collection_poster"
                         title = set_data["collection"]["collection_name"]
+                        is_collection = True
 
                     elif data["fileType"] == FileType.SQUARE_ART.value:
                         # This is a square art
@@ -357,6 +364,7 @@ class MediuxScraper:
                             # The only remaining artwork can be the collection background
                             title = set_data["collection"]["collection_name"]
                             file_type = "background"
+                            is_collection = True
 
             image_stub = data["id"]
             poster_url = f"{base_url}{image_stub}{quality_suffix}{cache_buster}"
@@ -401,7 +409,7 @@ class MediuxScraper:
                     )
 
             elif media_type == MediaType.MOVIE.value:
-                if "Collection" in title:
+                if is_collection:
                     if (self.options.has_no_filters() and file_type in self.config.mediux_filters) or self.options.has_filter(file_type):
                         if not self.options.is_excluded(image_stub):
                             self.callbacks.debug(f"{i+1}. ✅ Including {file_type.replace('_', ' ')} for '{title}'.", "MediuxScraper/_process_set")

--- a/tests/test_mediux_scraper_collection.py
+++ b/tests/test_mediux_scraper_collection.py
@@ -1,0 +1,65 @@
+"""
+Regression tests for MediuxScraper collection handling.
+
+Covers the bug where scraping a movie collection whose name does not contain the
+literal word "Collection" raised:
+    UnboundLocalError: cannot access local variable 'year' ...
+because collection artwork was mis-routed into the movie branch (which references
+`year`, only set for individual-movie artwork).
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from models.options import Options
+from scrapers.mediux_scraper import MediuxScraper
+
+
+class _NoopCallbacks:
+    """Every callback (debug/log/...) is a no-op that still evaluates its args."""
+
+    def __getattr__(self, _name):
+        return lambda *a, **k: None
+
+
+def _make_scraper():
+    # Avoid touching config.json / Plex; just exercise _process_set in isolation.
+    with patch("core.config.Config.load", lambda self: None):
+        scraper = MediuxScraper(url="test", callbacks=_NoopCallbacks())
+    scraper.set_options(Options())  # defaults: no filters, no exclusions
+    scraper.config.mediux_filters = ["collection_poster", "background", "movie_poster"]
+    return scraper
+
+
+def _collection_poster_set(collection_name):
+    """A minimal MediUX set payload consisting of a single collection poster."""
+    file_entry = {
+        "movie_id": None,
+        "collection_id": {"id": 1},
+        "show_id": None,
+        "show_id_backdrop": None,
+        "episode_id": None,
+        "season_id": None,
+        "id": "img123",
+        "fileType": "poster",
+    }
+    return {"files": [file_entry], "collection": {"collection_name": collection_name}}
+
+
+@pytest.mark.unit
+def test_collection_without_word_collection_in_name_does_not_crash():
+    # Regression: this used to raise UnboundLocalError on `year`.
+    scraper = _make_scraper()
+    scraper._process_set(_collection_poster_set("James Bond"))
+    assert len(scraper.collection_artwork) == 1
+    assert scraper.collection_artwork[0]["title"] == "James Bond"
+    assert scraper.collection_artwork[0]["type"] == "collection_poster"
+
+
+@pytest.mark.unit
+def test_collection_with_word_collection_in_name_still_works():
+    scraper = _make_scraper()
+    scraper._process_set(_collection_poster_set("James Bond Collection"))
+    assert len(scraper.collection_artwork) == 1
+    assert scraper.collection_artwork[0]["title"] == "James Bond Collection"


### PR DESCRIPTION
Fixes #53.

## Problem

Scraping a MediUX **movie collection** whose collection name doesn't contain the literal word "Collection" crashes:

```
❌ Scraper error: Can't scrape from MediUX: cannot access local variable 'year' where it is not associated with a value
```

In `_process_set()`, collection artwork (collection poster / collection background) sets `title` but never `year` — `year` is only assigned for individual-movie artwork. Collection-vs-movie was then decided with `if "Collection" in title:`, so a collection whose name lacks that word fell into the movie branch and referenced the unset `year`.

Because `year` is function-local, it only surfaces when such a collection asset is processed before any individual movie has set `year` (e.g. the collection poster is first in the set, or the set is collection-only). TV is unaffected — that branch already defaults `year = None` up front.

## Fix

Classify by an explicit `is_collection` flag set in the three collection branches, instead of the fragile title substring. This fixes the crash *and* the underlying misrouting (defaulting `year` alone would just move the crash to `movie_id`, which is also unset on that path).

## Tests

Adds `tests/test_mediux_scraper_collection.py` — a hermetic regression test (no config/Plex/network; `Config.load` patched, no-op callbacks) that drives `_process_set()` with a collection poster named `"James Bond"` (reproduces the crash on current `main`) and `"James Bond Collection"` (the previously-working case). Also adds `pythonpath = .` to `pytest.ini` so the suite imports from the repo root under a plain `pytest` invocation.

```
$ pytest -q
tests/test_mediux_scraper_collection.py ..                               [100%]
2 passed
```

## Note

I kept this minimal and low-risk. A broader follow-up would be to drop the `"Collection" in title` heuristic entirely and route all movie/collection artwork by `file_type` — happy to do that in a separate PR if you'd prefer that direction.
