### PR TITLE
Only show the Stop button while a scrape is running

### DIFF
--- a/artwork_uploader.py
+++ b/artwork_uploader.py
@@ -162,6 +162,7 @@ def process_scrape_url_from_web(instance: Instance, url: str) -> None:
 
     try:
         globals.scrapes_running += 1
+        notify_web(instance, "scrape_state", {"running": True})
         # Check if the Plex TV and movie libraries are configured
         if globals.plex.tv_libraries is None or globals.plex.movie_libraries is None:
             update_status(instance, "Plex setup incomplete. Please configure your settings.", color=StatusColor.WARNING.value)
@@ -186,6 +187,7 @@ def process_scrape_url_from_web(instance: Instance, url: str) -> None:
         if globals.scrapes_running <= 0:
             globals.scrapes_running = 0
             globals.cancel_scrape = False
+            notify_web(instance, "scrape_state", {"running": False})
         if instance.mode == "web":
             notify_web(instance, "element_disable", { "element": ["scrape_url", "scrape_button", "bulk_button"], "mode": False })
             notify_web(instance, "add_spinner", { "element": "scrape_button", "mode": False })
@@ -252,6 +254,7 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
 
     try:
         globals.scrapes_running += 1
+        notify_web(instance, "scrape_state", {"running": True})
 
         # Check if plex setup returned valid values
         if globals.plex.tv_libraries is None or globals.plex.movie_libraries is None:
@@ -323,6 +326,7 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
         if globals.scrapes_running <= 0:
             globals.scrapes_running = 0
             globals.cancel_scrape = False
+            notify_web(instance, "scrape_state", {"running": False})
         notify_web(instance, "element_disable", { "element": ["scrape_url", "scrape_button", "bulk_button"], "mode": False })
         notify_web(instance, "add_spinner", { "element": "bulk_button", "mode": False })
 

--- a/static/web_interface.js
+++ b/static/web_interface.js
@@ -342,6 +342,15 @@ socket.on("status_update", (data) => {
     }
 });
 
+socket.on("scrape_state", (data) => {
+    if (validResponse(data, true)) {
+        const stopButton = document.getElementById("stop_scrape_button");
+        if (stopButton) {
+            stopButton.classList.toggle("d-none", !data.running);
+        }
+    }
+});
+
 
 // Update the log page
 function updateLog(message, color = null, artwork_title = null) {

--- a/templates/web_interface.html
+++ b/templates/web_interface.html
@@ -812,7 +812,7 @@
 
             <!-- Scraping Log Tab -->
             <div class="tab-pane fade" id="scraping-log" role="tabpanel" aria-labelledby="scraping-log-tab" tabindex="0">
-                <button type="button" class="btn btn-danger btn-sm mt-3" id="stop_scrape_button" onclick="stopScrape()"><i class="bi bi-stop-circle"></i>&ensp;Stop</button>
+                <button type="button" class="btn btn-danger btn-sm mt-3 d-none" id="stop_scrape_button" onclick="stopScrape()"><i class="bi bi-stop-circle"></i>&ensp;Stop</button>
                 <div class="mt-3" id="scraping_log"><!-- --></div>
             </div>
 


### PR DESCRIPTION
The Stop button in the Log tab is always visible, even when nothing is running. Clicking it while idle already does nothing (the backend no-ops a stale stop request), but the persistent button is misleading. This shows it only while a scrape is actually in progress.

The app already tracks in-flight work with `globals.scrapes_running` and pushes UI updates over Socket.IO, so this adds a small `scrape_state` event emitted when that counter crosses 0 (running true at the start of a web or bulk scrape, running false when the last one finishes), and the frontend shows or hides the button on it. The button now starts hidden in the template. It is driven by the running-state counter rather than the status spinner, so it stays correct regardless of any cosmetic status changes, and it inherits the same per-instance scoping as the existing spinner and input-disable events.

- Backend emits `scrape_state {running}` at the start and end of both the single URL and bulk web scrape paths
- Frontend toggles `#stop_scrape_button` visibility on the event, gated by the existing `validResponse` broadcast check
- Button carries `d-none` in the template so it is hidden until the first scrape starts
- Tested on the 0.8.8 Docker image by driving both a single scrape and a bulk import over Socket.IO and confirming the event fires true at start and false at finish for each, and confirmed in Firefox and Chrome that the button appears when a scrape starts and disappears when it ends
