### PR TITLE
Remove the replaced artwork's label only after the new upload succeeds

### DIFF
--- a/plex/plex_uploader.py
+++ b/plex/plex_uploader.py
@@ -61,7 +61,6 @@ class PlexUploader:
 
                 if self.confirm_match is not None and not self.confirm_match():
                     return f'⚠️ {self.description} | {self.artwork_type} skipped in {self.upload_target.librarySectionTitle} - artwork is for a different title'
-                self.remove_stale_labels()
                 self.process_overlay_label()
 
                 if self.artwork_id == ArtworkIDPrefix.BACKGROUND.value:
@@ -87,6 +86,10 @@ class PlexUploader:
                         self.upload_target.uploadPoster(url = self.artwork["url"])
                     if self.track_artwork_ids:
                         self.upload_target.addLabel(self.label)
+                # Remove the labels for the artwork we just replaced only AFTER the new one is on
+                # the item, so a failed upload leaves the old label in place and the item stays
+                # recognisable as ours, rather than looking like artwork set by hand
+                self.remove_stale_labels()
                 if self.artwork["source"] == ScraperSource.THEPOSTERDB.value and self.type == "url":
                     time.sleep(TPDB_RATE_LIMIT_DELAY)
                 return f'{"♻️" if self.options.force else "✅"} {self.description} | {self.artwork_type} {"forced update" if self.options.force else "updated"} in {self.upload_target.librarySectionTitle}'
@@ -108,7 +111,7 @@ class PlexUploader:
                         self.upload_target.removeLabel(existing_label, False)  # Remove the existing label as we're no longer tracking the artwork IDs
                         self.upload_target.reload()
                 else:
-                    self.stale_labels.append(existing_label)  # Defer removal until we're about to replace the artwork (see remove_stale_labels)
+                    self.stale_labels.append(existing_label)  # Defer removal until the replacement is on the item (see remove_stale_labels)
 
         return existing_artwork
 
@@ -121,8 +124,8 @@ class PlexUploader:
         return False
 
     def remove_stale_labels(self) -> None:
-        # Remove same-type labels for artwork we're replacing, just before the upload, so a
-        # declined confirmation or a failed upload doesn't leave the item without its label
+        # Remove same-type labels for artwork we've now replaced. Called after the new artwork and
+        # its label are on the item, so a failed upload never strips the old label.
         for existing_label in self.stale_labels:
             self.upload_target.removeLabel(existing_label, False)
             self.upload_target.reload()

--- a/tests/test_plex_uploader_label_safety.py
+++ b/tests/test_plex_uploader_label_safety.py
@@ -1,0 +1,109 @@
+"""Tests that a failed upload never strips the label of the artwork it was replacing.
+
+The artwork-ID label is how the uploader recognises artwork it applied itself. If the old label is
+removed and the replacement upload then fails, the item is left locked with no label at all, which
+every later run reads as artwork the user set by hand and leaves alone forever.
+"""
+
+import pytest
+
+from models.options import Options
+from plex.plex_uploader import PlexUploader
+from utils import utils
+
+ASSETS = "https://theposterdb.com/api/assets"
+
+
+@pytest.fixture(autouse=True)
+def _no_rate_limit_sleep(monkeypatch):
+    # upload_to_plex sleeps TPDB_RATE_LIMIT_DELAY after a real upload; skip it in tests.
+    monkeypatch.setattr("plex.plex_uploader.time.sleep", lambda *a: None)
+
+
+def _url(asset_id):
+    return f"{ASSETS}/{asset_id}"
+
+
+def _label(prefix, asset_id):
+    return prefix + utils.calculate_md5(_url(asset_id))
+
+
+class _Field:
+    def __init__(self, name, locked):
+        self.name = name
+        self.locked = locked
+
+
+class _Target:
+    """Minimal stand-in for a plexapi Movie."""
+
+    def __init__(self, labels=(), locked=False, rating_key=1):
+        self.labels = list(labels)
+        self.fields = [_Field("thumb", locked)]
+        self.librarySectionTitle = "Movies"
+        self.ratingKey = rating_key
+        self.uploaded = []
+        self.fail_upload = False
+
+    def uploadPoster(self, url=None, filepath=None):
+        if self.fail_upload:
+            raise RuntimeError("Plex upload failed")
+        self.uploaded.append(url or filepath)
+
+    def addLabel(self, label):
+        self.labels.append(str(label))
+
+    def removeLabel(self, label, *args):
+        self.labels = [existing for existing in self.labels if str(existing) != str(label)]
+
+    def reload(self):
+        pass
+
+
+def _uploader(target, candidate_id, *, confirm_match=None):
+    uploader = PlexUploader(target, "Poster", "PID:")
+    uploader.set_options(Options())
+    uploader.set_artwork({"id": candidate_id, "url": _url(candidate_id), "source": "theposterdb"})
+    uploader.set_description("The Dark Knight")
+    uploader.track_artwork_ids = True
+    uploader.confirm_match = confirm_match
+    return uploader
+
+
+def test_failed_upload_keeps_the_existing_label():
+    # The item carries the label of the poster we applied last time. The replacement upload throws,
+    # so the old label must survive: next run has to still recognise the item as ours.
+    old = _label("PID:", 666275)
+    target = _Target(labels=[old])
+    target.fail_upload = True
+
+    result = _uploader(target, 670744).upload_to_plex()
+
+    assert result.startswith("❌")
+    assert old in target.labels
+    assert target.uploaded == []
+
+
+def test_successful_upload_swaps_the_label():
+    old = _label("PID:", 666275)
+    target = _Target(labels=[old])
+
+    result = _uploader(target, 670744).upload_to_plex()
+
+    assert result.startswith("✅")
+    assert target.uploaded == [_url(670744)]
+    assert old not in target.labels
+    assert _label("PID:", 670744) in target.labels
+
+
+def test_declined_match_keeps_the_existing_label():
+    # A local title match that the poster page then contradicts declines the upload. Nothing was
+    # replaced, so the old label must stay.
+    old = _label("PID:", 666275)
+    target = _Target(labels=[old])
+
+    result = _uploader(target, 670744, confirm_match=lambda: False).upload_to_plex()
+
+    assert result.startswith("⚠️")
+    assert old in target.labels
+    assert target.uploaded == []


### PR DESCRIPTION

`remove_stale_labels()` runs before the upload. An upload that throws part way through therefore
leaves the item with its field locked and no artwork ID label at all. Every later run reads a locked
field with no label as artwork the user set by hand, and skips it. One failed upload freezes that
item permanently, and nothing in the logs says so.

I introduced this in #56 when I moved the label removal out of `artwork_exists_on_plex()`. The
deferral itself was right and it stopped a declined match from stripping a label. But it still runs
before the upload rather than after, and the comment I left claims a protection the code does not
give.

Moving the call to after `addLabel()` closes it. A failed upload leaves the old label in place, so
the next run still recognises the item. A successful upload ends with only the new label, exactly as
before.

Adds `tests/test_plex_uploader_label_safety.py`, three cases:

- a failed upload keeps the existing label. **This one fails on `main` today.**
- a successful upload swaps the label
- a declined match keeps the existing label

The last two pass on `main` already and are there to hold the behaviour still.

Full suite green on this branch, apart from one pre-existing failure on `main` that #75 fixes.
