### PR TITLE
Implement per-library indexing

### DIFF
--- a/core/constants.py
+++ b/core/constants.py
@@ -28,7 +28,7 @@ DEFAULT_TV_LIBRARY = ["TV Shows"]
 DEFAULT_MOVIE_LIBRARY = ["Movies"]
 
 # Plex library index refresh timeout (seconds)
-PLEX_LIBRARY_INDEX_TIMEOUT = 900 # Default 15 minutes
+PLEX_LIBRARY_INDEX_TIMEOUT = 6 * 60 * 60 # Default 6 hours
 
 # Filter types - valid artwork types that can be filtered
 FILTER_TITLE_CARD = "title_card"

--- a/plex/library_index.py
+++ b/plex/library_index.py
@@ -29,70 +29,144 @@ class PlexLibraryIndex:
     def __init__(self, movie_libraries: List, tv_libraries: List) -> None:
         self.movie_libraries: List = []
         self.tv_libraries: List = []
-        self.last_refresh: float = time.time()
-        self.index: dict = {}
+        self.last_refresh: Dict[str, float] = {}
+        self.index: Dict[str, Dict[str, List[Dict]]] = {}
+        self.library_snapshots: Dict[str, Tuple[int, Optional[object], Optional[str]]] = {}
         self._initialize_index(movie_libraries, tv_libraries)
+
+    def _get_library_snapshot(self, library) -> Tuple[int, Optional[object], Optional[str]]:
+        library.reload()
+        total_size = library.totalSize
+        latest_item = library.search(sort='addedAt:desc', limit=1)
+        latest_added = latest_item[0].addedAt if latest_item else None
+        latest_key = latest_item[0].ratingKey if latest_item else None
+        return (total_size, latest_added, latest_key)
 
     def _initialize_index(self, movie_libraries:List, tv_libraries: List) -> None:
         if not movie_libraries and not tv_libraries:
             return
         
+        current_libraries = self.movie_libraries + self.tv_libraries
+        new_libraries = movie_libraries + tv_libraries
+
+        new_titles = {lib.title for lib in new_libraries}
+        removed_libraries = [lib for lib in current_libraries if lib.title not in new_titles]
+
+        for library in removed_libraries:
+            self._remove_library(library)
+        
+        start_time = time.time()
+        any_updates = False
+
+        for library in new_libraries:
+            indexed = self._add_library(library)
+            any_updates = any_updates or indexed
+
+        self.movie_libraries = movie_libraries
+        self.tv_libraries = tv_libraries
+
+        movies = 0
+        shows = 0
+
+        for lib_dict in self.index.values():
+            for entries in lib_dict.values():
+                for entry in entries:
+                    if entry["type"] == MediaType.MOVIE.value:
+                        movies += 1
+                    elif entry["type"] == MediaType.TV_SHOW.value:
+                        shows += 1
+
         now = time.time()
-        index_timed_out = (now - self.last_refresh) > PLEX_LIBRARY_INDEX_TIMEOUT
-        changed_libraries = set([lib.title for lib in self.movie_libraries]) != set([lib.title for lib in movie_libraries]) or set([lib.title for lib in self.tv_libraries]) != set([lib.title for lib in tv_libraries])
+        index_time = elapsed_time(now - start_time, precise=True)
 
-        if not self.index or changed_libraries or index_timed_out:
-            self.index = {}
-            debug_me(f"Initializing Plex library index")
-            start_time = time.time()
-            for library in movie_libraries + tv_libraries:
-                self._add_library(self.index, library)
-
-            movies = sum(len(v) for v in self.index.values() if any(movie["type"] == MediaType.MOVIE.value for movie in v))
-            shows = sum(len(v) for v in self.index.values() if any(show["type"] == MediaType.TV_SHOW.value for show in v))
-            debug_me(f"Indexed {movies} movie and "
-                        f"{shows} TV index entries "
-                        f"across {len(self.movie_libraries) + len(self.tv_libraries)} libraries "
-                        f"in {time.time() - start_time:.1f}s")
-            self.last_refresh = time.time()
-            self.movie_libraries = movie_libraries
-            self.tv_libraries = tv_libraries
+        if any_updates:
+            debug_me(
+                f"Index update complete in {index_time}: there are {movies} movie and {shows} "
+                f"TV show entries across {len(new_libraries)} libraries"
+            )
         else:
-            debug_me(f"Index is still fresh ({elapsed_time(now - self.last_refresh)}), skipping re-indexing")
+            debug_me(f"No libraries required reindexing")
             
+    def _remove_library(self, library) -> None:
+        """ Removes the library from the index and its tracking metadata"""
+        if library.title not in self.index:
+            return
+        
+        self.index.pop(library.title, None)
+        self.library_snapshots.pop(library.title, None)
+        self.last_refresh.pop(library.title, None)
 
