### PR TITLE
Add a Sonarr/Radarr webhook that applies cached artwork when new media is imported

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,13 @@ Plus you can allow your bulk file to be auto-managed (cleaned and sorted for you
 ### Web UI
 Oh, last but not least, there's now a shiny new web UI so you can leave it running on your Plex Server and access it remotely!
 
+### Automatic artwork for new imports (Sonarr/Radarr webhook)
+With ```cache_user_scrapes``` enabled, the app already knows every poster your favourite ThePosterDB users have uploaded, so it can apply the right artwork within about a minute of Sonarr or Radarr importing something, instead of waiting for the next scheduled run.  Turn on ```enable_webhooks```, set a ```webhook_token``` and list the ThePosterDB users to apply from (in order of preference) under Webhook settings in the web UI, then add a webhook connection in each app:
+
+- **Radarr / Sonarr:** Settings -> Connect -> + -> Webhook.  URL ```http://<artwork-uploader host>:4567/webhook/radarr``` (or ```/webhook/sonarr```), Method POST.  Tick only the "On File Import" trigger.  Send the token as the connection's Password, or as a header: click the **Advanced** (cog) button and add a Header with Key ```X-Webhook-Token``` and Value set to the token.  The Test button is acknowledged so you can save the connection.
+
+On an import the title is looked up in the cached index; if one of the configured users covers it, that single poster (plus season covers for the imported seasons, on TV) is applied through the same processing path as a normal scrape, so artwork labels, locked-artwork skips and Kometa asset mode all behave the same.  Imports usually reach the webhook before Plex has scanned the new file, so the apply retries quietly for a few minutes, then gives up and leaves it to the next scheduled run.  Ambiguous title matches (for example same-name remakes) are skipped rather than guessed, and nothing is applied when no configured user has the title.  The endpoints return 404 while ```enable_webhooks``` is off.
+
 ### Scheduler with Apprise notifications
 Basic scheduler, so that you can leave this running and update all your artwork every day. 
 
@@ -276,6 +283,18 @@ This is optional - if you don't do this, a new config.json will be created when 
 
 ```"apprise_urls"```
 - Provide a comma-separated list of Apprise service URLs to send notifications upong completion of scheduled bulk imports. Check [the Apprise service list](https://appriseit.com/services/) for details on the supported services and how to set them up and generate a notification URL for your favorite services.
+
+```"enable_webhooks"```
+- Set to ```true``` to enable the Sonarr/Radarr import webhook endpoints (```/webhook/radarr``` and ```/webhook/sonarr```).  ```false``` (default) leaves them disabled and returning 404, so the app is unchanged unless you turn this on.  Requires ```cache_user_scrapes``` so there is an index to look artwork up in.
+
+```"webhook_token"```
+- The shared secret that webhook requests must provide, in an ```X-Webhook-Token``` header, as the HTTP Basic password, or a ```?token=``` query parameter.  Required when ```enable_webhooks``` is ```true```.
+
+```"webhook_tpdb_users"```
+- A list of ThePosterDB user names to apply cached artwork from on import, in order of preference (first match wins).  Only used when ```enable_webhooks``` is ```true```.
+
+```"webhook_apply_delay"```
+- Seconds to wait after an import before applying artwork (default ```30```).  The *arr apps fire the webhook the moment they import a file, usually before Plex has scanned it, so this gives Plex a head start; if the item still is not in Plex the apply retries for a few minutes before giving up.
 
 ### Filter options
 Both mediux_filters and tpdb_filters specify which artwork types to upload by including the flags below.  Specify one or more in an array ["show_cover, "title_card"]. TPDb does not provide title cards, backgrounds or square art so these filters are not available in the web UI.

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ With ```cache_user_scrapes``` enabled, the app already knows every poster your f
 
 - **Radarr / Sonarr:** Settings -> Connect -> + -> Webhook.  URL ```http://<artwork-uploader host>:4567/webhook/radarr``` (or ```/webhook/sonarr```), Method POST.  Tick only the "On File Import" trigger.  Send the token as the connection's Password, or as a header: click the **Advanced** (cog) button and add a Header with Key ```X-Webhook-Token``` and Value set to the token.  The Test button is acknowledged so you can save the connection.
 
-On an import the title is looked up in the cached index; if one of the configured users covers it, that single poster (plus season covers for the imported seasons, on TV) is applied through the same processing path as a normal scrape, so artwork labels, locked-artwork skips and Kometa asset mode all behave the same.  Imports usually reach the webhook before Plex has scanned the new file, so the apply retries quietly for a few minutes, then gives up and leaves it to the next scheduled run.  Ambiguous title matches (for example same-name remakes) are skipped rather than guessed, and nothing is applied when no configured user has the title.  The endpoints return 404 while ```enable_webhooks``` is off.
+On an import the title is looked up in the cached index; if one of the configured users covers it, that single poster (plus season covers for the imported seasons, on TV) is applied through the same processing path as a normal scrape, so artwork labels, locked-artwork skips and Kometa asset mode all behave the same.  Imports usually reach the webhook before Plex has scanned the new file, so the apply retries quietly for a few minutes, then gives up and leaves it to the next scheduled run.  Ambiguous title matches (for example same-name remakes) are skipped rather than guessed, and nothing is applied when no configured user has the title.  The endpoints return 404 if ```enable_webhooks``` is disabled.
 
 ### Scheduler with Apprise notifications
 Basic scheduler, so that you can leave this running and update all your artwork every day. 
@@ -175,9 +175,6 @@ If you also enable ```allow_artist_updates```, a scheduled scrape may additional
 With ```local_library_matching``` enabled (the default), a user-catalog scrape skips everything that isn't in your libraries without any web requests, so full-catalog runs take minutes rather than hours.
 
 Additionally, you can configure one or more push notification services so you get a notification every time a scheduled bulk import job completes. Notifications are provided by Apprise. Configure the list of notification services by providing a comma-separated list of Apprise notification URLs through the web UI or via the ```apprise_urls``` variable in the ```config.json```file. Check [the Apprise service list](https://appriseit.com/services/) for details on the supported services and how to set them up and generate a notification URL for your favorite services.
-
-## Coming soon
-- API integration with MediUX so we don't need to scrape any more.  I've been in contact with them to get access to the API as soon as it's launched.
 
 ## Thanks
 Many thanks to Brian Brown [@bbrown430] (https://github.com/bbrown430) for the original plex-poster-set-helper - what a fantastic idea!  It's saved me a load of time, and it's made my Plex beautiful!  And it's made me learn a bit of Python too!  I really hope you don't mind me taking your work and running with it, please get in touch if you'd like to merge the two projects!

--- a/artwork_uploader.py
+++ b/artwork_uploader.py
@@ -52,6 +52,7 @@ from services import (
     BulkFileService,
     ImageService,
     SchedulerService,
+    WebhookService,
     UtilityService
 )
 from services.artwork_processor import ArtworkProcessor
@@ -734,6 +735,7 @@ if __name__ == "__main__":
     # Create services
     globals.bulk_file_service = BulkFileService(get_exe_dir())
     globals.scheduler_service = SchedulerService(check_interval=SCHEDULER_CHECK_INTERVAL)
+    globals.webhook_service = WebhookService()
     globals.update_service = UpdateService(
         github_repo=GITHUB_REPO,
         current_version=current_version,

--- a/core/config.py
+++ b/core/config.py
@@ -40,6 +40,10 @@ class Config:
         auth_username: Username for web server authentication
         auth_password_hash: Hashed password for web server authentication
         apprise_urls: List of Apprise notification URLs
+        enable_webhooks: Whether the Sonarr/Radarr import webhook endpoint is enabled
+        webhook_token: Shared secret required on webhook requests
+        webhook_tpdb_users: ThePosterDB users to apply cached artwork from on import, in priority order
+        webhook_apply_delay: Seconds to wait after an import before applying artwork (lets Plex scan first)
     """
 
     def __init__(self, config_path: str = "config/config.json") -> None:
@@ -68,6 +72,10 @@ class Config:
         self.auth_username: str = ""
         self.auth_password_hash: str = ""
         self.apprise_urls: List[str] = []
+        self.enable_webhooks: bool = False
+        self.webhook_token: str = ""
+        self.webhook_tpdb_users: List[str] = []
+        self.webhook_apply_delay: int = 30
 
 
     def load(self) -> None:
@@ -110,6 +118,10 @@ class Config:
             self.auth_username = config.get("auth_username", "")
             self.auth_password_hash = config.get("auth_password_hash", "")
             self.apprise_urls = config.get("apprise_urls", [])
+            self.enable_webhooks = config.get("enable_webhooks", False)
+            self.webhook_token = config.get("webhook_token", "")
+            self.webhook_tpdb_users = config.get("webhook_tpdb_users", [])
+            self.webhook_apply_delay = config.get("webhook_apply_delay", 30)
 
         except Exception as e:
             raise ConfigLoadError(f"Error loading configuration from '{self.path}': {e}") from e
@@ -137,7 +149,11 @@ class Config:
             "auto_manage_bulk_files": True,
             "reset_overlay": True,
             "schedules": [],
-            "apprise_urls": []
+            "apprise_urls": [],
+            "enable_webhooks": False,
+            "webhook_token": "",
+            "webhook_tpdb_users": [],
+            "webhook_apply_delay": 30
         }
 
         if globals.docker:
@@ -185,7 +201,11 @@ class Config:
             "auth_enabled": self.auth_enabled,
             "auth_username": self.auth_username,
             "auth_password_hash": self.auth_password_hash,
-            "apprise_urls": self.apprise_urls
+            "apprise_urls": self.apprise_urls,
+            "enable_webhooks": self.enable_webhooks,
+            "webhook_token": self.webhook_token,
+            "webhook_tpdb_users": self.webhook_tpdb_users,
+            "webhook_apply_delay": self.webhook_apply_delay
         }
 
         try:

--- a/core/constants.py
+++ b/core/constants.py
@@ -116,6 +116,10 @@ TPDB_COLLECTION_MEDIA_TYPES = [
 # crawl cut short by a bad page must never be mistaken for a catalogue that shrank.
 RECONCILE_MIN_COVERAGE = 0.9
 
+# Webhook (Sonarr/Radarr on-import trigger)
+WEBHOOK_TOKEN_HEADER = "X-Webhook-Token"
+WEBHOOK_RETRY_DELAYS = [20, 60, 180, 600]  # seconds; retries while the imported item is not yet in Plex
+
 # MediUX configuration
 MEDIUX_BASE_URL = "https://mediux.pro"
 MEDIUX_API_BASE_URL = "https://api.mediux.pro/assets/"

--- a/core/globals.py
+++ b/core/globals.py
@@ -11,6 +11,7 @@ docker: bool = False # Running in Docker
 bulk_file_service = None
 scheduler_service = None
 update_service = None
+webhook_service = None
 
 # Scrape cancellation (user-initiated "Stop" from the web UI)
 cancel_scrape: bool = False   # Set when the user asks to stop; long loops check it and stop cleanly

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -12,6 +12,7 @@ from .utility_service import UtilityService
 from .authentication_service import AuthenticationService
 from .notify_service import NotifyService
 from .asset_index import AssetIndex
+from .webhook_service import WebhookService
 
 __all__ = [
     'BulkFileService',
@@ -20,5 +21,6 @@ __all__ = [
     'UtilityService',
     'AuthenticationService',
     'NotifyService',
-    'AssetIndex'
+    'AssetIndex',
+    'WebhookService'
 ]

--- a/services/asset_index.py
+++ b/services/asset_index.py
@@ -258,6 +258,41 @@ class AssetIndex:
         finally:
             conn.close()
 
+    def lookup(self, user_keys: List[str], title: str, year: Optional[int],
+               media_types: List[str], season: Optional[int] = None) -> Optional[sqlite3.Row]:
+        """Find the best cached asset for an imported title, or None.
+
+           user_keys is the preferred-first list of ThePosterDB users; the first user with an
+           acceptable match wins, and within a user the newest (highest asset_id) is taken. Year
+           is matched exactly then within one year; a missing year only matches when the
+           candidates share a single year, so same-name remakes are skipped rather than guessed."""
+        title_keys = {normalize_title(title)}
+        stripped = re.sub(r"\s*\([^)]*\)\s*$", "", title).strip()
+        if stripped and stripped != title:
+            title_keys.add(normalize_title(stripped))
+        title_keys = [key for key in title_keys if key]
+        if not title_keys or not user_keys or not media_types:
+            return None
+        conn = self._connect()
+        try:
+            sql = (
+                "SELECT * FROM user_assets WHERE missing_since IS NULL "
+                f"AND media_type IN ({','.join('?' * len(media_types))}) "
+                f"AND title_key IN ({','.join('?' * len(title_keys))})"
+            )
+            params = list(media_types) + title_keys
+            if season is not None:
+                sql += " AND season = ?"
+                params.append(season)
+            rows = conn.execute(sql, params).fetchall()
+        finally:
+            conn.close()
+        for user_key in user_keys:
+            chosen = _best_by_year([row for row in rows if row["user_key"] == user_key], year)
+            if chosen is not None:
+                return chosen
+        return None
+
 
 def page_is_fully_known(page_ids: Set[int], known_ids: Set[int]) -> bool:
     """Incremental stop rule: a page halts the crawl only if it had assets and every one was
@@ -277,3 +312,18 @@ def full_crawl_due(last_full_crawl: Optional[str], refresh_days: int) -> bool:
     except (TypeError, ValueError):
         return True
     return (datetime.now(timezone.utc) - last).total_seconds() >= refresh_days * 86400
+
+
+def _best_by_year(candidates: List[sqlite3.Row], year: Optional[int]) -> Optional[sqlite3.Row]:
+    """Pick the newest candidate whose year matches (exact, then within one year). With no year
+       to match on, only pick when every candidate shares one year - otherwise it is ambiguous
+       (a same-name remake) and nothing is returned."""
+    if not candidates:
+        return None
+    if year is not None:
+        pool = [row for row in candidates if row["year"] == year] or \
+               [row for row in candidates if row["year"] is not None and abs(row["year"] - year) <= 1]
+        return max(pool, key=lambda row: row["asset_id"]) if pool else None
+    if len({row["year"] for row in candidates}) > 1:
+        return None
+    return max(candidates, key=lambda row: row["asset_id"])

--- a/services/webhook_service.py
+++ b/services/webhook_service.py
@@ -1,0 +1,220 @@
+"""
+In-tool Sonarr/Radarr import webhook.
+
+On a Radarr/Sonarr "Download" (import) event, look the imported title up in the persistent
+asset index and apply the cached poster through the normal upload path, retrying for a few
+minutes while Plex finishes scanning the new file. Everything downstream of the dispatch (the
+authoritative TMDb resolution, artwork-ID skips, locked-artwork skips, Kometa mode) is the same
+code a normal scrape uses, so the webhook inherits all of it without re-implementing any of it.
+"""
+
+import threading
+import time
+from dataclasses import dataclass
+from typing import FrozenSet, List, Optional, Union
+
+from core import globals
+from core.constants import WEBHOOK_RETRY_DELAYS
+from core.enums import ScraperSource
+from core.exceptions import MovieNotFound, ShowNotFound
+from models.instance import Instance
+from models.options import Options
+from services.asset_index import AssetIndex, normalize_title
+
+
+def _log(text: str) -> None:
+    # utils.notifications imports the services package, so import it lazily to avoid an import
+    # cycle when the services package pulls this module in at start-up.
+    from utils.notifications import update_log
+    update_log(Instance(broadcast=True), text)
+
+
+def _debug(message: str) -> None:
+    from utils.notifications import debug_me
+    debug_me(message, "WebhookService")
+
+
+@dataclass(frozen=True)
+class WebhookEvent:
+    """A parsed Sonarr/Radarr import event."""
+    kind: str                      # "movie" or "tv"
+    title: str
+    year: Optional[int]
+    tmdb_id: Optional[int]
+    tvdb_id: Optional[int]
+    seasons: FrozenSet[int]
+    source: str                    # "radarr" or "sonarr"
+
+    def label(self) -> str:
+        return f"{self.title} ({self.year})" if self.year else self.title
+
+
+def _int_or_none(value) -> Optional[int]:
+    """Map absent numeric fields to None. Radarr/Sonarr serialise absent ints and years as 0
+       (C# defaults), so 0 is treated as absent. NOT used for season numbers, where 0 (Specials)
+       is a real value."""
+    try:
+        number = int(value)
+    except (TypeError, ValueError):
+        return None
+    return number or None
+
+
+def parse_event(payload: dict) -> Union[WebhookEvent, str, None]:
+    """Parse a Radarr/Sonarr webhook payload.
+
+       Returns a WebhookEvent for an import ("Download") event, the string "test" for the
+       connection Test button, or None for any other event type or malformed payload. Never
+       raises, so an unexpected payload is acknowledged and ignored rather than erroring."""
+    if not isinstance(payload, dict):
+        return None
+    event_type = payload.get("eventType")
+    if event_type == "Test":
+        return "test"
+    if event_type != "Download":
+        return None
+    movie = payload.get("movie")
+    if isinstance(movie, dict) and movie.get("title"):
+        return WebhookEvent(
+            kind="movie", title=movie["title"], year=_int_or_none(movie.get("year")),
+            tmdb_id=_int_or_none(movie.get("tmdbId")), tvdb_id=None,
+            seasons=frozenset(), source="radarr",
+        )
+    series = payload.get("series")
+    if isinstance(series, dict) and series.get("title"):
+        episodes = payload.get("episodes") or []
+        seasons = frozenset(
+            episode["seasonNumber"] for episode in episodes
+            if isinstance(episode, dict) and isinstance(episode.get("seasonNumber"), int)
+        )
+        return WebhookEvent(
+            kind="tv", title=series["title"], year=_int_or_none(series.get("year")),
+            tmdb_id=_int_or_none(series.get("tmdbId")), tvdb_id=_int_or_none(series.get("tvdbId")),
+            seasons=seasons, source="sonarr",
+        )
+    return None
+
+
+class WebhookService:
+    """Applies cached artwork for imported titles off the request thread, with a retry ladder
+       for the window where an item has been imported but Plex has not scanned it in yet."""
+
+    def __init__(self) -> None:
+        self._inflight: set = set()
+        self._lock = threading.Lock()
+
+    def enqueue(self, event: WebhookEvent) -> None:
+        """Queue an import event for application. Returns immediately; work happens on a thread."""
+        key = self._dedupe_key(event)
+        with self._lock:
+            if key in self._inflight:
+                _debug(f"Import for {event.label()} is already pending, ignoring the duplicate")
+                return
+            self._inflight.add(key)
+        # Wait a configurable delay before the first attempt: the *arr apps fire the webhook the
+        # moment they import a file, usually before Plex has scanned it in, so give Plex a head
+        # start. If it is still not ready by then, the retry ladder takes over.
+        delay = max(0, globals.config.webhook_apply_delay or 0)
+        timer = threading.Timer(delay, self._attempt, args=(event, key))
+        timer.daemon = True
+        timer.start()
+
+    @staticmethod
+    def _dedupe_key(event: WebhookEvent):
+        identity = event.tmdb_id or event.tvdb_id or normalize_title(event.title)
+        return (event.kind, identity, event.seasons)
+
+    def _release(self, key) -> None:
+        with self._lock:
+            self._inflight.discard(key)
+
+    def _attempt(self, event: WebhookEvent, key, attempt: int = 0,
+                 artwork: Optional[List[dict]] = None) -> None:
+        # UploadProcessor pulls in the processors -> plex chain; import it here so the services
+        # package does not drag that in at start-up (mirrors the app's own lazy-import pattern).
+        from processors.upload_processor import UploadProcessor
+        try:
+            if artwork is None:
+                artwork = self._collect_artwork(event)
+                if not artwork:
+                    _log(f"📥 Webhook | No cached artwork for '{event.label()}' from the configured users")
+                    self._release(key)
+                    return
+                _log(f"📥 Webhook | {event.source.title()} import: {event.label()}")
+            globals.plex.connect()
+            processor = UploadProcessor(globals.plex)
+            processor.set_options(Options())
+            pending = []
+            for item in artwork:
+                try:
+                    if event.kind == "movie":
+                        results = processor.process_movie_artwork(item)
+                    else:
+                        results = processor.process_tv_artwork(item)
+                    results = results or []
+                    # A season/episode whose show is in Plex but which Plex has not scanned in yet
+                    # comes back as a "not available" result rather than an exception; treat that
+                    # the same as not-found so it retries once Plex catches up.
+                    if any("not available" in str(result).lower() for result in results):
+                        pending.append(item)
+                    else:
+                        for result in results:
+                            _log(result)
+                except (MovieNotFound, ShowNotFound):
+                    pending.append(item)          # not in Plex yet, retry it
+                except Exception as error:
+                    _log(f"❌ Webhook | {event.label()}: {error}")
+            if pending and attempt < len(WEBHOOK_RETRY_DELAYS):
+                delay = WEBHOOK_RETRY_DELAYS[attempt]
+                _debug(f"{event.label()} not in Plex yet, retrying in {delay}s")
+                timer = threading.Timer(delay, self._attempt, args=(event, key, attempt + 1, pending))
+                timer.daemon = True
+                timer.start()
+                return                            # keep the in-flight key until the chain ends
+            if pending:
+                _log(f"⚠️ Webhook | '{event.label()}' has not appeared in Plex, leaving it for the next scheduled run")
+        except Exception as error:
+            _debug(f"Webhook apply failed for {event.label()}: {error}")
+        self._release(key)
+
+    def _collect_artwork(self, event: WebhookEvent) -> List[dict]:
+        """Build the artwork dicts to apply by looking the title up in the index for each
+           configured user, in preference order. Empty when nobody covers it."""
+        user_keys = [user.strip().casefold() for user in (globals.config.webhook_tpdb_users or []) if user.strip()]
+        if not user_keys:
+            return []
+        index = AssetIndex()
+        cache_buster = f"&_cb={int(time.time())}"
+        artwork: List[dict] = []
+        if event.kind == "movie":
+            row = index.lookup(user_keys, event.title, event.year, ["movie_poster"])
+            if row:
+                artwork.append(self._artwork_dict(row, cache_buster, "movie_poster"))
+        else:
+            row = index.lookup(user_keys, event.title, event.year, ["show_cover"])
+            if row:
+                artwork.append(self._artwork_dict(row, cache_buster, "show_cover"))
+            for season in sorted(event.seasons):
+                season_row = index.lookup(user_keys, event.title, event.year, ["season_cover"], season=season)
+                if season_row:
+                    artwork.append(self._artwork_dict(season_row, cache_buster, "season_cover", season))
+        return artwork
+
+    @staticmethod
+    def _artwork_dict(row, cache_buster: str, artwork_type: str, season=None) -> dict:
+        """Build a get_posters-shaped artwork dict from an index row. tmdb_id stays None so the
+           processor resolves identity authoritatively from the poster page at write time."""
+        artwork = {
+            "title": row["title"],
+            "author": row["author"],
+            "tmdb_id": None,
+            "url": f"{row['url']}{cache_buster}",
+            "year": row["year"],
+            "source": ScraperSource.THEPOSTERDB.value,
+            "id": str(row["asset_id"]),
+            "type": artwork_type,
+        }
+        if artwork_type in ("show_cover", "season_cover"):
+            artwork["season"] = "Cover" if artwork_type == "show_cover" else season
+            artwork["episode"] = None
+        return artwork

--- a/services/webhook_service.py
+++ b/services/webhook_service.py
@@ -203,7 +203,10 @@ class WebhookService:
     @staticmethod
     def _artwork_dict(row, cache_buster: str, artwork_type: str, season=None) -> dict:
         """Build a get_posters-shaped artwork dict from an index row. tmdb_id stays None so the
-           processor resolves identity authoritatively from the poster page at write time."""
+           processor resolves identity authoritatively from the poster page at write time. The
+           artwork type MUST be keyed as 'file_type' - the key get_posters writes and the upload
+           processor reads to resolve the Plex label prefix; 'type' leaves it unresolved and the
+           uploader crashes on None + md5."""
         artwork = {
             "title": row["title"],
             "author": row["author"],
@@ -212,7 +215,7 @@ class WebhookService:
             "year": row["year"],
             "source": ScraperSource.THEPOSTERDB.value,
             "id": str(row["asset_id"]),
-            "type": artwork_type,
+            "file_type": artwork_type,
         }
         if artwork_type in ("show_cover", "season_cover"):
             artwork["season"] = "Cover" if artwork_type == "show_cover" else season

--- a/services/webhook_service.py
+++ b/services/webhook_service.py
@@ -144,6 +144,13 @@ class WebhookService:
             globals.plex.connect()
             processor = UploadProcessor(globals.plex)
             processor.set_options(Options())
+            # allow_artist_updates is a scheduled-scrape concern and must never apply here.
+            # set_options resolves it from the global config, so a bare Options() still inherits it.
+            # Radarr and Sonarr send "Download" on an upgrade as well as a first import, so the item
+            # this runs against may already carry artwork the user locked. The webhook also picks its
+            # artists from its own configured list rather than from the scrape, so letting it replace
+            # a locked field would re-sort artwork nobody asked it to touch.
+            processor.allow_artist_updates = False
             pending = []
             for item in artwork:
                 try:

--- a/static/web_interface.js
+++ b/static/web_interface.js
@@ -798,6 +798,12 @@ function saveConfig() {
     save_config.auth_username = document.getElementById("auth_username").value.trim();
     save_config.auth_password = document.getElementById("auth_password").value;
 
+    // Webhook settings
+    save_config.enable_webhooks = document.getElementById("enable_webhooks").checked;
+    save_config.webhook_token = document.getElementById("webhook_token").value.trim();
+    save_config.webhook_tpdb_users = document.getElementById("webhook_tpdb_users").value.split(",").map(u => u.trim()).filter(u => u);
+    save_config.webhook_apply_delay = parseInt(document.getElementById("webhook_apply_delay").value, 10) || 0;
+
     // Process every possible condition of auth enable/disable and same/different username and password/no password provided
     // If auth is enabled and a password is NOT provided
     if (save_config.auth_enabled && !save_config.auth_password) {
@@ -893,6 +899,12 @@ function updateConfigUI(config) {
     document.getElementById("auth_enabled").checked = config.auth_enabled || false;
     document.getElementById("auth_username").value = config.auth_username || "";
     
+    // Load webhook settings
+    document.getElementById("enable_webhooks").checked = config.enable_webhooks || false;
+    document.getElementById("webhook_token").value = config.webhook_token || "";
+    document.getElementById("webhook_tpdb_users").value = (config.webhook_tpdb_users || []).join(", ");
+    document.getElementById("webhook_apply_delay").value = config.webhook_apply_delay ?? 30;
+    
     // Toggle Kometa settings visibility
     toggleKometaSettings();
     
@@ -901,6 +913,9 @@ function updateConfigUI(config) {
     
     // Toggle auth settings visibility
     toggleAuthSettings();
+    
+    // Toggle webhook settings visibility
+    toggleWebhookSettings();
     
     // Make sure Plex options visibility is set correctly on load
     togglePlexOptions();
@@ -1998,6 +2013,24 @@ function toggleAuthSettings() {
 
 // Add event listener for auth_enabled checkbox
 document.getElementById("auth_enabled").addEventListener("change", toggleAuthSettings);
+
+// ==================================================
+// Webhook Settings Toggle
+// ==================================================
+
+function toggleWebhookSettings() {
+    const enabled = document.getElementById("enable_webhooks").checked;
+    document.getElementById("webhook_settings").style.display = enabled ? "block" : "none";
+    // When enabling with an empty token, pre-fill a random one. getRandomValues works in
+    // insecure (plain http) contexts, unlike crypto.randomUUID.
+    const tokenField = document.getElementById("webhook_token");
+    if (enabled && !tokenField.value) {
+        tokenField.value = Array.from(crypto.getRandomValues(new Uint8Array(16)))
+            .map(b => b.toString(16).padStart(2, "0")).join("");
+    }
+}
+
+document.getElementById("enable_webhooks").addEventListener("change", toggleWebhookSettings);
 
 // ==================================================
 // Kometa Settings Toggle

--- a/static/web_interface.js
+++ b/static/web_interface.js
@@ -10,7 +10,7 @@ let currentBulkImport = '';     // Current bulk import file
 let bulkTextAsLoaded = '';      // File contents when loaded, to determine changes
 let barTimer = null;            // Timer for progress bar
 let docker = false;             // Docker environment detected or not
-let tvPicker, moviePicker;
+let tvPicker, moviePicker, tpdbUserPicker;
 
 const socket = io();
 const instanceId = getInstanceId();
@@ -35,6 +35,18 @@ const bulkFileSwitcher = document.getElementById("switch_bulk_file");
 // Event listeners
 document.addEventListener("DOMContentLoaded", function () {
     updateLog("📍 New session started with ID: " + instanceId)
+    tpdbUserPicker = new TomSelect('#webhook_tpdb_users', {
+            create: true,
+            createOnBlur: true,
+            delimiter: ',',
+            persist: false,
+            plugins: {
+                'clear_button': {
+                    html: (data) => `<div class="${data.className}" title="${data.title}"><i class="bi bi-x-circle"></i></div>`
+                },
+                'remove_button': {}
+            }
+        });    
     tvPicker = new TomSelect('#tv_library', {
         inputTypes: [],
         controlInput: '<input readonly>',
@@ -67,6 +79,7 @@ document.addEventListener("DOMContentLoaded", function () {
     });        
     loadConfig();
     toggleThePosterDBElements();
+    toggleWebhookSettings();
     detectEnvironment();
     getScrapeState();
 });
@@ -801,7 +814,7 @@ function saveConfig() {
     // Webhook settings
     save_config.enable_webhooks = document.getElementById("enable_webhooks").checked;
     save_config.webhook_token = document.getElementById("webhook_token").value.trim();
-    save_config.webhook_tpdb_users = document.getElementById("webhook_tpdb_users").value.split(",").map(u => u.trim()).filter(u => u);
+    save_config.webhook_tpdb_users = tpdbUserPicker ? tpdbUserPicker.getValue() : [];
     save_config.webhook_apply_delay = parseInt(document.getElementById("webhook_apply_delay").value, 10) || 0;
 
     // Process every possible condition of auth enable/disable and same/different username and password/no password provided
@@ -902,7 +915,14 @@ function updateConfigUI(config) {
     // Load webhook settings
     document.getElementById("enable_webhooks").checked = config.enable_webhooks || false;
     document.getElementById("webhook_token").value = config.webhook_token || "";
-    document.getElementById("webhook_tpdb_users").value = (config.webhook_tpdb_users || []).join(", ");
+    if (Array.isArray(config.webhook_tpdb_users) && tpdbUserPicker) {
+        // Clear existing options
+        tpdbUserPicker.clearOptions();
+        // Add options first
+        config.webhook_tpdb_users.forEach(user => tpdbUserPicker.addOption({ value: user, text: user }));
+        // Set active values (chips)
+        tpdbUserPicker.setValue(config.webhook_tpdb_users, true);
+    };
     document.getElementById("webhook_apply_delay").value = config.webhook_apply_delay ?? 30;
     
     // Toggle Kometa settings visibility

--- a/templates/web_interface.html
+++ b/templates/web_interface.html
@@ -280,6 +280,35 @@
                                     </div>
                                 </div>
                             </div>
+                            <!-- Webhook settings -->
+                            <div class="p-3 border mt-3 rounded-3 shadow-sm">
+                                <h5 class="mb-3"><i class="bi bi-broadcast-pin"></i>&ensp;Webhook settings</h5>
+                                <div class="form-check form-switch mb-3">
+                                    <input class="form-check-input" type="checkbox" id="enable_webhooks"/>
+                                    <label for="enable_webhooks" class="form-check-label">Enable the Sonarr/Radarr import webhook, so newly imported items get cached artwork applied straight away</label>
+                                </div>
+                                <div id="webhook_settings" style="display: none;">
+                                    <div class="mb-3">
+                                        <label for="webhook_token" class="form-label"><i class="bi bi-key"></i>&ensp;Webhook token</label>
+                                        <input type="text" id="webhook_token" name="webhook_token" class="form-control" placeholder="required">
+                                    </div>
+                                    <div class="alert alert-info" role="alert">
+                                        <i class="bi bi-info-circle"></i> In Sonarr/Radarr go to Settings &rarr; Connect &rarr; + &rarr; Webhook. Set the URL to <code>/webhook/sonarr</code> or <code>/webhook/radarr</code> on this server, method POST, and tick only the "On File Import" trigger. Send this token either as the connection's Password, or as a header: click the <strong>Advanced</strong> (cog) button on the webhook connection and add a Header with Key <code>X-Webhook-Token</code> and Value set to this token.
+                                    </div>
+                                    <div class="mb-3">
+                                        <label for="webhook_tpdb_users" class="form-label"><i class="bi bi-people"></i>&ensp;ThePosterDB users to apply from, in order of preference</label>
+                                        <input type="text" id="webhook_tpdb_users" name="webhook_tpdb_users" class="form-control" placeholder="preferreduser, filleruser" title="Comma-separated ThePosterDB user names whose cached uploads are searched, first match wins.">
+                                    </div>
+                                    <div class="alert alert-info" role="alert">
+                                        <i class="bi bi-info-circle"></i> Comma-separated ThePosterDB user names, searched in this order (first match wins). Requires "Remember each ThePosterDB user's uploads" to be enabled, and a scrape of these users to have run at least once, so their artwork is cached and can be looked up.
+                                    </div>
+                                    <div class="mb-3">
+                                        <label for="webhook_apply_delay" class="form-label"><i class="bi bi-clock"></i>&ensp;Delay before applying (seconds)</label>
+                                        <input type="number" min="0" id="webhook_apply_delay" name="webhook_apply_delay" class="form-control" placeholder="30">
+                                        <small class="form-text text-muted">How long to wait after an import before applying artwork, giving Plex time to scan the new item. If it is still not ready, the apply retries for a few minutes.</small>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                         <div class="col-lg-7">
                             <div class="row mb-3">

--- a/templates/web_interface.html
+++ b/templates/web_interface.html
@@ -251,7 +251,7 @@
                                     </div>
                                 </div>
                                 <div id="docker_warning" class="alert alert-info mt-3 mb-0 alert-dismissible fade show" role="alert" style="display: block;">
-                                    <i class="bi bi-info-circle"></i>&ensp; When running in Docker the Kometa asset and temp directories are hardcoded 
+                                    <i class="bi bi-info-circle"></i>&ensp;When running in Docker the Kometa asset and temp directories are hardcoded 
                                     inside the container to <code>/assets</code> and <code>/temp</code> respectively. The host paths displayed here are the ones 
                                     mapped to these container paths via bind mounts in the <span class="text-nowrap"><code>docker-compose.yml</code></span> file.
                                     To change them you must edit your compose file and restart the container.
@@ -285,27 +285,42 @@
                                 <h5 class="mb-3"><i class="bi bi-broadcast-pin"></i>&ensp;Webhook settings</h5>
                                 <div class="form-check form-switch mb-3">
                                     <input class="form-check-input" type="checkbox" id="enable_webhooks"/>
-                                    <label for="enable_webhooks" class="form-check-label">Enable the Sonarr/Radarr import webhook, so newly imported items get cached artwork applied straight away</label>
+                                    <label for="enable_webhooks" class="form-check-label">Enable Sonarr/Radarr webhook</label>
+                                    <i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="Allows TPDb artwork from cached user pages to be applied to items 
+                                    or downloaded to the Kometa asset directory immediately after they are imported in Sonarr or Radarr"></i>
                                 </div>
                                 <div id="webhook_settings" style="display: none;">
                                     <div class="mb-3">
                                         <label for="webhook_token" class="form-label"><i class="bi bi-key"></i>&ensp;Webhook token</label>
                                         <input type="text" id="webhook_token" name="webhook_token" class="form-control" placeholder="required">
                                     </div>
-                                    <div class="alert alert-info" role="alert">
-                                        <i class="bi bi-info-circle"></i> In Sonarr/Radarr go to Settings &rarr; Connect &rarr; + &rarr; Webhook. Set the URL to <code>/webhook/sonarr</code> or <code>/webhook/radarr</code> on this server, method POST, and tick only the "On File Import" trigger. Send this token either as the connection's Password, or as a header: click the <strong>Advanced</strong> (cog) button on the webhook connection and add a Header with Key <code>X-Webhook-Token</code> and Value set to this token.
+                                    <div class="alert alert-info alert-dismissible fade show" role="alert">
+                                        <i class="bi bi-info-circle"></i>&ensp;In Sonarr/Radarr go to Settings &rarr; Connect &rarr; + &rarr; Webhook. Set the URL to 
+                                        <code>/webhook/sonarr</code> or <code>/webhook/radarr</code> on this server, method POST, and tick only the "On File Import" 
+                                        trigger. Send this token either as the connection's Password, or as a header: click the <strong>Advanced</strong> (cog) button 
+                                        on the webhook connection and add a Header with Key <code>X-Webhook-Token</code> and Value set to this token.
+                                        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
                                     </div>
                                     <div class="mb-3">
-                                        <label for="webhook_tpdb_users" class="form-label"><i class="bi bi-people"></i>&ensp;ThePosterDB users to apply from, in order of preference</label>
-                                        <input type="text" id="webhook_tpdb_users" name="webhook_tpdb_users" class="form-control" placeholder="preferreduser, filleruser" title="Comma-separated ThePosterDB user names whose cached uploads are searched, first match wins.">
-                                    </div>
-                                    <div class="alert alert-info" role="alert">
-                                        <i class="bi bi-info-circle"></i> Comma-separated ThePosterDB user names, searched in this order (first match wins). Requires "Remember each ThePosterDB user's uploads" to be enabled, and a scrape of these users to have run at least once, so their artwork is cached and can be looked up.
+                                        <label for="webhook_tpdb_users" class="form-label"><i class="bi bi-people"></i>&ensp;ThePosterDB users</label>
+                                        <i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="List of TPDb users, searched in this order (first 
+                                        match wins). Requires 'Cache ThePosterDB user pages' enabled, and a scrape of these users needs to have run at least once,
+                                        so their artwork is cacehd and ca be looked up.)"></i>
+                                        <select id="webhook_tpdb_users" name="webhook_tpdb_users" multiple placeholder="Enter usernames"></select>
                                     </div>
                                     <div class="mb-3">
-                                        <label for="webhook_apply_delay" class="form-label"><i class="bi bi-clock"></i>&ensp;Delay before applying (seconds)</label>
-                                        <input type="number" min="0" id="webhook_apply_delay" name="webhook_apply_delay" class="form-control" placeholder="30">
-                                        <small class="form-text text-muted">How long to wait after an import before applying artwork, giving Plex time to scan the new item. If it is still not ready, the apply retries for a few minutes.</small>
+                                        <label for="webhook_apply_delay" class="form-label me-2 mb-0"><i class="bi bi-clock""></i>&ensp;Delay</label>
+                                        <input type="number" 
+                                            class="form-control form-control-sm text-center d-inline-block me-2" 
+                                            id="webhook_apply_delay" 
+                                            name="webhook_apply_delay"
+                                            min="0" 
+                                            placeholder="30" 
+                                            style="width: 60px;" 
+                                            required />
+                                        <span class="text-body">seconds before applying</span>
+                                        <i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="How long to wait after an import before applying artwork, 
+                                        giving Plex time to scan the new item. If it is still not ready, the apply retries for a few minutes."></i>
                                     </div>
                                 </div>
                             </div>

--- a/tests/test_webhook_service.py
+++ b/tests/test_webhook_service.py
@@ -1,7 +1,11 @@
 """Unit tests for the Sonarr/Radarr import webhook (services/webhook_service.py)."""
 
+from unittest.mock import MagicMock
+
 import pytest
 
+from core.constants import ARTWORK_ID_MAP, ARTWORK_TYPE_MAP
+from plex.plex_uploader import PlexUploader
 from services.asset_index import AssetIndex
 from services.webhook_service import WebhookEvent, WebhookService, parse_event
 
@@ -126,3 +130,33 @@ def test_dedupe_key():
     no_id = WebhookEvent(kind="movie", title="Léon", year=1994, tmdb_id=None, tvdb_id=None,
                          seasons=frozenset(), source="radarr")
     assert WebhookService._dedupe_key(no_id)[1] == "leon"
+
+
+# ------------------- regression: the file_type contract (the live crash) -------------------
+
+@pytest.mark.unit
+@pytest.mark.parametrize("artwork_type,season", [
+    ("movie_poster", None),
+    ("show_cover", None),
+    ("season_cover", 2),
+])
+def test_artwork_dict_carries_the_file_type_key_the_processor_reads(artwork_type, season):
+    """The webhook must key the artwork type as 'file_type' - the key get_posters writes and the
+       upload processor reads. Keyed as 'type' (the old bug), ARTWORK_ID_MAP.get(...) returns None
+       and PlexUploader.set_artwork does None + md5, the exact 'unsupported operand type(s) for +:
+       NoneType and str' that broke a real Radarr import in production."""
+    row = {"title": "Dune", "author": "someuser", "year": 2021, "asset_id": 42,
+           "url": "https://theposterdb.com/api/assets/42"}
+    artwork = WebhookService._artwork_dict(row, "&_cb=123", artwork_type, season)
+
+    assert artwork["file_type"] == artwork_type
+    assert ARTWORK_ID_MAP.get(artwork["file_type"]) is not None
+
+    # Reproduce the runtime path: the processor derives artwork_id from file_type and hands it to
+    # the uploader, whose set_artwork builds label = artwork_id + md5(url). A None artwork_id here
+    # is the crash.
+    artwork_id = ARTWORK_ID_MAP.get(artwork.get("file_type"))
+    artwork_type_str = ARTWORK_TYPE_MAP.get(artwork.get("file_type"))
+    uploader = PlexUploader(MagicMock(), artwork_type_str, artwork_id)
+    uploader.set_artwork(artwork)
+    assert isinstance(uploader.label, str) and uploader.label

--- a/tests/test_webhook_service.py
+++ b/tests/test_webhook_service.py
@@ -1,0 +1,128 @@
+"""Unit tests for the Sonarr/Radarr import webhook (services/webhook_service.py)."""
+
+import pytest
+
+from services.asset_index import AssetIndex
+from services.webhook_service import WebhookEvent, WebhookService, parse_event
+
+FAR_FUTURE = "2999-01-01T00:00:00+00:00"
+
+
+@pytest.fixture
+def index(tmp_path):
+    return AssetIndex(str(tmp_path / "asset_index.db"))
+
+
+def _rec(index, user, asset_id, title, year, media_type, season=None):
+    index.record(user, [{
+        "id": asset_id, "title": title, "year": year, "season": season,
+        "media_type": media_type, "author": user,
+        "url": f"https://theposterdb.com/api/assets/{asset_id}",
+    }])
+
+
+# ------------------------------- parse_event -------------------------------
+
+@pytest.mark.unit
+def test_parse_radarr_download():
+    event = parse_event({"eventType": "Download",
+                         "movie": {"title": "Dune", "year": 2021, "tmdbId": 438631}})
+    assert isinstance(event, WebhookEvent)
+    assert (event.kind, event.title, event.year, event.tmdb_id, event.source) == \
+           ("movie", "Dune", 2021, 438631, "radarr")
+    assert event.seasons == frozenset()
+
+
+@pytest.mark.unit
+def test_parse_sonarr_download_multi_episode():
+    event = parse_event({"eventType": "Download",
+                         "series": {"title": "Severance", "year": 2022, "tvdbId": 371980, "tmdbId": 95396},
+                         "episodes": [{"seasonNumber": 1}, {"seasonNumber": 2}, {"seasonNumber": 0}]})
+    assert event.kind == "tv"
+    assert event.tvdb_id == 371980 and event.tmdb_id == 95396
+    assert event.seasons == frozenset({0, 1, 2})   # season 0 (Specials) is kept
+
+
+@pytest.mark.unit
+def test_parse_csharp_zero_defaults_are_none():
+    event = parse_event({"eventType": "Download",
+                         "movie": {"title": "Nope", "year": 0, "tmdbId": 0}})
+    assert event.year is None and event.tmdb_id is None
+
+
+@pytest.mark.unit
+def test_parse_test_and_ignored_events():
+    assert parse_event({"eventType": "Test"}) == "test"
+    for event_type in ("Grab", "MovieAdded", "Rename", "Health", "SeriesAdd"):
+        assert parse_event({"eventType": event_type, "movie": {"title": "X"}}) is None
+    assert parse_event({}) is None                                   # missing eventType
+    assert parse_event({"eventType": "Download"}) is None            # no movie/series
+    assert parse_event({"eventType": "Download", "movie": {}}) is None  # no title
+    assert parse_event("not a dict") is None                         # never raises
+
+
+# --------------------------------- lookup ----------------------------------
+
+@pytest.mark.unit
+def test_lookup_preferred_user_wins(index):
+    _rec(index, "filler", 999, "Heat", 1995, "movie_poster")   # newer id, less preferred
+    _rec(index, "preferred", 1, "Heat", 1995, "movie_poster")
+    row = index.lookup(["preferred", "filler"], "Heat", 1995, ["movie_poster"])
+    assert row["user_key"] == "preferred"
+
+
+@pytest.mark.unit
+def test_lookup_newest_within_user(index):
+    _rec(index, "user", 1, "Heat", 1995, "movie_poster")
+    _rec(index, "user", 5, "Heat", 1995, "movie_poster")
+    assert index.lookup(["user"], "Heat", 1995, ["movie_poster"])["asset_id"] == 5
+
+
+@pytest.mark.unit
+def test_lookup_year_exact_then_nearby(index):
+    _rec(index, "user", 1, "Heat", 1995, "movie_poster")
+    assert index.lookup(["user"], "Heat", 1995, ["movie_poster"]) is not None
+    assert index.lookup(["user"], "Heat", 1996, ["movie_poster"]) is not None   # +/-1
+    assert index.lookup(["user"], "Heat", 2010, ["movie_poster"]) is None       # too far
+
+
+@pytest.mark.unit
+def test_lookup_year_none_ambiguity(index):
+    _rec(index, "user", 1, "Solo Title", 2020, "movie_poster")
+    assert index.lookup(["user"], "Solo Title", None, ["movie_poster"]) is not None
+    _rec(index, "user", 2, "Solo Title", 1990, "movie_poster")   # now two distinct years
+    assert index.lookup(["user"], "Solo Title", None, ["movie_poster"]) is None
+
+
+@pytest.mark.unit
+def test_lookup_season_and_show_cover(index):
+    _rec(index, "user", 10, "Severance", 2022, "show_cover")
+    _rec(index, "user", 11, "Severance", 2022, "season_cover", season=0)
+    _rec(index, "user", 12, "Severance", 2022, "season_cover", season=1)
+    assert index.lookup(["user"], "Severance", 2022, ["season_cover"], season=0)["asset_id"] == 11
+    assert index.lookup(["user"], "Severance", 2022, ["season_cover"], season=1)["asset_id"] == 12
+    assert index.lookup(["user"], "Severance", 2022, ["show_cover"])["asset_id"] == 10
+
+
+@pytest.mark.unit
+def test_lookup_tombstoned_and_parenthetical(index):
+    _rec(index, "user", 1, "The Office", 2005, "show_cover")   # index stores the parsed (stripped) title
+    row = index.lookup(["user"], "The Office (US)", 2005, ["show_cover"])   # query strips the suffix
+    assert row is not None and row["asset_id"] == 1
+    index.reconcile("user", seen_ids=set(), crawl_started_at=FAR_FUTURE)   # tombstone everything
+    assert index.lookup(["user"], "The Office (US)", 2005, ["show_cover"]) is None
+
+
+# ------------------------------- dedupe key --------------------------------
+
+@pytest.mark.unit
+def test_dedupe_key():
+    def series(seasons):
+        return WebhookEvent(kind="tv", title="Show", year=2020, tmdb_id=42, tvdb_id=7,
+                            seasons=frozenset(seasons), source="sonarr")
+    assert WebhookService._dedupe_key(series([1])) == WebhookService._dedupe_key(series([1]))
+    assert WebhookService._dedupe_key(series([1])) != WebhookService._dedupe_key(series([2]))
+    # falls back to normalized title when there is no id
+    no_id = WebhookEvent(kind="movie", title="Léon", year=1994, tmdb_id=None, tvdb_id=None,
+                         seasons=frozenset(), source="radarr")
+    assert WebhookService._dedupe_key(no_id)[1] == "leon"

--- a/tests/test_webhook_service.py
+++ b/tests/test_webhook_service.py
@@ -160,3 +160,47 @@ def test_artwork_dict_carries_the_file_type_key_the_processor_reads(artwork_type
     uploader = PlexUploader(MagicMock(), artwork_type_str, artwork_id)
     uploader.set_artwork(artwork)
     assert isinstance(uploader.label, str) and uploader.label
+
+
+# --------------------------- allow_artist_updates ---------------------------
+
+@pytest.mark.unit
+def test_attempt_forces_allow_artist_updates_off(monkeypatch):
+    """The webhook must never inherit allow_artist_updates from the global config.
+
+    set_options resolves the flag as `self.options.allow_artist_updates or
+    globals.config.allow_artist_updates`, so handing it a bare Options() is not enough: a user with
+    the option on globally would have it on here too. Radarr and Sonarr send "Download" on an upgrade
+    as well as a first import, so the item may already carry artwork the user locked, and the webhook
+    picks its artists from its own configured list rather than from the scrape.
+
+    This drives _attempt itself rather than re-stating the assignment, so deleting the guard from
+    services/webhook_service.py fails the test.
+    """
+    import processors.upload_processor as upload_processor_module
+    from core import globals as app_globals
+
+    seen = {}
+
+    class _FakeProcessor:
+        def __init__(self, _plex):
+            # Whatever set_options would have resolved from the global config.
+            self.allow_artist_updates = True
+
+        def set_options(self, _options):
+            self.allow_artist_updates = True      # the inheritance the guard has to undo
+
+        def process_movie_artwork(self, _item):
+            seen["at_upload"] = self.allow_artist_updates
+            return ["done"]
+
+    monkeypatch.setattr(upload_processor_module, "UploadProcessor", _FakeProcessor)
+    monkeypatch.setattr(app_globals, "plex", MagicMock())
+
+    service = WebhookService()
+    event = parse_event({"eventType": "Download",
+                         "movie": {"title": "Dune", "year": 2021, "tmdbId": 438631}})
+    service._attempt(event, ("movie", 438631), artwork=[{"id": 1, "file_type": "movie_poster"}])
+
+    assert seen.get("at_upload") is False, \
+        "the webhook reached the uploader with allow_artist_updates still on"

--- a/web_routes.py
+++ b/web_routes.py
@@ -10,7 +10,7 @@ The routes are organized into:
 - Helper functions for file uploads and processing
 """
 
-import os, logging, flask.cli, sys, re, base64, tempfile, zipfile, subprocess
+import os, logging, flask.cli, sys, re, base64, hmac, tempfile, zipfile, subprocess
 from pathlib import Path
 from packaging import version
 from plexapi.server import PlexServer
@@ -25,7 +25,8 @@ from core.enums import FileType, MediaType, ScraperSource, StatusColor
 from processors.media_metadata import parse_title
 from utils.notifications import update_log, update_status, notify_web, debug_me
 from services import UtilityService, AuthenticationService
-from core.constants import UPLOAD_CHUNK_SIZE
+from services.webhook_service import parse_event
+from core.constants import UPLOAD_CHUNK_SIZE, WEBHOOK_TOKEN_HEADER
 
 def login_required(f):
     """Decorator to require authentication for routes."""
@@ -110,6 +111,45 @@ def setup_routes(web_app, config: Config):
         """Serve files from the uploads directory."""
         uploads_path = os.path.join(UtilityService.get_exe_dir(), 'uploads')
         return send_from_directory(uploads_path, filename)
+
+    def webhook_token_ok():
+        """A webhook request is authorised when it carries the configured token, sent as the
+           X-Webhook-Token header, the HTTP Basic password, or a ?token= query parameter."""
+        token = globals.config.webhook_token
+        if not token:
+            return False
+        provided = (request.headers.get(WEBHOOK_TOKEN_HEADER)
+                    or (request.authorization.password if request.authorization else None)
+                    or request.args.get("token") or "")
+        return hmac.compare_digest(provided, token)
+
+    @web_app.route("/webhook/radarr", methods=["POST"])
+    @web_app.route("/webhook/sonarr", methods=["POST"])
+    def arr_webhook():
+        """Receive a Sonarr/Radarr import event and apply the cached artwork for it. Disabled
+           by default (404), so the endpoint is indistinguishable from upstream when off."""
+        if not globals.config.enable_webhooks:
+            return {"status": "not found"}, 404
+        if not webhook_token_ok():
+            update_log(Instance(broadcast=True), "⛔ Webhook request rejected (missing or invalid token)")
+            return {"status": "unauthorized"}, 401
+        payload = request.get_json(silent=True)
+        if payload is None:
+            return {"status": "invalid json"}, 400
+        event = parse_event(payload)
+        if event == "test":
+            update_log(Instance(broadcast=True), "🧪 Webhook test received")
+            return {"status": "test ok"}, 200
+        if event is None:
+            return {"status": "ignored"}, 200
+        if globals.plex is None or not (globals.plex.movie_libraries or globals.plex.tv_libraries):
+            update_log(Instance(broadcast=True), "⛔ Webhook received but Plex libraries are not configured")
+            return {"status": "plex not configured"}, 503
+        if not globals.config.webhook_tpdb_users:
+            update_log(Instance(broadcast=True), "📥 Webhook received but no ThePosterDB users are configured (webhook_tpdb_users)")
+            return {"status": "no users configured"}, 200
+        globals.webhook_service.enqueue(event)
+        return {"status": "queued"}, 200
 
 
 def setup_socket_handlers(


### PR DESCRIPTION
With `cache_user_scrapes` enabled (#57), the app already knows every poster your favourite ThePosterDB users have uploaded. This adds an opt-in webhook that Sonarr and Radarr can call on import. A newly added movie or episode then gets its artwork within a minute or so, instead of waiting for the next scheduled run.

On an import event the app looks the title up in the cached index. You configure which users to apply from, in order of preference, and the first match wins. If one of them covers the title, that single artwork goes through the same processing path as a normal scrape. Artwork labels, skips and Kometa asset mode all behave as usual. Nothing is fetched or applied when no cached artwork matches.

Imports usually reach the webhook before Plex has scanned the new file. So there is a configurable delay before the first attempt, plus a short retry. After that it gives up and leaves the item to the next scheduled run.

- New in config.json: `enable_webhooks` (default `false`, so the endpoints return 404 when disabled), `webhook_token`, `webhook_tpdb_users` and `webhook_apply_delay` (default 30 seconds). The token is required. Send it as an `X-Webhook-Token` header, the connection's Basic password, or a `?token=` query parameter. There is a Webhook settings section in the web UI to match.
- Endpoints `POST /webhook/radarr` and `POST /webhook/sonarr`. The apps' Test button is acknowledged so the connection can be saved. Only "On File Import" events do any work, and everything else is acknowledged and ignored.
- Sonarr imports apply the show cover and the covers for the imported seasons. Radarr imports apply the movie poster. Ambiguous title matches, for example same-name remakes, are skipped rather than guessed.
- No new dependencies. Unit tests for the payload parsing and index lookup under `tests/`.
- README updated with setup steps for both apps.

Now that #57 is merged, this is rebased onto current main, so the diff is webhook-only. I also checked it against the local library matching added in #73. The webhook leaves `tmdb_id` unset, so `_resolve_tmdb_id` resolves it. An import Plex has not scanned yet comes back as not-found, and the existing retry already handles that.
