### PR TITLE
Added option to skip artwork with locked fields in Plex

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ The basic version is available now on the bulk imports page, click on the clock 
 
 It's there for when we have API access (and works for scrapers in the meantime) but is limited to running once a day which should be fine.
 
+If you enable ```skip_locked_artwork```, a scheduled user or bulk scrape will only fill items that are still on their default artwork and leave anything you've set by hand untouched, so it's safe to leave running against a curated library.
+
 Additionally, you can configure one or more push notification services so you get a notification every time a scheduled bulk import job completes. Notifications are provided by Apprise. Configure the list of notification services by providing a comma-separated list of Apprise notification URLs through the web UI or via the ```apprise_urls``` variable in the ```config.json```file. Check [the Apprise service list](https://appriseit.com/services/) for details on the supported services and how to set them up and generate a notification URL for your favorite services.
 
 ## Coming soon
@@ -223,6 +225,10 @@ This is optional - if you don't do this, a new config.json will be created when 
 ```"track_artwork_ids"```
 - Setting this to ```true``` will result in speedy scraping re-runs.  It uses Plex labels to store a special ID for the artwork, so that next time, we can check if the scraped artwork is the same as the current artwork and skip re-uploading.
 - By setting this to ```false```, it'll upload every artwork every time you run (like using the --force option for every item).  This can result in long run-times, especially if you're using ThePosterDB.  We recommend you leave this as **true** and use --force when you need to!
+
+```"skip_locked_artwork"```
+- Setting this to ```true``` will skip any artwork whose target field (poster, background or square art) is locked in Plex, unless ```--force``` is used.  Plex locks a field whenever artwork is deliberately set - manually or by an upload - so this makes scheduled bulk imports and user scrapes fill items still on default artwork while leaving anything you've already set alone.
+- Setting to ```false``` (the default) keeps the existing behaviour where artwork is applied regardless of locks.
 
 ```"auto_manage_bulk_files"```
 - Setting this to ```true``` will automatically add, label and sort URLs from the scrape tab into the currently loaded bulk import file.  At the moment it won't auto-save, but I might add that later.
@@ -346,6 +352,8 @@ The script supports various command-line arguments for flexible use.
 ```--add-posters``` will also parse the additional posters section of the set, when using the Poster DB
    
 ```--force``` will force the artwork to be updated even if it's the same as the one on plex already - or maybe you changed the artwork manually and want to override it...
+    
+```--skip-locked``` will skip any artwork whose target field is locked in Plex (i.e. it's been deliberately set, manually or by a previous upload), unless ```--force``` is also used.  This is the same as setting ```skip_locked_artwork``` to ```true``` in ```config.json```, but per URL.
     
 ```--exclude <id1> [<id2> <id3> ...]``` will exclude the poster or artwork with the specified ID from being uploaded.  Grab the ID from the session log...
 - ThePosterDB is a number

--- a/artwork_uploader.py
+++ b/artwork_uploader.py
@@ -640,6 +640,7 @@ if __name__ == "__main__":
     cli_options = Options(add_posters=args.add_posters,
                           add_sets=args.add_sets,
                           force=args.force,
+                          skip_locked=args.skip_locked,
                           filters=args.filters,
                           exclude=args.exclude,
                           year=args.year,

--- a/artwork_uploader.py
+++ b/artwork_uploader.py
@@ -385,7 +385,8 @@ def process_uploaded_artwork(instance: Instance, file_list, skipped, zip_title, 
         year=int(plex_year) if plex_year else None, 
         temp=True if "temp" in options else False, 
         stage=True if "stage" in options else False, 
-        force=True if "force" in options else False
+        force=True if "force" in options else False,
+        skip_locked=True if "skip-locked" in options else False
     )
     processor = ArtworkProcessor(globals.plex, callbacks)
     processor.process_uploaded_files(file_list, skipped, zip_title, zip_author, zip_source, opts, override_title=plex_title)

--- a/core/config.py
+++ b/core/config.py
@@ -30,6 +30,7 @@ class Config:
         save_to_kometa: Whether to save artwork to Kometa
         stage_assets: Whether to download assets for seasons and episodes that are not in Plex yet (except Specials)
         track_artwork_ids: Whether to track artwork IDs using Plex labels
+        skip_locked_artwork: Whether to skip artwork whose target field is locked in Plex (already set)
         auto_manage_bulk_files: Whether to auto-organize bulk files
         reset_overlay: Whether to reset Kometa overlay labels on upload
         schedules: List of scheduled bulk import jobs
@@ -53,6 +54,7 @@ class Config:
         self.save_to_kometa: bool = False
         self.stage_assets: bool = False
         self.track_artwork_ids: bool = True
+        self.skip_locked_artwork: bool = False
         self.auto_manage_bulk_files: bool = True
         self.reset_overlay: bool = False
         self.schedules: List[Dict[str, Any]] = []
@@ -90,6 +92,7 @@ class Config:
             self.stage_assets = config.get("stage_assets", True)
             self.bulk_txt = config.get("bulk_txt", "bulk_import.txt")
             self.track_artwork_ids = config.get("track_artwork_ids", True)
+            self.skip_locked_artwork = config.get("skip_locked_artwork", False)
             self.auto_manage_bulk_files = config.get("auto_manage_bulk_files", True)
             self.reset_overlay = config.get("reset_overlay", False)
             self.schedules = config.get("schedules", [])
@@ -116,6 +119,7 @@ class Config:
             "save_to_kometa": False,
             "stage_assets": False,
             "track_artwork_ids": True,
+            "skip_locked_artwork": False,
             "auto_manage_bulk_files": True,
             "reset_overlay": True,
             "schedules": [],
@@ -156,6 +160,7 @@ class Config:
             "stage_assets": self.stage_assets,
             "bulk_txt": self.bulk_txt,
             "track_artwork_ids": self.track_artwork_ids,
+            "skip_locked_artwork": self.skip_locked_artwork,
             "auto_manage_bulk_files": self.auto_manage_bulk_files,
             "reset_overlay": self.reset_overlay,
             "schedules": self.schedules,

--- a/models/arguments.py
+++ b/models/arguments.py
@@ -7,6 +7,7 @@ import argparse
 # --add-sets        Adds ALL the "additional set" sections from TPDb page as well as the main posters
 # --add-posters     Adds the "additional posters" section from TPDb page as well as the main posters
 # --force           Forces each poster to upload even, if the same artwork is already there according to the label.
+# --skip-locked     Skips artwork when its target field is locked in Plex (i.e. the artwork has been deliberately set), unless --force is used.
 # --filters         Specify one or more filters, only these types will be applied (e.g., title_card, background, square_art, season_cover, show_cover, movie_poster, collection_poster)
 # --exclude         Specify one or more IDs to exclude from any uploads
 # --year            Override the year for matching (use the year in Plex)
@@ -26,6 +27,7 @@ def parse_arguments():
     parser.add_argument('--add-sets', action='store_true', help="Scrape additional sets from same page - TPDb only")
     parser.add_argument('--add-posters', action='store_true', help="Scrape additional posters from same page - TPDb only")
     parser.add_argument('--force', action='store_true', help="Force upload/save even if its the same artwork or artwork already exists")
+    parser.add_argument('--skip-locked', action='store_true', help="Skip artwork when its target field is locked in Plex (already set), unless --force is used")
     parser.add_argument("--filters", nargs='+', help="Only these artwork types will be applied (e.g., title_card, background, square_art, season_cover, show_cover, movie_poster, collection_poster).")
     parser.add_argument("--exclude", nargs='+', help="Specify one or more IDs to exclude from any uploads.")
     parser.add_argument("--year", type=int, help="Override the year for matching (use the year in Plex)")

--- a/models/options.py
+++ b/models/options.py
@@ -20,6 +20,7 @@ class Options:
         stage: Download artwork for seasons and episodes not yet in Plex (except Specials)
         temp: Use temporary directory instead of Kometa asset directory
         force: Force re-upload even if artwork hasn't changed
+        skip_locked: Skip artwork when the target Plex field is locked (already set)
         filters: List of artwork types to include (e.g., ['show_cover', 'title_card'])
         exclude: List of artwork IDs to skip
         year: Override year for Plex matching
@@ -32,6 +33,7 @@ class Options:
     stage: bool = False
     temp: bool = False
     force: bool = False
+    skip_locked: bool = False
     filters: List[str] = field(default_factory=list)
     exclude: Optional[List[str]] = None
     year: Optional[int] = None

--- a/plex/plex_uploader.py
+++ b/plex/plex_uploader.py
@@ -30,6 +30,7 @@ class PlexUploader:
         self.type: Optional[str] = None
         self.track_artwork_ids: bool = True
         self.reset_overlay: bool = False
+        self.skip_locked: bool = False
 
     def set_artwork(self, artwork: AnyArtwork) -> None:
         self.artwork = artwork
@@ -56,6 +57,8 @@ class PlexUploader:
 
     def upload_to_plex(self) -> str:
         try:
+            if self.skip_locked and not self.options.force and self.artwork_field_is_locked():
+                return f'🔒 {self.description} | {self.artwork_type} locked, skipped in {self.upload_target.librarySectionTitle}'
             if self.artwork_exists_on_plex() is False or self.options.force:
 
                 self.process_overlay_label()
@@ -107,4 +110,12 @@ class PlexUploader:
                     self.upload_target.reload()
 
         return existing_artwork
+
+    def artwork_field_is_locked(self) -> bool:
+        # Backgrounds lock the art field, square art locks squareArt, all poster types lock thumb
+        locked_field = "art" if self.artwork_id == "BID:" else "squareArt" if self.artwork_id == "SAID:" else "thumb"
+        for field in self.upload_target.fields:
+            if field.name == locked_field and field.locked:
+                return True
+        return False
 

--- a/processors/upload_processor.py
+++ b/processors/upload_processor.py
@@ -29,6 +29,7 @@ class UploadProcessor:
     def set_options(self, options: Options) -> None:
         self.options = options
         self.kometa: bool = self.options.kometa or globals.config.save_to_kometa
+        self.skip_locked: bool = self.options.skip_locked or globals.config.skip_locked_artwork
 
     def process_collection_artwork(self, artwork: CollectionArtwork) -> Optional[str]:
 
@@ -69,6 +70,7 @@ class UploadProcessor:
                     uploader.set_artwork(artwork)
                     uploader.track_artwork_ids = self.config.track_artwork_ids
                     uploader.reset_overlay = self.config.reset_overlay
+                    uploader.skip_locked = self.skip_locked
                     uploader.set_description(description)
                     uploader.set_options(self.options)
                     result = uploader.upload_to_plex()
@@ -137,6 +139,7 @@ class UploadProcessor:
                     uploader.set_artwork(artwork)
                     uploader.track_artwork_ids = self.config.track_artwork_ids
                     uploader.reset_overlay = self.config.reset_overlay
+                    uploader.skip_locked = self.skip_locked
                     uploader.set_description(desc)
                     uploader.set_options(self.options)
                     result = uploader.upload_to_plex()
@@ -274,6 +277,7 @@ class UploadProcessor:
                         uploader.set_artwork(artwork)
                         uploader.track_artwork_ids = self.config.track_artwork_ids
                         uploader.reset_overlay = self.config.reset_overlay
+                        uploader.skip_locked = self.skip_locked
                         uploader.set_description(desc)
                         uploader.set_options(self.options)
                         result = uploader.upload_to_plex()

--- a/static/web_interface.js
+++ b/static/web_interface.js
@@ -618,6 +618,9 @@ function saveConfig() {
     // Checkbox for reset overlay for Kometa
     save_config.reset_overlay = document.getElementById("reset_overlay").checked;
 
+    // Checkbox for skipping artwork with locked fields in Plex
+    save_config.skip_locked_artwork = document.getElementById("skip_locked_artwork").checked;
+
     // Get selected mediux filters
     save_config.mediux_filters = Array.from(document.querySelectorAll('[id^="m_filter-"]:checked'))
         .map(checkbox => checkbox.value);
@@ -694,6 +697,7 @@ function loadConfig() {
             document.getElementById("temp_dir").value = data.config.temp_dir || "";
             document.getElementById("auto_manage_bulk_files").checked = data.config.auto_manage_bulk_files;
             document.getElementById("reset_overlay").checked = data.config.reset_overlay;
+            document.getElementById("skip_locked_artwork").checked = data.config.skip_locked_artwork;
             document.getElementById("option-add-to-bulk").checked = data.config.auto_manage_bulk_files;
             document.getElementById("apprise_urls").value = data.config.apprise_urls.join(", ");
 

--- a/static/web_interface.js
+++ b/static/web_interface.js
@@ -620,6 +620,7 @@ function saveConfig() {
 
     // Checkbox for skipping artwork with locked fields in Plex
     save_config.skip_locked_artwork = document.getElementById("skip_locked_artwork").checked;
+    toggleSkipLockedCheckbox();
 
     // Get selected mediux filters
     save_config.mediux_filters = Array.from(document.querySelectorAll('[id^="m_filter-"]:checked'))
@@ -722,6 +723,9 @@ function loadConfig() {
 
             // Make sure scraper stage option visibility is set correctly on load
             toggleScraperStageCheckbox();
+
+            // Make sure skip locked artwork option visibility is set correctly on load
+            toggleSkipLockedCheckbox();
 
             // Show/hide logout button based on auth enabled
             if (data.config.auth_enabled) {
@@ -1801,8 +1805,8 @@ function toggleKometaSettings() {
             forceLabel.textContent = 'Force save the artwork, replacing any existing asset';
             forceLabelUpload.textContent = 'Force save the artwork, replacing any existing asset';
         } else {
-            forceLabel.textContent = 'Force upload the artwork, even if it already exists';
-            forceLabelUpload.textContent = 'Force upload the artwork, even if it already exists';
+            forceLabel.textContent = 'Force upload the artwork, even if it\'s locked or it already exists';
+            forceLabelUpload.textContent = 'Force upload the artwork, even if it\'s locked or it already exists';
         }
     }
 
@@ -1810,7 +1814,38 @@ function toggleKometaSettings() {
     toggleTempCheckbox();
     togglePlexOptions();
     toggleScraperStageCheckbox();
+    toggleSkipLockedCheckbox();
 }
+
+function toggleSkipLockedCheckbox() {
+    const saveToKometa = document.getElementById("save_to_kometa").checked;
+    const globalSetting = document.getElementById("skip_locked_artwork").checked;
+    const skipLockedCheckbox = document.getElementById("option-skip-locked");
+    const skipLockedCheckboxUpload = document.getElementById("upload-option-skip-locked");
+
+    // Hide and uncheck the skip locked option if Kometa is enabled
+    if (saveToKometa) {
+        skipLockedCheckbox.parentElement.style.display = "none";
+        skipLockedCheckbox.checked = false;
+        skipLockedCheckboxUpload.parentElement.style.display = "none";
+        skipLockedCheckboxUpload.checked = false;
+    } else {
+        if (globalSetting) {
+            skipLockedCheckbox.parentElement.style.display = "none";
+            skipLockedCheckbox.checked = true;
+            skipLockedCheckboxUpload.parentElement.style.display = "none";
+            skipLockedCheckboxUpload.checked = true;
+        } else {
+            skipLockedCheckbox.parentElement.style.display = "block";
+            skipLockedCheckbox.checked = false;
+            skipLockedCheckboxUpload.parentElement.style.display = "block";
+            skipLockedCheckboxUpload.checked = false;
+        }
+    }
+}
+
+// Add event listener for global skip locked artwork checkbox
+document.getElementById("skip_locked_artwork").addEventListener("change", toggleSkipLockedCheckbox);
 
 function toggleScraperStageCheckbox() {
     const globalStageSetting = document.getElementById("stage_assets").checked;
@@ -1859,15 +1894,19 @@ function toggleTempCheckbox() {
 function togglePlexOptions() {
     const saveToKometa = document.getElementById("save_to_kometa").checked;
     const trackArtworkIDs = document.getElementById("track_artwork_ids").parentElement;
+    const skipLocked = document.getElementById("skip_locked_artwork").parentElement;
     const resetOverlay = document.getElementById("reset_overlay").parentElement;
 
     // Ony show the Track Artwork IDs and Reset Overlay options if Kometa is disabled
     if (!saveToKometa) {
         trackArtworkIDs.style.display = "block";
         resetOverlay.style.display = "block";
+        skipLocked.style.display = "block";
     } else {
         trackArtworkIDs.style.display = "none";
         resetOverlay.style.display = "none";
+        skipLocked.style.display = "none";
+        document.getElementById("skip_locked_artwork").checked = false; // Uncheck the skip locked option if Kometa is enabled
         document.getElementById("track_artwork_ids").checked = true;
     }
 }

--- a/templates/web_interface.html
+++ b/templates/web_interface.html
@@ -384,7 +384,8 @@
                                         <h5 class="mb-3"><i class="bi bi-sliders"></i>&ensp;Additional settings</h5>
                                         <div class="form-check form-switch mb-3" style="display: none;">
                                             <input class="form-check-input" type="checkbox" value="--force" id="track_artwork_ids"/>
-                                            <label for="track_artwork_ids" class="form-check-label">Track artwork ID in Plex labels (recommend to leave checked)</label>
+                                            <label for="track_artwork_ids" class="form-check-label">Track artwork ID in Plex labels</label>
+                                            <i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="(Recommended) Tracks artwork IDs through Plex labels, avoiding having to download assets that have already been downloaded and set"></i>
                                         </div>
                                         <div class="form-check form-switch mb-3">
                                             <input class="form-check-input" type="checkbox" value="auto_manage" id="auto_manage_bulk_files"/>
@@ -392,7 +393,8 @@
                                         </div>
                                         <div class="form-check form-switch mb-3">
                                             <input class="form-check-input" type="checkbox" value="skip_locked_artwork" id="skip_locked_artwork"/>
-                                            <label for="skip_locked_artwork" class="form-check-label">Skip artwork that's locked in Plex, so scheduled runs only fill default artwork</label>
+                                            <label for="skip_locked_artwork" class="form-check-label">Skip locked artwork</label>
+                                            <i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="Skips artwork that is locked in Plex, so scheduled runs only update default artwork"></i>
                                         </div>
                                     </div>
                                 </div>
@@ -549,7 +551,8 @@
                                 </div>
                                 <div class="form-check form-switch mb-2">
                                     <input class="form-check-input" type="checkbox" value="--skip-locked" id="option-skip-locked"/>
-                                    <label for="option-skip-locked" class="form-check-label">Skip artwork that's locked in Plex (already set), unless forced</label>
+                                    <label for="option-skip-locked" class="form-check-label">Skip locked artwork</label>
+                                    <i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="Skips artwork that is locked in Plex, so scheduled runs only update default artwork"></i>
                                 </div>
                                 <div class="form-check form-switch mb-2">
                                     <input class="form-check-input" type="checkbox" value="--stage" id="option-stage"/>
@@ -719,6 +722,11 @@
                                 <label for="upload-option-force" class="form-check-label">Force upload the artwork, even if it
                                     already exists</label>
                             </div>
+                                <div class="form-check form-switch mb-2">
+                                    <input class="form-check-input" type="checkbox" value="skip-locked" id="upload-option-skip-locked"/>
+                                    <label for="upload-option-skip-locked" class="form-check-label">Skip locked artwork</label>
+                                    <i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="Skips artwork that is locked in Plex, so scheduled runs only update default artwork"></i>
+                                </div>                            
                             <div class="form-check form-switch mb-2">
                                 <input class="form-check-input" type="checkbox" value="stage" id="upload-option-stage"/>
                                     <label for="upload-option-stage" class="form-check-label">Stage assests&ensp;</label>

--- a/templates/web_interface.html
+++ b/templates/web_interface.html
@@ -390,6 +390,10 @@
                                             <input class="form-check-input" type="checkbox" value="auto_manage" id="auto_manage_bulk_files"/>
                                             <label for="auto_manage_bulk_files" class="form-check-label">Sort and label bulk files automatically</label>
                                         </div>
+                                        <div class="form-check form-switch mb-3">
+                                            <input class="form-check-input" type="checkbox" value="skip_locked_artwork" id="skip_locked_artwork"/>
+                                            <label for="skip_locked_artwork" class="form-check-label">Skip artwork that's locked in Plex, so scheduled runs only fill default artwork</label>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
@@ -542,6 +546,10 @@
                                     <input class="form-check-input" type="checkbox" value="--force" id="option-force"/>
                                     <label for="option-force" class="form-check-label">Force upload the artwork, even if it
                                         already exists</label>
+                                </div>
+                                <div class="form-check form-switch mb-2">
+                                    <input class="form-check-input" type="checkbox" value="--skip-locked" id="option-skip-locked"/>
+                                    <label for="option-skip-locked" class="form-check-label">Skip artwork that's locked in Plex (already set), unless forced</label>
                                 </div>
                                 <div class="form-check form-switch mb-2">
                                     <input class="form-check-input" type="checkbox" value="--stage" id="option-stage"/>

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -215,7 +215,7 @@ def parse_url_and_options(line):
                     year == None
                 options.year = year
             # If it's one of these flags it shouldn't have any arguments
-            elif flag in ["add-posters", "add-sets", "add-to-bulk", "force", "kometa", "stage", "temp"]:
+            elif flag in ["add-posters", "add-sets", "add-to-bulk", "force", "kometa", "stage", "temp", "skip-locked"]:
                 inv_flags.append(f"--{flag} has too many argumens")
             # If we ge to this point it's not a valid flag
             else:
@@ -224,7 +224,7 @@ def parse_url_and_options(line):
         else:
             if flag in ["filters", "exclude", "year"]:
                 inv_flags.append(f"--{flag} needs at least one argument")
-            elif flag not in ["add-posters", "add-sets" ,"add-to-bulk" ,"force", "kometa", "stage", "temp"]:
+            elif flag not in ["add-posters", "add-sets" ,"add-to-bulk" ,"force", "kometa", "stage", "temp", "skip-locked"]:
                 inv_flags.append(f"--{flag} is not a valid flag")
             else:
                 setattr(options, flag.replace("-","_"), True) # Convert add-posters into add_posters as the Options class expects


### PR DESCRIPTION
This adds an opt-in `skip_locked_artwork` option that skips any artwork whose target field (`thumb` for posters, `art` for backgrounds, `squareArt` for square art) is locked in Plex, unless `--force` is used. Plex locks a field whenever artwork is deliberately set (manually or by an upload), so with this enabled a scheduled bulk import or user-catalog scrape only fills items still on default artwork and never overwrites posters that were chosen by hand or applied earlier. That makes it safe to leave a daily user scrape running against a library that also has curated artwork.

- `skip_locked_artwork` in config.json (default `false`, existing behaviour unchanged), plus `--skip-locked` per URL on the command line, in bulk files and in the web UI
- The lock check runs before the artwork-ID label check, so skipped items keep their tracking labels intact
- Skipped items also skip the label handling and the TPDB rate-limit delay, so re-runs get faster
- No-op in Kometa asset mode (that path already skips existing files)
- README updated