-    def _add_library(self, index: dict, library) -> None:
-        n = 0
-        for item in library.all():
-            n += 1
-            # Index values come from the listing response only - without this, reading an attribute
-            # the item doesn't have (e.g. originalTitle on most items) makes plexapi reload the
-            # item, which would be one extra request per library item
-            item._autoReload = False
-            tmdb_id: Optional[int] = None
-            for guid in item.guids:
-                if "tmdb://" in guid.id:
-                    try:
-                        tmdb_id = int(guid.id.split("tmdb://", 1)[-1])
-                    except ValueError:
-                        pass
-                    break
-            entry = {
-                "title": item.title,
-                "year": item.year,
-                "tmdb_id": tmdb_id,
-                "library": library.title,
-                "type": MediaType.TV_SHOW.value if library.type == "show" else MediaType.MOVIE.value
-            }
-            for key in self._title_keys(item):
-                index.setdefault(key, []).append(entry)
-        debug_me(f"Added {n} {MediaType.TV_SHOW.value if library.type == "show" else MediaType.MOVIE.value} items from library {library.title} to index")
+        debug_me(f"Removed library {library.title} from the index")
+
+    def _add_library(self, library) -> bool:
+        """ Adds a library to the index if the library is not already in the index or if the 
+        content of the library has changed based on the snapshot, and it also updates the snapshot"""
+
+        # Get current state
+        last_refresh = self.last_refresh.get(library.title, 0)
+        current_snapshot = self.library_snapshots.get(library.title)
+
+        # Get new state
+        now = time.time()
+        new_snapshot = self._get_library_snapshot(library)
+
+        library_changed = current_snapshot != new_snapshot
+        index_expired = (now - last_refresh) > PLEX_LIBRARY_INDEX_TIMEOUT
+
+        not_in_index = library.title not in self.index
+
+        # If the library doesn't exist in the index or the contents of the library have changed
+        # or the library index has timed out it reindexes the library from scratch
+        if not_in_index or library_changed or index_expired:
+            if not_in_index:
+                debug_me(f"Adding library {library.title} to the Plex Library Index")
+            elif library_changed:
+                debug_me(f"Reindexing '{library.title}' due to library content changes")
+            elif index_expired:
+                debug_me(f"Reindexing '{library.title}' because its index has expired ({elapsed_time(now - last_refresh)})")
+
+            # Update state
+            self.library_snapshots[library.title] = new_snapshot
+            self.last_refresh[library.title] = now
+
+            # Initializae index
+            self.index[library.title] = {}
+
+            n = 0
+            for item in library.all():
+                n += 1
+                # Index values come from the listing response only - without this, reading an attribute
+                # the item doesn't have (e.g. originalTitle on most items) makes plexapi reload the
+                # item, which would be one extra request per library item
+                item._autoReload = False
+                tmdb_id: Optional[int] = None
+                for guid in item.guids:
+                    if "tmdb://" in guid.id:
+                        try:
+                            tmdb_id = int(guid.id.split("tmdb://", 1)[-1])
+                        except ValueError:
+                            pass
+                        break
+                entry = {
+                    "title": item.title,
+                    "year": item.year,
+                    "tmdb_id": tmdb_id,
+                    "type": MediaType.TV_SHOW.value if library.type == "show" else MediaType.MOVIE.value
+                }
+                for key in self._title_keys(item):
+                    self.index[library.title].setdefault(key, []).append(entry)
+
+            debug_me(f"Indexed {n} {MediaType.TV_SHOW.value if library.type == 'show' else MediaType.MOVIE.value} items from library {library.title}")
+            return True
+
+        return False
 
     def _title_keys(self, item) -> set:
         """All the normalized keys an item should be findable under."""
         keys = {normalize_title(item.title)}
-        slug_without_year = item.slug.split(f"-{item.year}")[0].strip()
-        keys.add(normalize_title(slug_without_year))
+        if item.slug:
+            slug_without_year = item.slug.split(f"-{item.year}")[0].strip()
+            keys.add(normalize_title(slug_without_year))
         if item.originalTitle:
             keys.add(normalize_title(item.originalTitle))
         
@@ -113,7 +187,11 @@ class PlexLibraryIndex:
         """
         _kind = [kind] if kind is not None else [MediaType.TV_SHOW, MediaType.MOVIE]
         lookup_string = normalize_title(title)
-        candidates = [c for c in self.index.get(lookup_string, []) if c["type"] in _kind]
+        candidates = []
+
+        for lib_index in self.index.values():
+            candidates.extend(c for c in lib_index.get(lookup_string, []) if c["type"] in _kind)
+
         if candidates and year is not None:
             for candidate_year in (year, int(year) - 1, int(year) + 1):
                 matched = [c for c in candidates if c["year"] == candidate_year]

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -54,9 +54,10 @@ def title_cleaner(string):
 
     return title
 
-def elapsed_time(seconds: float) -> str:
+def elapsed_time(seconds: float, precise: bool = False) -> str:
     """ Converts seconds into 2h 31m 12s, 9m 34s or 32s format for readability"""
-    seconds = int(round(seconds))
+    seconds = int(round(seconds)) if not precise else round(seconds, 2)
+    
     if seconds < 60:
         return f"{seconds}s"
     
@@ -65,7 +66,9 @@ def elapsed_time(seconds: float) -> str:
 
     if h > 0:
         return f"{h}h {m}m {s}s"
-    return f"{m}m {s}s"
+    if m > 0:
+        return f"{m}m {s}s"
+    return f"{s}s"
 
 def parse_string_to_dict(input_string):
     # Remove unnecessary replacements


### PR DESCRIPTION
Implement per-library indexing with per-library change detection and/or index expiration so that it only has to reindex libraries individually when there have been changes or they have timed out. Timeout extended to 6 hours.