### PR TITLE
Cap the session log to the most recent lines so long scrapes don't crash the browser

### DIFF
--- a/static/web_interface.js
+++ b/static/web_interface.js
@@ -359,8 +359,18 @@ function updateLog(message, color = null, artwork_title = null) {
         message = message.replace(/^\[(\d{2}:\d{2}:\d{2})\.\d{3}\]/, '[$1]');
     }
 
-    // Prepend the new message with timestamp
-    statusElement.innerHTML = '<div class="log_message">' + message + '</div>' + statusElement.innerHTML;
+    // Prepend the new message (newest first) as a node, so we do not re-parse the entire log
+    // on every line. That, plus the line cap below, stops a long scrape from growing the page
+    // until the browser runs out of memory.
+    const entry = document.createElement("div");
+    entry.className = "log_message";
+    entry.innerHTML = message;
+    statusElement.prepend(entry);
+
+    const MAX_LOG_LINES = 500;
+    while (statusElement.childElementCount > MAX_LOG_LINES) {
+        statusElement.removeChild(statusElement.lastElementChild);
+    }
 }
 socket.on("log_update", (data) => {
     if (validResponse(data,true)) {


### PR DESCRIPTION
The session log in the web UI appends every line to `#scraping_log` and never trims it, so a big scrape (for example scraping a dozen ThePosterDB users at once, thousands of matches) grows the page until the browser runs out of memory and reloads. It also did `statusElement.innerHTML = newLine + statusElement.innerHTML` on every line, which re-parses the entire log on each update.

This changes `updateLog()` to append each line as a DOM node (`createElement` + `prepend`, so no full re-parse) and cap the log to the most recent 500 lines, trimming the oldest as new lines arrive. Newest-first order is unchanged; once the cap is reached the oldest lines drop off.

No dependencies, no config, no behaviour change other than the cap.
