### PR TITLE
Save Kometa item assets with lowercase filenames again (fixes #64)

### DIFF
--- a/core/constants.py
+++ b/core/constants.py
@@ -74,6 +74,18 @@ ARTWORK_TYPE_MAP = {
     FileType.TITLE_CARD.value: "Title card"
 }
 
+# Artwork type to Kometa asset filename mapping. Kometa's item-level asset names are
+# lowercase on disk (poster.ext / background.ext / square.ext) and its matching is
+# case-sensitive on Linux, so these must not use the display strings above.
+ARTWORK_FILENAME_MAP = {
+    FileType.BACKGROUND.value: "background",
+    FileType.BACKDROP.value: "background",
+    FileType.SQUARE_ART.value: "square",
+    FileType.MOVIE_POSTER.value: "poster",
+    FileType.COLLECTION_POSTER.value: "poster",
+    FileType.POSTER.value: "poster",
+}
+
 # Media types
 MEDIA_TYPE_TV_SHOW = "TV Show"
 MEDIA_TYPE_MOVIE = "Movie"

--- a/processors/upload_processor.py
+++ b/processors/upload_processor.py
@@ -4,7 +4,7 @@ from core.config import Config
 from core.exceptions import CollectionNotFound, MovieNotFound, ShowNotFound, PlexConnectorException
 from core.enums import ScraperSource
 from core.exceptions import ScraperException
-from core.constants import ARTWORK_ID_MAP, ARTWORK_TYPE_MAP
+from core.constants import ARTWORK_ID_MAP, ARTWORK_TYPE_MAP, ARTWORK_FILENAME_MAP
 from models.options import Options
 from plex.plex_connector import PlexConnector
 from plex.plex_uploader import PlexUploader
@@ -58,7 +58,7 @@ class UploadProcessor:
                     base_dir = ("/temp" if self.options.temp else "/assets") if globals.docker else getattr(globals.config, "temp_dir" if self.options.temp else "kometa_base", None)
                     saver.dest_dir = os.path.join(base_dir, library, asset_folder)
                     debug_me(f"Destination directory is {saver.dest_dir}")
-                    saver.dest_file_name = "square" if artwork_type == "square_art" else artwork_type
+                    saver.dest_file_name = ARTWORK_FILENAME_MAP.get(artwork.get('file_type'), 'poster')
                     saver.dest_file_ext = ".jpg"
                     saver.set_description(description)
                     saver.set_options(self.options)
@@ -127,7 +127,7 @@ class UploadProcessor:
                     base_dir = ("/temp" if self.options.temp else "/assets") if globals.docker else getattr(globals.config, "temp_dir" if self.options.temp else "kometa_base", None)
                     saver.dest_dir = os.path.join(base_dir, library, asset_folder)
                     debug_me(f"Destination directory is {saver.dest_dir}")
-                    saver.dest_file_name = "square" if artwork_type == "square_art" else artwork_type
+                    saver.dest_file_name = ARTWORK_FILENAME_MAP.get(artwork.get('file_type'), 'poster')
                     saver.dest_file_ext = ".jpg"
                     saver.set_description(desc)
                     saver.set_options(self.options)


### PR DESCRIPTION
Fixes #64.

**Root cause:** the 0.8.6 refactor (7edaf4a) dropped the `.lower()` calls when setting `dest_file_name` in `upload_processor.py`, and the value it now uses comes from `ARTWORK_TYPE_MAP`, which holds capitalized display strings ("Poster", "Background") intended for logging per its own comment. So `save_to_kometa` started writing `Poster.jpg` and `Background.jpg`. Kometa's asset matching is case sensitive on Linux, which makes those files invisible to it, and a force replace deletes the previously working lowercase file first, so affected titles silently lose their only Kometa readable asset.

**The fix** adds a dedicated `ARTWORK_FILENAME_MAP` in `constants.py`, following the same map pattern the refactor introduced, so item level assets are written as `poster` / `background` / `square` again (matching pre 0.8.6 behavior and Kometa's documented naming). It also fixes the square art check: the old line compared the display string against the raw enum value (`artwork_type == "square_art"`), which could never be true, so square art would have been saved under the display string name.

Scope notes: season assets (`Season##.jpg`) go through the TV path with an explicitly computed `file_name` and are untouched, since their capitalization is correct for Kometa. Users who ran 0.8.6 may have leftover capitalized files next to new lowercase ones after this fix; a force reapply or manual rename cleans those up.

**Tested** on the 0.8.6 Docker image with the patch applied: a live MediUX scrape with `--force` on a set whose assets already existed replaced them in place as `poster.jpg` (lowercase) in both mapped libraries, where stock 0.8.6 wrote `Poster.jpg` on the same code path. Also verified the map resolves every item level file type to the expected lowercase name and that both files compile cleanly.
