### PR TITLE
Stop a user crawl when the uploads run out instead of trusting the page count

### DIFF
--- a/scrapers/theposterdb_scraper.py
+++ b/scrapers/theposterdb_scraper.py
@@ -78,12 +78,21 @@ class ThePosterDBScraper:
                     if globals.cancel_scrape:
                         break
                     self.callbacks.progress(user_page + 1, self.user_pages, f"Collecting assets from TPDb user {self.author} • {user_page + 1} of {self.user_pages} pages • {collected} assets collected of {self.user_uploads}")
-                    self.scrape_user_page(user_page)
+                    assets_before = self.total
+                    page_scraped = self.scrape_user_page(user_page)
                     movies = len(self.movie_artwork)
                     collections = len(self.collection_artwork)
                     shows = len(self.tv_artwork)
                     collected = movies + shows + collections
                     self.callbacks.debug(f"Processed {user_page + 1} out of {self.user_pages} user pages. Collected {movies} movie, {collections} collection and {shows} TV show assets so far, skipped {self.skipped}")
+
+                    # The uploads counter can be higher than the number of assets actually listed,
+                    # so the page count derived from it can overshoot. A page that scraped cleanly
+                    # but held nothing is the end of the user's uploads. A page that failed also
+                    # adds nothing, so only stop when the page itself was fine.
+                    if page_scraped and self.total == assets_before:
+                        self.callbacks.debug(f"No assets on page {user_page + 1}, the user's uploads end here")
+                        break
                 self.callbacks.debug(f"Total assets collected: {collected} of {self.user_uploads}")
 
                 return
@@ -174,8 +183,11 @@ class ThePosterDBScraper:
             self.errored += child_scraper.errored
             self.total += child_scraper.total
 
+            return True
+
         except Exception as e:
             self.callbacks.debug(f"Failed to scrape user asset page {page}: {str(e)}")
+            return False
 
     def get_set_title(self, soup: Any) -> None:
         try:
@@ -216,7 +228,13 @@ class ThePosterDBScraper:
         """
         cache_buster = f"&_cb={int(time.time())}"
 
-        posters = poster_div.find_all('div', class_='col-6 col-lg-2 p-1')
+        # The uploads counter can be higher than the number of assets actually listed, so a user
+        # crawl can request a page past the last one. Such a page has no poster grid - treat it as
+        # empty rather than an error.
+        posters = poster_div.find_all('div', class_='col-6 col-lg-2 p-1') if poster_div else []
+
+        if not posters:
+            return
 
         if posters[-1].find('a', class_='rounded view_all'):
             posters.pop()

--- a/tests/test_theposterdb_user_crawl.py
+++ b/tests/test_theposterdb_user_crawl.py
@@ -1,0 +1,135 @@
+"""Unit tests for the ThePosterDB user-uploads crawl.
+
+These drive the real scrape_user_page / get_posters path with HTML fixtures and stub only the
+network (cook_soup), so a change that turns the crawl into a no-op is caught rather than hidden.
+"""
+
+import os
+
+import pytest
+from bs4 import BeautifulSoup
+
+from models.callbacks import ProcessingCallbacks
+from models.options import Options
+from scrapers.theposterdb_scraper import ThePosterDBScraper
+
+POSTER_GRID_CLASS = "row d-flex flex-wrap m-0 w-100 mx-n1 mt-n1"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cwd(tmp_path, monkeypatch):
+    # Config.load() writes config/config.json when it's missing; keep that out of the repo.
+    os.makedirs(tmp_path / "config", exist_ok=True)
+    monkeypatch.chdir(tmp_path)
+
+
+def _poster_tile(poster_id, title):
+    return f"""
+    <div class="col-6 col-lg-2 p-1">
+      <a class="text-white" data-toggle="tooltip" data-placement="top" title="Movie">x</a>
+      <div class="overlay" data-poster-id="{poster_id}"></div>
+      <p class="p-0 mb-1 text-break">{title}</p>
+    </div>
+    """
+
+
+def _user_page(n_tiles, start_id=1000):
+    tiles = "".join(_poster_tile(start_id + i, f"Film {start_id + i} (2020)") for i in range(n_tiles))
+    return BeautifulSoup(f'<div class="{POSTER_GRID_CLASS}">{tiles}</div>', "html.parser")
+
+
+def _base_user_page(count, author="someone"):
+    return BeautifulSoup(
+        f'<span class="numCount" data-count="{count}"></span>'
+        f'<p class="h1 mb-0 mr-md-1"><a>{author}</a></p>',
+        "html.parser",
+    )
+
+
+def _scraper(url="https://theposterdb.com/user/someone"):
+    scraper = ThePosterDBScraper(url, ProcessingCallbacks())
+    scraper.set_options(Options())
+    return scraper
+
+
+# --- get_posters robustness (the crash site) ---------------------------------------------------
+
+def test_get_posters_on_a_missing_grid_does_not_raise():
+    # numCount can overshoot the pages actually listed, so the crawl can request a page past the
+    # last real one. scrape_posters passes get_posters a None grid for such a page.
+    scraper = _scraper()
+    scraper.get_posters(None)
+    assert scraper.total == 0
+
+
+def test_get_posters_on_an_empty_grid_does_not_raise():
+    scraper = _scraper()
+    empty = BeautifulSoup(f'<div class="{POSTER_GRID_CLASS}"></div>', "html.parser").div
+    scraper.get_posters(empty)
+    assert scraper.total == 0
+
+
+# --- scrape_user_page reports success/failure --------------------------------------------------
+
+def test_scrape_user_page_returns_true_on_success(monkeypatch):
+    scraper = _scraper()
+    monkeypatch.setattr("utils.soup_utils.cook_soup", lambda url: _user_page(3))
+    assert scraper.scrape_user_page(0) is True
+    assert scraper.total == 3
+
+
+def test_scrape_user_page_returns_false_when_the_fetch_fails(monkeypatch):
+    scraper = _scraper()
+
+    def boom(url):
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr("utils.soup_utils.cook_soup", boom)
+    assert scraper.scrape_user_page(0) is False
+
+
+# --- the crawl stops at the end of the uploads -------------------------------------------------
+
+def test_crawl_stops_at_the_first_empty_page(monkeypatch):
+    # Counter claims 120 uploads (5 pages); only the first two actually hold assets. The crawl
+    # must stop at the first empty page and NOT fetch pages 4 and 5. Asserting on the pages
+    # actually fetched (not just the asset total, which is 48 either way) is what makes this
+    # detect a crawl that silently ploughs on to the end of the counter's page count.
+    scraper = _scraper()
+    fetched = []
+    pages = {1: _user_page(24, 1000), 2: _user_page(24, 2000)}
+
+    def fake_cook_soup(url):
+        if "section=uploads" not in url:
+            return _base_user_page(120)
+        page = int(url.split("page=")[1])
+        fetched.append(page)
+        return pages.get(page, _user_page(0))   # pages 3+ are empty
+
+    monkeypatch.setattr("utils.soup_utils.cook_soup", fake_cook_soup)
+    scraper.scrape()
+
+    assert fetched == [1, 2, 3]                  # stopped AT the first empty page, 4 and 5 untouched
+    assert scraper.total == 48
+
+
+def test_crawl_does_not_stop_on_a_failed_page(monkeypatch):
+    # A failed page also adds nothing to total, but it is not the end of the list, so the crawl
+    # must carry on to the pages after it rather than mistaking a failure for the end.
+    scraper = _scraper()
+    fetched = []
+
+    def fake_cook_soup(url):
+        if "section=uploads" not in url:
+            return _base_user_page(72)          # 3 pages
+        page = int(url.split("page=")[1])
+        fetched.append(page)
+        if page == 2:
+            raise RuntimeError("transient")
+        return _user_page(24, page * 1000)
+
+    monkeypatch.setattr("utils.soup_utils.cook_soup", fake_cook_soup)
+    scraper.scrape()
+
+    assert fetched == [1, 2, 3]                  # page 2 failed but the crawl continued to page 3
+    assert scraper.total == 48                   # pages 1 and 3 contributed


### PR DESCRIPTION
### Problem

`scrape_user_info()` sizes a user crawl as `ceil(numCount / TPDB_USER_UPLOADS_PER_PAGE)`, taking `numCount` from the upload counter on the user page. That counter can be higher than the number of assets actually listed on the `?section=uploads` pages, so the crawl requests one or more pages past the last real one. Those pages have no poster grid, so `get_posters()` calls `.find_all()` on a `None` element (and `posters[-1]` on an empty list) and raises, which aborts the whole user scrape.

I hit this with a user whose counter reads 4063 while the pages actually list 3950 (165 pages), so the crawl walked into pages 166-170 and threw.

### Fix

- Treat a page with no poster grid as empty rather than raising.
- Have `scrape_user_page()` report whether it succeeded.
- Stop the crawl at the first page that scrapes cleanly but yields no assets (the end of the user's uploads), while still continuing past a page that genuinely failed to fetch, so a transient error isn't mistaken for the end.

### Tests

Adds `tests/test_theposterdb_user_crawl.py` (6 tests) that drive the crawl with HTML fixtures and stub only the network: the missing/empty grid no longer raises, `scrape_user_page` reports success/failure, the crawl stops at the first empty page, and a failed page does not end the crawl early.
