### PR TITLE
Stop the completion toast saying "for for"

### DIFF
--- a/services/artwork_processor.py
+++ b/services/artwork_processor.py
@@ -128,12 +128,12 @@ class ArtworkProcessor:
             self.callbacks.progress(1, 1, "", "main")  # nudge to 100% so the frontend clears the bar (it only hides at 100%)
             self.callbacks.log(f"🛑 {description} | Canceled by user • {self.callbacks.success_counter[0]} asset(s) updated before stopping")
             if not bulk:
-                self.callbacks.status(f"Process canceled for {f'{title} by {scraper.author}' if title else f"{scraper.author}'s TPDb portfolio"}", "warning")
+                self.callbacks.status(f"Process canceled {f'{title} by {scraper.author}' if title else f"for {scraper.author}'s TPDb portfolio"}", "warning")
         else:
             self.callbacks.assets(count=(scraper.total - scraper.skipped))
             self.callbacks.log(f"✔️ {description} | {scraper.total - scraper.skipped} asset(s) processed in {elapsed} • {self.callbacks.success_counter[0]} asset(s) updated")
             if not bulk:
-                self.callbacks.status(f"Process completed for {f'{title} by {scraper.author}' if title else f"{scraper.author}'s TPDb portfolio"}", "success")
+                self.callbacks.status(f"Process completed {f'{title} by {scraper.author}' if title else f"for {scraper.author}'s TPDb portfolio"}", "success")
         return scraper.title, scraper.author
 
     def _process_single_artwork(

--- a/tests/test_stop_scrape.py
+++ b/tests/test_stop_scrape.py
@@ -213,7 +213,8 @@ def test_single_url_cancel_emits_stopped_status():
 
         assert statuses, "a cancelled single-URL scrape must emit a status toast"
         message, color = statuses[-1]
-        assert "Stopped" in message
+        assert "Process canceled" in message
+        assert "for for" not in message
         assert "Processed all artwork" not in message
         assert color == "warning"
     finally:


### PR DESCRIPTION
`title` is built as `f"for {scraper.title}"` on line 92 of `services/artwork_processor.py`, and both status toasts then add their own "for" in front of it. So a scrape of a named set finishes with:

> Process completed for for Some Title by Some Author

The cancel path reads the same way. The portfolio case, where `title` is empty, was already correct, so this moves the word inside the conditional rather than removing it. Two lines.

While in there: `test_stop_scrape.py::test_single_url_cancel_emits_stopped_status` has been failing on main. It asserts on "Stopped", the wording before the Stop button was merged. The message became "Process canceled for ..." at that point and the test did not follow. It now asserts what the code emits, plus the absence of the duplicate. The suite goes from 27 passing with 1 failure to 28 passing.
