### PR TITLE
Persist a stable Plex client identifier so runs stop registering as new devices

### DIFF
--- a/artwork_uploader.py
+++ b/artwork_uploader.py
@@ -6,6 +6,33 @@ import threading
 import sys
 import time
 
+# plexapi builds its X-Plex-Client-Identifier from uuid.getnode(), which can be
+# random on every process start (commonly in Docker, where no MAC is readable).
+# That registers each run as a brand new Plex device and fires new device
+# notifications. Persist one identifier in the config folder and pass it to
+# plexapi through its environment override, before plexapi is imported below.
+# An identifier already set in the environment always takes precedence.
+def _ensure_stable_plex_identifier() -> None:
+    if os.environ.get("PLEXAPI_HEADER_IDENTIFIER"):
+        return
+    id_file = os.path.join("config", ".plex_client_id")
+    try:
+        if os.path.isfile(id_file):
+            with open(id_file) as f:
+                client_id = f.read().strip()
+        else:
+            client_id = str(uuid.uuid4())
+            os.makedirs("config", exist_ok=True)
+            with open(id_file, "w") as f:
+                f.write(client_id)
+        if client_id:
+            os.environ["PLEXAPI_HEADER_IDENTIFIER"] = client_id
+            os.environ.setdefault("PLEXAPI_HEADER_DEVICE_NAME", "Artwork Uploader")
+    except OSError:
+        pass  # fall back to the plexapi default rather than block startup
+
+_ensure_stable_plex_identifier()
+
 from models import arguments
 from models.instance import Instance
 from utils.notifications import update_log, update_status, notify_web, debug_me, send_notification


### PR DESCRIPTION
**Problem:** every run of the app can register as a brand new device on the Plex server, and owners with new device notifications enabled get pinged each time. With a daily scheduled bulk run that means a phone notification every single morning, and the server quietly accumulates phantom device entries (found 66 on mine).

**Cause:** plexapi builds its `X-Plex-Client-Identifier` from `uuid.getnode()`, which returns a random value per process when no MAC address is readable. That is the common case in Docker, so the long running web UI holds one identity while every CLI or scheduled bulk invocation shows up as a fresh device. Verified in the 0.8.8 container: three consecutive `python -c "import uuid; print(hex(uuid.getnode()))"` calls returned three different values.

**Fix:** generate a UUID once, persist it as `config/.plex_client_id`, and hand it to plexapi via its `PLEXAPI_HEADER_IDENTIFIER` environment override before plexapi is imported. An identifier the user already set in the environment always wins, and any file error falls back to current behavior rather than blocking startup. Also sets a friendly `PLEXAPI_HEADER_DEVICE_NAME` so the device list shows "Artwork Uploader".

**Tested** on the 0.8.8 Docker image with the patch applied: two consecutive bulk runs generated the identifier once, reused it on the second run, and registered exactly one device on the Plex server between them (previously one per run). A third run with `PLEXAPI_HEADER_IDENTIFIER` set in the environment left the persisted file untouched, confirming the precedence path.
