### PR TITLE
Add a Stop button to cancel a running scrape

### DIFF
--- a/artwork_uploader.py
+++ b/artwork_uploader.py
@@ -141,6 +141,15 @@ def get_exe_dir():
     return UtilityService.get_exe_dir()
 
 
+def request_scrape_stop() -> bool:
+    """Ask any in-flight scrape to stop. Returns True if a run was flagged to stop, or
+    False when nothing is running - a stale click must not arm the next run."""
+    if globals.scrapes_running:
+        globals.cancel_scrape = True
+        return True
+    return False
+
+
 def process_scrape_url_from_web(instance: Instance, url: str) -> None:
 
     """
@@ -155,6 +164,7 @@ def process_scrape_url_from_web(instance: Instance, url: str) -> None:
     title = None
 
     try:
+        globals.scrapes_running += 1
         # Check if the Plex TV and movie libraries are configured
         if globals.plex.tv_libraries is None or globals.plex.movie_libraries is None:
             update_status(instance, "Plex setup incomplete. Please configure your settings.", color="warning")
@@ -174,6 +184,10 @@ def process_scrape_url_from_web(instance: Instance, url: str) -> None:
         update_status(instance, f"{scraping_error}", color="danger")
 
     finally:
+        globals.scrapes_running -= 1
+        if globals.scrapes_running <= 0:
+            globals.scrapes_running = 0
+            globals.cancel_scrape = False
         if instance.mode == "web":
             notify_web(instance, "element_disable", { "element": ["scrape_url", "scrape_button", "bulk_button"], "mode": False })
             notify_web(instance, "add_spinner", { "element": "scrape_button", "mode": False })
@@ -240,6 +254,7 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
     errors = 0
 
     try:
+        globals.scrapes_running += 1
 
         # Check if plex setup returned valid values
         if globals.plex.tv_libraries is None or globals.plex.movie_libraries is None:
@@ -256,6 +271,8 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
 
         # Loop through the bulk list
         for i, parsed_line in enumerate(parsed_urls, 1):
+            if globals.cancel_scrape:
+                break
 
             notify_web(instance, "element_disable", {"element": ["bulk_button"], "mode": True})
 
@@ -278,16 +295,26 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
         end_time = time.time()
         elapsed = elapsed_time(end_time - start_time)
 
-        message = (
-            ("🏁 " if errors == 0 else "⚠️ ")
-            + ("Scheduled b" if scheduled else "B")
-            + f"ulk import of '{display_filename}' completed "
-            + (f"successfully in {elapsed} • " if errors == 0 else f"with {errors} error(s) in {elapsed}, check logs for details • ")
-            + f"{assets_processed[0]} asset(s) processed • "
-            + f"{success_counter[0]} asset(s) updated"
-        )
-        
-        update_status(instance, message[2:], color="success" if errors == 0 else "warning", sticky=False, spinner=False)
+        if globals.cancel_scrape:
+            message = (
+                "🛑 "
+                + ("Scheduled b" if scheduled else "B")
+                + f"ulk import of '{display_filename}' stopped by user • "
+                + f"{assets_processed[0]} asset(s) processed • "
+                + f"{success_counter[0]} asset(s) updated"
+            )
+            update_status(instance, message[2:], color="warning", sticky=False, spinner=False)
+            notify_web(instance, "progress_bar", {"percent": 100, "bar_type": "bulk"})
+        else:
+            message = (
+                ("🏁 " if errors == 0 else "⚠️ ")
+                + ("Scheduled b" if scheduled else "B")
+                + f"ulk import of '{display_filename}' completed "
+                + (f"successfully in {elapsed} • " if errors == 0 else f"with {errors} error(s) in {elapsed}, check logs for details • ")
+                + f"{assets_processed[0]} asset(s) processed • "
+                + f"{success_counter[0]} asset(s) updated"
+            )
+            update_status(instance, message[2:], color="success" if errors == 0 else "warning", sticky=False, spinner=False)
         update_log(instance, message)
         if scheduled:
             debug_me(f"Sending notifications to {len(globals.config.apprise_urls)} notification service(s).", "process_bulk_import_from_ui")
@@ -298,6 +325,10 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
         update_status(instance, f"Error during bulk import: {bulk_import_exception}", color="danger")
 
     finally:
+        globals.scrapes_running -= 1
+        if globals.scrapes_running <= 0:
+            globals.scrapes_running = 0
+            globals.cancel_scrape = False
         notify_web(instance, "element_disable", { "element": ["scrape_url", "scrape_button", "bulk_button"], "mode": False })
         notify_web(instance, "add_spinner", { "element": "bulk_button", "mode": False })
 

--- a/core/globals.py
+++ b/core/globals.py
@@ -10,3 +10,7 @@ docker: bool = False # Running in Docker
 bulk_file_service = None
 scheduler_service = None
 update_service = None
+
+# Scrape cancellation (user-initiated "Stop" from the web UI)
+cancel_scrape: bool = False   # Set when the user asks to stop; long loops check it and stop cleanly
+scrapes_running: int = 0      # How many scrapes are in flight; the flag clears when the last one ends

--- a/scrapers/mediux_scraper.py
+++ b/scrapers/mediux_scraper.py
@@ -1,5 +1,6 @@
 from typing import Optional, Any
 from core.config import Config
+from core import globals
 from utils import soup_utils
 from utils import utils
 from models.options import Options
@@ -73,6 +74,8 @@ class MediuxScraper:
                         # Spawn and scrape a child MediuxScraper for each set in the boxset
                         collected = 0
                         for n, set_id in enumerate(set_ids,1):
+                            if globals.cancel_scrape:
+                                break
                             #self.callbacks.status(f"Scraping sets in MediUX boxset {self.title} by {self.author}", color="info", sticky=True, spinner=True)
                             self.callbacks.progress(n, len(set_ids), f"Collecting assets from MediUX boxset • {n} of {len(set_ids)} sets • {collected} assets collected", "main")
                             self._scrape_set_in_boxset(set_id)

--- a/scrapers/theposterdb_scraper.py
+++ b/scrapers/theposterdb_scraper.py
@@ -8,6 +8,7 @@ from models.options import Options
 from models.callbacks import ProcessingCallbacks
 from core.exceptions import ScraperException
 from core.config import Config
+from core import globals
 from core.enums import MediaType, ScraperSource
 from core.constants import TPDB_API_ASSETS_URL, TPDB_USER_UPLOADS_PER_PAGE, BOOTSTRAP_COLORS, ANSI_RESET, ANSI_BOLD
 from models.artwork_types import MovieArtworkList, TVArtworkList, CollectionArtworkList
@@ -74,6 +75,8 @@ class ThePosterDBScraper:
 
                 collected = 0
                 for user_page in range(self.user_pages):
+                    if globals.cancel_scrape:
+                        break
                     self.callbacks.progress(user_page + 1, self.user_pages, f"Collecting assets from TPDb user {self.author} • {user_page + 1} of {self.user_pages} pages • {collected} assets collected of {self.user_uploads}")
                     #self.callbacks.status(f"Scraping TPDb asset pages for user {self.author}", color="info", sticky=True, spinner=True)
                     self.scrape_user_page(user_page)

--- a/services/artwork_processor.py
+++ b/services/artwork_processor.py
@@ -15,6 +15,7 @@ from plex.plex_connector import PlexConnector
 from models.options import Options
 from models.callbacks import ProcessingCallbacks
 from utils.utils import elapsed_time
+from core import globals
 from core.exceptions import (
     PlexConnectorException,
     ScraperException,
@@ -96,6 +97,8 @@ class ArtworkProcessor:
         n = 1
         title = f"for {scraper.title}" if scraper.title else ""
         for artwork in scraper.collection_artwork:
+            if globals.cancel_scrape:
+                break
             self.callbacks.progress(n, scraper.total - scraper.skipped, f"{description} • {n} of {scraper.total - scraper.skipped}", "main")
             n += 1
             self._process_single_artwork(
@@ -105,6 +108,8 @@ class ArtworkProcessor:
 
         # Process movies
         for artwork in scraper.movie_artwork:
+            if globals.cancel_scrape:
+                break
             self.callbacks.progress(n, scraper.total - scraper.skipped, f"{description} • {n} of {scraper.total - scraper.skipped}", "main")
             n += 1
             self._process_single_artwork(
@@ -114,6 +119,8 @@ class ArtworkProcessor:
 
         # Process TV shows
         for artwork in scraper.tv_artwork:
+            if globals.cancel_scrape:
+                break
             self.callbacks.progress(n, scraper.total - scraper.skipped, f"{description} • {n} of {scraper.total - scraper.skipped}", "main")
             n += 1
             self._process_single_artwork(
@@ -123,10 +130,16 @@ class ArtworkProcessor:
 
         end_time = time.time()
         elapsed = elapsed_time(end_time - start_time)
-        self.callbacks.assets(count=(scraper.total - scraper.skipped))
-        self.callbacks.log(f"✔️ {description} | {scraper.total - scraper.skipped} asset(s) processed in {elapsed} • {self.callbacks.success_counter[0]} asset(s) updated")
-        if not bulk:
-            self.callbacks.status(f"Processed all artwork {title} by {scraper.author}", "success")
+        if globals.cancel_scrape:
+            self.callbacks.progress(1, 1, "", "main")  # nudge to 100% so the frontend clears the bar (it only hides at 100%)
+            self.callbacks.log(f"🛑 {description} | Stopped by user • {self.callbacks.success_counter[0]} asset(s) updated before stopping")
+            if not bulk:
+                self.callbacks.status(f"Stopped artwork {title} by {scraper.author}", "warning")
+        else:
+            self.callbacks.assets(count=(scraper.total - scraper.skipped))
+            self.callbacks.log(f"✔️ {description} | {scraper.total - scraper.skipped} asset(s) processed in {elapsed} • {self.callbacks.success_counter[0]} asset(s) updated")
+            if not bulk:
+                self.callbacks.status(f"Processed all artwork {title} by {scraper.author}", "success")
         return scraper.title, scraper.author
 
     def _process_single_artwork(

--- a/static/web_interface.js
+++ b/static/web_interface.js
@@ -840,6 +840,10 @@ function startScrape() {
     }
 }
 
+function stopScrape() {
+    socket.emit("stop_scrape", { instance_id: instanceId });
+}
+
 // Function to check for changes and enable/disable the save button
 function updateBulkSaveButtonState() {
 

--- a/templates/web_interface.html
+++ b/templates/web_interface.html
@@ -812,6 +812,7 @@
 
             <!-- Scraping Log Tab -->
             <div class="tab-pane fade" id="scraping-log" role="tabpanel" aria-labelledby="scraping-log-tab" tabindex="0">
+                <button type="button" class="btn btn-danger btn-sm mt-3" id="stop_scrape_button" onclick="stopScrape()"><i class="bi bi-stop-circle"></i>&ensp;Stop</button>
                 <div class="mt-3" id="scraping_log"><!-- --></div>
             </div>
 

--- a/tests/test_stop_scrape.py
+++ b/tests/test_stop_scrape.py
@@ -1,0 +1,221 @@
+"""
+Tests for the scrape-cancellation "Stop" plumbing.
+
+Covers request_scrape_stop(): it must only arm globals.cancel_scrape when a scrape
+is actually in flight, so a stale Stop click can't leak forward and cancel the
+next run before it starts.
+
+Also covers the P1+P2 break checks: once cancel_scrape is armed, the TPDb crawl
+loop and ArtworkProcessor's upload loops must both stop, rather than letting a
+partial harvest reach Plex.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import core.globals as globals
+from artwork_uploader import process_bulk_import_from_ui, request_scrape_stop
+from models.instance import Instance
+from models.options import Options
+from scrapers.theposterdb_scraper import ThePosterDBScraper
+from services.artwork_processor import ArtworkProcessor
+from models.callbacks import ProcessingCallbacks
+
+
+@pytest.mark.unit
+def test_stale_stop_cannot_arm_next_run():
+    try:
+        # Nothing running: Stop must be a no-op, not arm cancel_scrape for later.
+        globals.scrapes_running = 0
+        globals.cancel_scrape = False
+        assert request_scrape_stop() is False
+        assert globals.cancel_scrape is False
+
+        # A scrape is in flight: Stop must arm cancel_scrape.
+        globals.scrapes_running = 1
+        assert request_scrape_stop() is True
+        assert globals.cancel_scrape is True
+    finally:
+        globals.cancel_scrape = False
+        globals.scrapes_running = 0
+
+
+@pytest.mark.unit
+def test_cancel_scrape_breaks_crawl_and_blocks_partial_upload():
+    """
+    P1+P2 must land together: breaking only the TPDb crawl loop would let scrape()
+    return normally with a partial harvest that then gets uploaded to live Plex.
+    This asserts both halves - the crawl stops early AND the partial harvest it
+    collected is never handed to the upload processor.
+    """
+    try:
+        # --- the TPDb user-page crawl loop breaks early on cancel_scrape ---
+        globals.cancel_scrape = False
+        with patch("core.config.Config.load", lambda self: None):
+            scraper = ThePosterDBScraper(url="https://theposterdb.com/user/someuser", callbacks=ProcessingCallbacks(success_counter=[0]))
+        scraper.user_pages = 5  # high page count; loop must not run to completion
+
+        calls = {"n": 0}
+
+        def fake_scrape_user_page(page):
+            calls["n"] += 1
+            if calls["n"] == 2:
+                globals.cancel_scrape = True
+
+        with (
+            patch("utils.soup_utils.cook_soup", return_value=MagicMock()),
+            patch.object(scraper, "scrape_user_info", lambda: None),
+            patch.object(scraper, "scrape_user_page", side_effect=fake_scrape_user_page) as mock_scrape_page,
+        ):
+            scraper.scrape()
+
+        assert mock_scrape_page.call_count < scraper.user_pages, "crawl loop should have broken early on cancel_scrape"
+
+        # --- the per-artwork upload loops refuse to upload a cancelled harvest ---
+        globals.cancel_scrape = True
+
+        mock_scraper = MagicMock()
+        mock_scraper.source = "theposterdb"
+        mock_scraper.title = "Some Title"
+        mock_scraper.author = "Some Author"
+        mock_scraper.total = 3
+        mock_scraper.skipped = 0
+        mock_scraper.errored = 0
+        mock_scraper.collection_artwork = [{"title": "Collection 1"}]
+        mock_scraper.movie_artwork = [{"title": "Movie 1"}]
+        mock_scraper.tv_artwork = [{"title": "Show 1"}]
+
+        mock_upload_processor = MagicMock()
+        mock_upload_processor.process_collection_artwork.return_value = []
+        mock_upload_processor.process_movie_artwork.return_value = []
+        mock_upload_processor.process_tv_artwork.return_value = []
+
+        processor = ArtworkProcessor(plex=MagicMock(), callbacks=ProcessingCallbacks(success_counter=[0]))
+
+        with (
+            patch("services.artwork_processor.Scraper", return_value=mock_scraper),
+            patch("services.artwork_processor.UploadProcessor", return_value=mock_upload_processor),
+        ):
+            processor.scrape_and_process(url="https://theposterdb.com/user/someuser", bulk=False, options=Options())
+
+        mock_upload_processor.process_collection_artwork.assert_not_called()
+        mock_upload_processor.process_movie_artwork.assert_not_called()
+        mock_upload_processor.process_tv_artwork.assert_not_called()
+    finally:
+        globals.cancel_scrape = False
+        globals.scrapes_running = 0
+
+
+@pytest.mark.unit
+def test_cancelled_bulk_run_reports_stopped_not_success():
+    """
+    P3: once cancel_scrape is armed, the bulk summary must report an honest
+    "stopped" message - never the green "completed successfully" wording a
+    finished run gets. This drives the real process_bulk_import_from_ui
+    reporting branch (with the Plex-config check and the actual scrape
+    stubbed out) so the assertions exercise real branch logic on
+    globals.cancel_scrape, not a mock of it. scheduled=True so the
+    notification branch runs too - a suppressed notification on a cancelled
+    scheduled run would leave a dangling "started" with no terminal event.
+    """
+    try:
+        globals.cancel_scrape = True
+        globals.scrapes_running = 0
+        globals.plex = MagicMock(tv_libraries=MagicMock(), movie_libraries=MagicMock())
+        globals.config = MagicMock(apprise_urls=[])
+
+        instance = Instance(mode="cli")
+        parsed_urls = [MagicMock()]  # loop must break before this is ever touched
+
+        messages = {}
+
+        def fake_update_log(inst, message, *args, **kwargs):
+            messages["log"] = message
+
+        def fake_update_status(inst, message, *args, **kwargs):
+            messages["status"] = message
+
+        def fake_send_notification(inst, message, *args, **kwargs):
+            messages["notification"] = message
+
+        with (
+            patch("artwork_uploader.scrape_and_upload") as mock_scrape_and_upload,
+            patch("artwork_uploader.update_log", side_effect=fake_update_log),
+            patch("artwork_uploader.update_status", side_effect=fake_update_status),
+            patch("artwork_uploader.send_notification", side_effect=fake_send_notification),
+            patch("artwork_uploader.notify_web") as mock_notify_web,
+            patch("artwork_uploader.debug_me"),
+        ):
+            process_bulk_import_from_ui(instance, parsed_urls, "test_bulk.txt", scheduled=True)
+
+        mock_scrape_and_upload.assert_not_called()
+
+        assert "log" in messages, "update_log must fire even on a cancelled run"
+        assert "🛑" in messages["log"]
+        assert "stopped" in messages["log"].lower()
+        assert "completed successfully" not in messages["log"]
+        assert "Processed all artwork" not in messages["log"]
+
+        assert "status" in messages
+        assert "stopped" in messages["status"].lower()
+        assert "completed successfully" not in messages["status"]
+        assert "Processed all artwork" not in messages["status"]
+
+        assert "notification" in messages, "a scheduled cancelled run must not suppress the terminal notification"
+        assert "🛑" in messages["notification"]
+        assert "completed successfully" not in messages["notification"]
+
+        progress_hides = [
+            c for c in mock_notify_web.call_args_list
+            if len(c.args) >= 3 and c.args[1] == "progress_bar" and c.args[2].get("percent") == 100
+        ]
+        assert progress_hides, "a cancelled bulk run must clear the progress bar (emit percent 100)"
+    finally:
+        globals.cancel_scrape = False
+        globals.scrapes_running = 0
+        globals.plex = None
+        globals.config = None
+
+
+@pytest.mark.unit
+def test_single_url_cancel_emits_stopped_status():
+    """A cancelled single-URL scrape must surface a 'Stopped' status toast (color warning),
+    not a green 'Processed all artwork' success - matching the bulk path's stopped feedback."""
+    try:
+        globals.cancel_scrape = True
+
+        statuses = []
+
+        callbacks = ProcessingCallbacks(
+            success_counter=[0],
+            on_status_update=lambda message, color, spinner, sticky: statuses.append((message, color)),
+        )
+
+        mock_scraper = MagicMock()
+        mock_scraper.source = "theposterdb"
+        mock_scraper.title = "Some Title"
+        mock_scraper.author = "Some Author"
+        mock_scraper.total = 3
+        mock_scraper.skipped = 0
+        mock_scraper.errored = 0
+        mock_scraper.collection_artwork = []
+        mock_scraper.movie_artwork = [{"title": "Movie 1"}]
+        mock_scraper.tv_artwork = []
+
+        processor = ArtworkProcessor(plex=MagicMock(), callbacks=callbacks)
+
+        with (
+            patch("services.artwork_processor.Scraper", return_value=mock_scraper),
+            patch("services.artwork_processor.UploadProcessor", return_value=MagicMock()),
+        ):
+            processor.scrape_and_process(url="https://theposterdb.com/set/123", bulk=False, options=Options())
+
+        assert statuses, "a cancelled single-URL scrape must emit a status toast"
+        message, color = statuses[-1]
+        assert "Stopped" in message
+        assert "Processed all artwork" not in message
+        assert color == "warning"
+    finally:
+        globals.cancel_scrape = False
+        globals.scrapes_running = 0

