### PR TITLE
Make Stop actually stop a cached user crawl

### DIFF
--- a/scrapers/theposterdb_scraper.py
+++ b/scrapers/theposterdb_scraper.py
@@ -501,6 +501,13 @@ class ThePosterDBScraper:
         clean = True
         collected = 0
         for user_page in range(self.user_pages):
+            # A Stop during a cached crawl must also mark the crawl unclean. The `if clean:` block in
+            # _scrape_user_cached gates both reconcile() and record_crawl(), so breaking out without
+            # this would tombstone every asset the crawl never reached and advance last_full_crawl
+            # over a partial pass.
+            if globals.cancel_scrape:
+                clean = False
+                break
             self.callbacks.progress(user_page + 1, self.user_pages, f"Collecting assets from TPDb user {self.author} • {user_page + 1} of {self.user_pages} pages • {collected} assets collected of {self.user_uploads}")
             page_catalog = []
             ok = self.scrape_user_page(user_page, catalog=page_catalog)

--- a/tests/test_user_cache_crawl.py
+++ b/tests/test_user_cache_crawl.py
@@ -88,6 +88,33 @@ def test_a_failed_page_still_marks_the_crawl_unclean(tmp_path, monkeypatch):
     assert clean is False                        # a real failure must still block reconcile
 
 
+def test_a_cancelled_crawl_is_unclean_and_stops(tmp_path, monkeypatch):
+    scraper = _scraper()
+    scraper.user_uploads = 240
+    scraper.user_pages = 10
+    index = AssetIndex(str(tmp_path / "idx.db"))
+
+    pages_fetched = []
+
+    def fake(page, catalog=None):
+        pages_fetched.append(page)
+        for asset_id in range(page * 1000, page * 1000 + 24):
+            catalog.append(_asset(asset_id))
+        if page == 2:
+            tpdb.globals.cancel_scrape = True    # user presses Stop partway through
+        return True
+
+    monkeypatch.setattr(scraper, "scrape_user_page", fake)
+    try:
+        new_rows, seen_ids, clean = scraper._crawl_user_pages(index, "someone", full=True)
+    finally:
+        tpdb.globals.cancel_scrape = False
+
+    assert pages_fetched == [0, 1, 2]            # it stops rather than crawling all ten
+    assert clean is False                        # and blocks reconcile, or the seven unreached
+                                                 # pages of assets would all be tombstoned
+
+
 # --- reconcile guard: never tombstone from a crawl that was cut short --------------------------
 
 def _seed(tmp_path, n):


### PR DESCRIPTION
`_crawl_user_pages` has no cancel check, so pressing Stop during a cached user crawl does nothing until the crawl finishes on its own. That is the crawl that takes longest, which makes it the one people reach for Stop during. The uncached `scrape()` loop already breaks on the same flag.

Adding the check needs a little care, which is why this is its own PR rather than a line in another one.

The `if clean:` block in `_scrape_user_cached` gates both `reconcile()` and `record_crawl()`. A bare `break` would leave `clean` True, so reconcile would then tombstone every asset the crawl never reached. A Stop at 92 percent through a three thousand asset user would permanently tombstone about 240 of them. The next scheduled run would then apply fewer posters, with nothing in the log to say why. Setting `clean = False` alongside the break is the whole fix.

The test drives a cancel on the third page of ten and asserts both halves: that the crawl stops, and that it reports unclean. On main it fails by crawling all ten pages.

One unrelated test is red on this branch: `test_stop_scrape.py::test_single_url_cancel_emits_stopped_status`. It fails on main as well, and #75 fixes it. Nothing here touches it.
