### PR TITLE
Report how many assets were skipped as locked in the run summary

### DIFF
--- a/artwork_uploader.py
+++ b/artwork_uploader.py
@@ -266,6 +266,7 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
     success_counter = [0]
     assets_processed = [0]
     cached_counter = [0]
+    locked_counter = [0]
     errors = 0
 
     try:
@@ -297,7 +298,7 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
                 break
 
             try:
-                scrape_and_upload(instance, parsed_line.url, parsed_line.options, True, success_counter, assets_processed, cached_counter=cached_counter)
+                scrape_and_upload(instance, parsed_line.url, parsed_line.options, True, success_counter, assets_processed, cached_counter=cached_counter, locked_counter=locked_counter)
                 #time.sleep(1)
             except ScraperException as e:
                 update_log(instance, f"❌ Error processing line: '{parsed_line.url}'")
@@ -325,6 +326,7 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
                 + f"{assets_processed[0]} asset(s) processed • "
                 + (f"{cached_counter[0]} new in cache • " if cached_counter[0] else "")
                 + f"{success_counter[0]} asset(s) updated"
+                + (f" • {locked_counter[0]} asset(s) locked (skipped)" if locked_counter[0] else "")
             )
             update_status(instance, message[2:], color=StatusColor.WARNING.value, sticky=False, spinner=False)
             notify_web(instance, "progress_bar", {"percent": 100, "bar_type": "bulk"})
@@ -337,6 +339,7 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
                 + f"{assets_processed[0]} asset(s) processed • "
                 + (f"{cached_counter[0]} new in cache • " if cached_counter[0] else "")
                 + f"{success_counter[0]} asset(s) updated"
+                + (f" • {locked_counter[0]} asset(s) locked (skipped)" if locked_counter[0] else "")
             )
             update_status(instance, message[2:], color=StatusColor.SUCCESS.value if errors == 0 else StatusColor.WARNING.value, sticky=False, spinner=False)
         update_log(instance, message)
@@ -357,7 +360,7 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
             globals.scrape_type = "stopped"
 
 # Scraped the URL then uploads what it's scraped to Plex or download to Kometa asset directory
-def scrape_and_upload(instance: Instance, url, options, bulk=False, success_counter=None, assets_processed=None, cached_counter=None):
+def scrape_and_upload(instance: Instance, url, options, bulk=False, success_counter=None, assets_processed=None, cached_counter=None, locked_counter=None):
     """
     Scrape artwork from a URL and upload to Plex.
 
@@ -396,7 +399,8 @@ def scrape_and_upload(instance: Instance, url, options, bulk=False, success_coun
         on_progress_update=progress_callback,
         success_counter=success_counter,
         assets_processed=assets_processed,
-        cached_counter=cached_counter
+        cached_counter=cached_counter,
+        locked_counter=locked_counter
     )
 
     # Use the service to do the actual work

--- a/models/callbacks.py
+++ b/models/callbacks.py
@@ -16,6 +16,7 @@ class ProcessingCallbacks:
     success_counter: Optional[list] = None  # Mutable list to track successful uploads (contains count as single element)
     assets_processed: Optional[list] = None  # Mutable list to track total assets processed (contains count as single element)
     cached_counter: Optional[list] = None  # Mutable list to track assets newly added to the user cache (contains count as single element)
+    locked_counter: Optional[list] = None  # Mutable list to track artwork skipped because the Plex field was locked (contains count as single element)
 
     def status(self, message: str, color: str = "info", spinner: bool = False, sticky: bool = False):
         if self.on_status_update:
@@ -44,3 +45,7 @@ class ProcessingCallbacks:
     def cached(self, count: int):
         if self.cached_counter:
             self.cached_counter[0] += count
+
+    def locked(self, count: int):
+        if self.locked_counter:
+            self.locked_counter[0] += count

--- a/services/artwork_processor.py
+++ b/services/artwork_processor.py
@@ -158,6 +158,10 @@ class ArtworkProcessor:
                 if result.startswith('✅') or result.startswith('♻️'):
                     self.callbacks.success(1)
 
+            # Track artwork left alone because its Plex field was locked
+                elif result.startswith('🔒'):
+                    self.callbacks.locked(1)
+
             # Log the result
                 self.callbacks.log(result)
 

--- a/tests/test_run_counters.py
+++ b/tests/test_run_counters.py
@@ -1,0 +1,32 @@
+"""Unit tests for the bulk-import run-summary counters."""
+
+from models.callbacks import ProcessingCallbacks
+from services.artwork_processor import ArtworkProcessor
+
+
+def test_locked_counter_increments():
+    locked = [0]
+    callbacks = ProcessingCallbacks(locked_counter=locked)
+    callbacks.locked(1)
+    callbacks.locked(2)
+    assert locked[0] == 3
+
+
+def test_locked_is_a_no_op_without_a_counter():
+    ProcessingCallbacks().locked(1)   # must not raise
+
+
+def test_locked_results_are_counted_and_successes_still_are():
+    locked, success = [0], [0]
+    callbacks = ProcessingCallbacks(locked_counter=locked, success_counter=success)
+    processor = ArtworkProcessor(plex=None, callbacks=callbacks)
+
+    processor._process_single_artwork({}, lambda artwork: [
+        "✅ A Movie | Poster updated in Movies",
+        "🔒 B Movie | Poster locked, skipped in Movies",
+        "🔒 C Movie | Poster locked, skipped in Movies",
+        "⏩ D Movie | Poster unchanged in Movies",
+    ])
+
+    assert locked[0] == 2
+    assert success[0] == 1


### PR DESCRIPTION

With `skip_locked_artwork` on, a scheduled bulk import over a library that is already fully covered
reports `0 asset(s) updated` every night. A run that failed to do anything at all produces the same
line. There is no way to tell a healthy no-op from a broken one without reading the whole log.

This counts the artwork left alone because its Plex field was locked, and adds it to the completion
summary and the notification:

```
33753 asset(s) processed - 18 new in cache - 23 asset(s) updated - 1409 asset(s) locked (skipped)
```

The clause only appears when the count is non-zero, so nothing changes for anyone running with
`skip_locked_artwork` off.

Implementation follows the existing counters: `locked_counter` and a `locked()` method on
`ProcessingCallbacks`, incremented where `_process_single_artwork` already inspects the result
string.

Adds `tests/test_run_counters.py`, three cases. Full suite green apart from the one pre-existing
`main` failure that #75 fixes.