--- a/web_routes.py
+++ b/web_routes.py
@@ -142,6 +142,7 @@ def setup_socket_handlers(
     # Import functions from artwork_uploader (to avoid circular imports at module level)
     from artwork_uploader import (
         process_scrape_url_from_web,
+        request_scrape_stop,
         run_bulk_import_scrape_in_thread,
         save_bulk_import_file,
         load_bulk_import_file,
@@ -263,6 +264,15 @@ def setup_socket_handlers(
             )
             notify_web(instance, "add_spinner", { "element": "scrape_button", "mode": True })
             process_scrape_url_from_web(instance, url)
+
+    @globals.web_socket.on("stop_scrape")
+    def handle_stop_scrape(data):
+        """Flag any in-flight scrape to stop cleanly (user pressed Stop in the web UI)."""
+        instance = Instance(data.get("instance_id"), "web")
+        if request_scrape_stop():
+            update_log(instance, "🛑 Stop requested - the current item will finish, then the run stops")
+        else:
+            update_log(instance, "ℹ️ Nothing to stop - no scrape is running")
 
     @globals.web_socket.on("start_bulk_import")
     def handle_bulk_import_from_web(data):


### PR DESCRIPTION
## Problem

Once a scrape or bulk import is running, there is no way to stop it from the UI. The only option is
restarting the container. A large user-catalogue scrape can run for tens of minutes (thousands of
assets, each with a rate-limited upload), so a run you no longer want has to be waited out or killed.

## What this adds

An always-enabled Stop button in the scraping-log pane that cancels the current run cleanly:

- `core/globals.py`: a `cancel_scrape` flag and a `scrapes_running` counter. The flag is set on Stop
  and cleared only when the last in-flight run ends, so a stale click cannot cancel the next run, and
  pressing Stop with nothing running is a no-op.
- A `stop_scrape` Socket.IO event plus the button (`web_routes.py`, `templates/web_interface.html`,
  `static/web_interface.js`). The button sits in the log pane, which the UI already switches to when a
  run starts.
- Cooperative cancellation: the long loops check the flag and break. That covers the TPDB and MediUX
  crawl loops, the three per-artwork upload loops, and the bulk-import URL loop. A run stops within one
  artwork; the in-flight upload's rate-limit wait is not interrupted (the upload path takes no
  cancellation token, kept intentionally simple).
- Honest reporting: a cancelled run logs a "stopped" line with the real count instead of a "Processed
  all artwork" success, and a cancelled scheduled run still sends its completion notification (with
  stopped wording) so it never leaves a dangling "started".
- The progress bar clears on cancel. The frontend only hides the bar when it reaches 100%, so a
  cancelled run (which breaks its loop early) would otherwise leave it stuck at "N of M" until the page
  was refreshed. The cancel path emits a 100% event so the bar clears.

When Stop is never pressed, behaviour is unchanged. Every branch is guarded on `cancel_scrape`, which
defaults to `False`.

## Design note

Stop is global, not per-run. There is no per-run registry (the scheduler runs a single cli-mode
instance that is not addressable per browser session), so Stop halts every in-flight run. Runs do not
normally overlap from a single UI.

## Tests

`tests/test_stop_scrape.py` (the repo's existing pytest setup): a stale Stop is a no-op, the crawl
breaks and a partial harvest is never uploaded, a bulk cancel stops and reports honestly (including the
scheduled notification and the progress-bar clear), and a single-URL cancel surfaces a "stopped"
status. All pass alongside the existing suite.
