### PR TITLE
Fix the collection test to read the file_type key the scraper writes

### DIFF
--- a/tests/test_mediux_scraper_collection.py
+++ b/tests/test_mediux_scraper_collection.py
@@ -54,7 +54,7 @@ def test_collection_without_word_collection_in_name_does_not_crash():
     scraper._process_set(_collection_poster_set("James Bond"))
     assert len(scraper.collection_artwork) == 1
     assert scraper.collection_artwork[0]["title"] == "James Bond"
-    assert scraper.collection_artwork[0]["type"] == "collection_poster"
+    assert scraper.collection_artwork[0]["file_type"] == "collection_poster"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
The MediUX collection regression test fails on a clean checkout:

tests/test_mediux_scraper_collection.py::test_collection_without_word_collection_in_name_does_not_crash raises KeyError: 'type'.

The test asserts the collection poster's type under the key "type". Since the MediUX scraper refactor the scraper writes it as "file_type" instead (the same key it uses for movie and TV artwork, and the one the upload processor reads), so the assertion no longer matches. This updates the test to read "file_type".

Test-only change, no runtime behaviour is affected. Both tests in the file pass.
