### PR TITLE
Add allow_artist_updates, so an artist's newer poster can replace their older one

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ It's there for when we have API access (and works for scrapers in the meantime) 
 
 If you enable ```skip_locked_artwork```, a scheduled user or bulk scrape will only fill items that are still on their default artwork and leave anything you've set by hand untouched, so it's safe to leave running against a curated library.
 
+If you also enable ```allow_artist_updates```, a scheduled scrape may additionally replace artwork it applied earlier when the same artist has posted a newer version of it. It still never touches artwork you set by hand (anything without one of this tool's artwork-ID labels) or artwork from a different artist, and it only ever moves forward to a newer upload, so runs settle on each artist's latest rather than flip-flopping. It needs both ```skip_locked_artwork``` and ```track_artwork_ids``` on. Because this writes over artwork the tool previously chose, take a note of your current posters before the first run if you want to be able to revert.
+
 With ```local_library_matching``` enabled (the default), a user-catalog scrape skips everything that isn't in your libraries without any web requests, so full-catalog runs take minutes rather than hours.
 
 Additionally, you can configure one or more push notification services so you get a notification every time a scheduled bulk import job completes. Notifications are provided by Apprise. Configure the list of notification services by providing a comma-separated list of Apprise notification URLs through the web UI or via the ```apprise_urls``` variable in the ```config.json```file. Check [the Apprise service list](https://appriseit.com/services/) for details on the supported services and how to set them up and generate a notification URL for your favorite services.
@@ -234,6 +236,12 @@ This is optional - if you don't do this, a new config.json will be created when 
 ```"skip_locked_artwork"```
 - Setting this to ```true``` will skip any artwork whose target field (poster, background or square art) is locked in Plex, unless ```--force``` is used.  Plex locks a field whenever artwork is deliberately set - manually or by an upload - so this makes scheduled bulk imports and user scrapes fill items still on default artwork while leaving anything you've already set alone.
 - Setting to ```false``` (the default) keeps the existing behaviour where artwork is applied regardless of locks.
+
+```"allow_artist_updates"```
+- Setting this to ```true``` lets a run replace artwork it applied earlier when the same artist has posted a newer version, even though the field is locked.  Artwork you set by hand (anything without one of this tool's artwork-ID labels) and artwork from a different artist are still left alone, and it only moves forward to a newer upload.
+- Requires ```skip_locked_artwork``` and ```track_artwork_ids``` to both be ```true```.  Has no effect otherwise.
+- Setting to ```false``` (the default) keeps the existing behaviour where a locked field is never updated by a scrape.
+
 ```"cache_user_scrapes"```
 - Setting this to ```true``` keeps a local index of each ThePosterDB user's uploads (a small SQLite file in your config directory), so scraping a user page again only fetches pages until it reaches uploads it has already seen - full-catalogue re-runs drop from hundreds of page requests to a couple, which is also much kinder to ThePosterDB.  Every ```user_cache_refresh_days``` days the next scrape of that user re-crawls every page to pick up edited or deleted uploads.
 - Setting to ```false``` (the default) crawls every page on every user scrape, exactly as before.
@@ -371,6 +379,8 @@ The script supports various command-line arguments for flexible use.
 ```--force``` will force the artwork to be updated even if it's the same as the one on plex already - or maybe you changed the artwork manually and want to override it...
     
 ```--skip-locked``` will skip any artwork whose target field is locked in Plex (i.e. it's been deliberately set, manually or by a previous upload), unless ```--force``` is also used.  This is the same as setting ```skip_locked_artwork``` to ```true``` in ```config.json```, but per URL.
+
+```--allow-artist-updates``` lets a run replace artwork it applied earlier when the same artist has posted a newer version, while still leaving hand-set artwork and other artists' artwork alone.  This is the same as setting ```allow_artist_updates``` to ```true``` in ```config.json```, but per URL.  It needs ```--skip-locked``` (or ```skip_locked_artwork```) and ```track_artwork_ids``` to take effect.
     
 ```--exclude <id1> [<id2> <id3> ...]``` will exclude the poster or artwork with the specified ID from being uploaded.  Grab the ID from the session log...
 - ThePosterDB is a number

--- a/artwork_uploader.py
+++ b/artwork_uploader.py
@@ -710,6 +710,7 @@ if __name__ == "__main__":
                           add_sets=args.add_sets,
                           force=args.force,
                           skip_locked=args.skip_locked,
+                          allow_artist_updates=args.allow_artist_updates,
                           filters=args.filters,
                           exclude=args.exclude,
                           year=args.year,

--- a/core/config.py
+++ b/core/config.py
@@ -30,6 +30,7 @@ class Config:
         track_artwork_ids: Whether to track artwork IDs using Plex labels
         skip_locked_artwork: Whether to skip artwork whose target field is locked in Plex (already set)
         local_library_matching: Whether to match scraped artwork against the local libraries before fetching poster pages
+        allow_artist_updates: Whether to update locked artwork we applied when the same artist has posted a newer version (requires skip_locked_artwork and track_artwork_ids)
         cache_user_scrapes: Whether to keep a persistent index of ThePosterDB users' uploads so repeat scrapes only fetch new ones
         user_cache_refresh_days: Days between full re-crawls of a cached user's uploads (catches edits and deletions)
         auto_manage_bulk_files: Whether to auto-organize bulk files
@@ -57,6 +58,7 @@ class Config:
         self.track_artwork_ids: bool = True
         self.skip_locked_artwork: bool = False
         self.local_library_matching: bool = True
+        self.allow_artist_updates: bool = False
         self.cache_user_scrapes: bool = False
         self.user_cache_refresh_days: int = 7
         self.auto_manage_bulk_files: bool = True
@@ -98,6 +100,7 @@ class Config:
             self.track_artwork_ids = config.get("track_artwork_ids", True)
             self.skip_locked_artwork = config.get("skip_locked_artwork", False)
             self.local_library_matching = config.get("local_library_matching", True)
+            self.allow_artist_updates = config.get("allow_artist_updates", False)
             self.cache_user_scrapes = config.get("cache_user_scrapes", False)
             self.user_cache_refresh_days = config.get("user_cache_refresh_days", 7)
             self.auto_manage_bulk_files = config.get("auto_manage_bulk_files", True)
@@ -128,6 +131,7 @@ class Config:
             "track_artwork_ids": True,
             "skip_locked_artwork": False,
             "local_library_matching": True,
+            "allow_artist_updates": False,
             "cache_user_scrapes": False,
             "user_cache_refresh_days": 7,
             "auto_manage_bulk_files": True,
@@ -172,6 +176,7 @@ class Config:
             "track_artwork_ids": self.track_artwork_ids,
             "skip_locked_artwork": self.skip_locked_artwork,
             "local_library_matching": self.local_library_matching,
+            "allow_artist_updates": self.allow_artist_updates,
             "cache_user_scrapes": self.cache_user_scrapes,
             "user_cache_refresh_days": self.user_cache_refresh_days,
             "auto_manage_bulk_files": self.auto_manage_bulk_files,

--- a/models/arguments.py
+++ b/models/arguments.py
@@ -8,6 +8,7 @@ import argparse
 # --add-posters     Adds the "additional posters" section from TPDb page as well as the main posters
 # --force           Forces each poster to upload even, if the same artwork is already there according to the label.
 # --skip-locked     Skips artwork when its target field is locked in Plex (i.e. the artwork has been deliberately set), unless --force is used.
+# --allow-artist-updates   Update locked artwork we applied when the same artist has posted a newer version. Requires --skip-locked (or skip_locked_artwork) and track_artwork_ids.
 # --filters         Specify one or more filters, only these types will be applied (e.g., title_card, background, square_art, season_cover, show_cover, movie_poster, collection_poster)
 # --exclude         Specify one or more IDs to exclude from any uploads
 # --year            Override the year for matching (use the year in Plex)
@@ -29,6 +30,7 @@ def parse_arguments():
     parser.add_argument('--add-posters', action='store_true', help="Scrape additional posters from same page - TPDb only")
     parser.add_argument('--force', action='store_true', help="Force upload/save even if its the same artwork or artwork already exists")
     parser.add_argument('--skip-locked', action='store_true', help="Skip artwork when its target field is locked in Plex (already set), unless --force is used")
+    parser.add_argument('--allow-artist-updates', action='store_true', help="Update locked artwork we applied when the same artist has posted a newer version (requires --skip-locked and track_artwork_ids)")
     parser.add_argument("--filters", nargs='+', help="Only these artwork types will be applied (e.g., title_card, background, square_art, season_cover, show_cover, movie_poster, collection_poster).")
     parser.add_argument("--exclude", nargs='+', help="Specify one or more IDs to exclude from any uploads.")
     parser.add_argument("--year", type=int, help="Override the year for matching (use the year in Plex)")

--- a/models/options.py
+++ b/models/options.py
@@ -21,6 +21,7 @@ class Options:
         temp: Use temporary directory instead of Kometa asset directory
         force: Force re-upload even if artwork hasn't changed
         skip_locked: Skip artwork when the target Plex field is locked (already set)
+        allow_artist_updates: Update locked artwork we applied when the same artist has posted a newer version
         no_cache: Ignore the cached user uploads index for this run and crawl every page
         filters: List of artwork types to include (e.g., ['show_cover', 'title_card'])
         exclude: List of artwork IDs to skip
@@ -35,6 +36,7 @@ class Options:
     temp: bool = False
     force: bool = False
     skip_locked: bool = False
+    allow_artist_updates: bool = False
     no_cache: bool = False
     filters: List[str] = field(default_factory=list)
     exclude: Optional[List[str]] = None

--- a/plex/plex_uploader.py
+++ b/plex/plex_uploader.py
@@ -27,6 +27,8 @@ class PlexUploader:
         self.track_artwork_ids: bool = True
         self.reset_overlay: bool = False
         self.skip_locked: bool = False
+        self.allow_artist_updates: bool = False
+        self.artist_assets: Optional[dict] = None  # {md5(asset url): asset id} for the artist being processed
         self.confirm_match = None
         self.stale_labels: list = []
 
@@ -56,7 +58,12 @@ class PlexUploader:
     def upload_to_plex(self) -> str:
         try:
             if self.skip_locked and not self.options.force and self.artwork_field_is_locked():
-                return f'🔒 {self.description} | {self.artwork_type} locked, skipped in {self.upload_target.librarySectionTitle}'
+                # A locked field is normally left alone. But if we applied its current artwork
+                # from this same artist and the artist has since posted a newer version,
+                # allow_artist_updates lets that one update flow through - a hand-set custom (no
+                # matching label) or another artist's poster is still protected.
+                if not (self.allow_artist_updates and self.candidate_supersedes_current()):
+                    return f'🔒 {self.description} | {self.artwork_type} locked, skipped in {self.upload_target.librarySectionTitle}'
             if self.artwork_exists_on_plex() is False or self.options.force:
 
                 if self.confirm_match is not None and not self.confirm_match():
@@ -131,3 +138,23 @@ class PlexUploader:
             self.upload_target.reload()
         self.stale_labels = []
 
+    def current_artwork_id(self) -> Optional[int]:
+        """The asset id of the artwork currently on this item of our type, if we applied it from
+           the artist being processed. None if it was set by hand or by a different artist."""
+        if not self.artist_assets:
+            return None
+        for label in self.upload_target.labels:
+            existing_label = str(label)
+            if existing_label.startswith(self.artwork_id):
+                return self.artist_assets.get(existing_label[len(self.artwork_id):])
+        return None
+
+    def candidate_supersedes_current(self) -> bool:
+        """True when the artwork we're about to apply is a same-or-newer asset from the same
+           artist that applied the current artwork. Only ever moves forward to a newer asset id,
+           so the nightly run converges on the artist's latest instead of flip-flopping."""
+        candidate = self.artwork.get("id") if self.artwork else None
+        if not (isinstance(candidate, (int, str)) and str(candidate).isdigit()):
+            return False  # file uploads and non-numeric ids can't be compared by asset id
+        current_id = self.current_artwork_id()
+        return current_id is not None and int(candidate) >= current_id

--- a/processors/upload_processor.py
+++ b/processors/upload_processor.py
@@ -25,12 +25,18 @@ class UploadProcessor:
         self.config: Config = Config()
         self.config.load()
         self._match_confirm_cache: dict = {}
+        self.artist_assets: Optional[dict] = None  # {md5(asset url): asset id} for the artist being processed
 
 
     def set_options(self, options: Options) -> None:
         self.options = options
         self.kometa: bool = self.options.kometa or globals.config.save_to_kometa
         self.skip_locked: bool = self.options.skip_locked or globals.config.skip_locked_artwork
+        self.allow_artist_updates: bool = self.options.allow_artist_updates or globals.config.allow_artist_updates
+        if self.allow_artist_updates and not self.config.track_artwork_ids:
+            debug_me("allow_artist_updates has no effect while track_artwork_ids is off - without "
+                     "artwork IDs there's no way to tell artwork we applied from artwork set by "
+                     "hand, so locked items are all left alone.", "UploadProcessor/set_options")
 
     def _resolve_tmdb_id(self, artwork, description: str, kind: Literal[MediaType.TV_SHOW, MediaType.MOVIE]) -> bool:
         """
@@ -148,6 +154,8 @@ class UploadProcessor:
                     uploader.track_artwork_ids = self.config.track_artwork_ids
                     uploader.reset_overlay = self.config.reset_overlay
                     uploader.skip_locked = self.skip_locked
+                    uploader.allow_artist_updates = self.allow_artist_updates
+                    uploader.artist_assets = self.artist_assets
                     uploader.set_description(description)
                     uploader.set_options(self.options)
                     result = uploader.upload_to_plex()
@@ -205,6 +213,8 @@ class UploadProcessor:
                     uploader.track_artwork_ids = self.config.track_artwork_ids
                     uploader.reset_overlay = self.config.reset_overlay
                     uploader.skip_locked = self.skip_locked
+                    uploader.allow_artist_updates = self.allow_artist_updates
+                    uploader.artist_assets = self.artist_assets
                     if locally_matched:
                         uploader.confirm_match = lambda a=artwork, item=movie_item: self._artwork_matches_item(a, item, "movie")
                     uploader.set_description(desc)
@@ -341,6 +351,8 @@ class UploadProcessor:
                         uploader.track_artwork_ids = self.config.track_artwork_ids
                         uploader.reset_overlay = self.config.reset_overlay
                         uploader.skip_locked = self.skip_locked
+                        uploader.allow_artist_updates = self.allow_artist_updates
+                        uploader.artist_assets = self.artist_assets
                         if locally_matched:
                             uploader.confirm_match = lambda a=artwork, item=tv_show: self._artwork_matches_item(a, item, "tv")
                         uploader.set_description(desc)

--- a/processors/upload_processor.py
+++ b/processors/upload_processor.py
@@ -8,7 +8,6 @@ from core.constants import ARTWORK_ID_MAP, ARTWORK_TYPE_MAP, ARTWORK_FILENAME_MA
 from models.options import Options
 from plex.plex_connector import PlexConnector
 from plex.plex_uploader import PlexUploader
-from plex.library_index import PlexLibraryIndex
 from plexapi.exceptions import NotFound
 from kometa.kometa_saver import KometaSaver
 from utils import soup_utils

--- a/scrapers/scraper.py
+++ b/scrapers/scraper.py
@@ -35,6 +35,7 @@ class Scraper:
         self.source: Optional[str] = None
         self.title: Optional[str] = None
         self.author: Optional[str] = None
+        self.artist_assets: Optional[dict] = None
         self.skipped: int = 0
         self.exclusions: int = 0
         self.filtered: int = 0
@@ -86,6 +87,7 @@ class Scraper:
 
             self.title = theposterdb_scraper.title
             self.author = theposterdb_scraper.author
+            self.artist_assets = theposterdb_scraper.artist_assets
             self.movie_artwork = theposterdb_scraper.movie_artwork
             self.tv_artwork = theposterdb_scraper.tv_artwork
             self.collection_artwork = theposterdb_scraper.collection_artwork

--- a/scrapers/theposterdb_scraper.py
+++ b/scrapers/theposterdb_scraper.py
@@ -2,6 +2,7 @@ import math, time
 from typing import Optional, Any
 from processors import media_metadata
 from utils import soup_utils
+from utils.utils import calculate_md5
 from models.options import Options
 from models.callbacks import ProcessingCallbacks
 from core.exceptions import ScraperException
@@ -42,6 +43,7 @@ class ThePosterDBScraper:
 
         self.user_uploads: int = 0
         self.user_pages: int = 0
+        self.artist_assets: Optional[dict] = None  # {md5(asset url): asset id} from the cached index, for allow_artist_updates
 
         # When set to a list, get_posters records every parsed asset (pre-filter) into it so a
         # user crawl can populate the persistent index. None (default) disables recording.
@@ -488,6 +490,13 @@ class ThePosterDBScraper:
         if new_rows:
             self.callbacks.cached(new_rows)
             self.callbacks.log(f"🆕 TPDb user • {self.author} | {new_rows} new asset(s) added to the cache")
+
+        # Map md5(url) -> asset id for every asset ever recorded for this user (tombstones
+        # included), so allow_artist_updates can recognise artwork we applied from this artist.
+        self.artist_assets = {
+            calculate_md5(row["url"].split("&_cb=")[0]): row["asset_id"]
+            for row in index.owned_asset_urls(user_key)
+        }
 
         self._hydrate_from_cache(index, user_key)
 

--- a/services/artwork_processor.py
+++ b/services/artwork_processor.py
@@ -73,6 +73,11 @@ class ArtworkProcessor:
         # Process the scraped artwork
         processor = UploadProcessor(self.plex)
         processor.set_options(options)
+        # allow_artist_updates needs to know which posters belong to the artist being processed.
+        # The cached scrape builds that from the index (tombstones included); otherwise derive it
+        # from what this scrape collected.
+        processor.artist_assets = scraper.artist_assets if getattr(scraper, "artist_assets", None) is not None \
+            else self._artist_assets_from_scrape(scraper)
 
         description = f"TBDb portfolio • {scraper.author}" if "/user" in url else f"{scraper.title} • {scraper.author}"
 
@@ -135,6 +140,20 @@ class ArtworkProcessor:
             if not bulk:
                 self.callbacks.status(f"Process completed {f'{title} by {scraper.author}' if title else f"for {scraper.author}'s TPDb portfolio"}", "success")
         return scraper.title, scraper.author
+
+    @staticmethod
+    def _artist_assets_from_scrape(scraper) -> dict:
+        """Fallback ownership map when there's no cached index: md5(url) -> asset id for every
+           poster this scrape collected. Enough to recognise artwork we applied from the same
+           run's artist; an asset the artist has since removed just falls back to protected."""
+        from utils.utils import calculate_md5
+        mapping = {}
+        for artwork in (scraper.movie_artwork + scraper.tv_artwork + scraper.collection_artwork):
+            url = artwork.get("url")
+            asset_id = artwork.get("id")
+            if url and str(asset_id).isdigit():
+                mapping[calculate_md5(url.split("&_cb=")[0])] = int(asset_id)
+        return mapping
 
     def _process_single_artwork(
         self,

--- a/services/asset_index.py
+++ b/services/asset_index.py
@@ -187,6 +187,19 @@ class AssetIndex:
         finally:
             conn.close()
 
+    def owned_asset_urls(self, user_key: str) -> List[sqlite3.Row]:
+        """(asset_id, url) for every asset ever recorded for the user, tombstoned ones included,
+           so artwork we applied stays recognisable as this artist's even after they delete or
+           replace the upload. Used to decide allow_artist_updates ownership."""
+        conn = self._connect()
+        try:
+            return conn.execute(
+                "SELECT asset_id, url FROM user_assets WHERE user_key = ? AND url IS NOT NULL",
+                (user_key,),
+            ).fetchall()
+        finally:
+            conn.close()
+
     def reconcile(self, user_key: str, seen_ids: Set[int], crawl_started_at: str) -> int:
         """After a clean full crawl, tombstone assets that weren't seen (deleted from the
            user's uploads), sparing any row inserted since the crawl began so an overlapping

--- a/static/web_interface.js
+++ b/static/web_interface.js
@@ -779,6 +779,9 @@ function saveConfig() {
     // ThePosterDB user cache expiration threshold
     save_config.user_cache_refresh_days = parseInt(document.getElementById("user_cache_refresh_days").value);
 
+    // Checkbox for taking an artist's newer artwork for posters we applied
+    save_config.allow_artist_updates = document.getElementById("allow_artist_updates").checked;
+
     // Get selected mediux filters
     save_config.mediux_filters = Array.from(document.querySelectorAll('[id^="m_filter-"]:checked'))
         .map(checkbox => checkbox.value);
@@ -882,6 +885,7 @@ function updateConfigUI(config) {
     document.getElementById("local_library_matching").checked = config.local_library_matching;
     document.getElementById("cache_user_scrapes").checked = config.cache_user_scrapes;
     document.getElementById("user_cache_refresh_days").value = config.user_cache_refresh_days;
+    document.getElementById("allow_artist_updates").checked = config.allow_artist_updates;
     document.getElementById("option-add-to-bulk").checked = config.auto_manage_bulk_files;
     document.getElementById("apprise_urls").value = config.apprise_urls.join(", ");
     

--- a/static/web_interface.js
+++ b/static/web_interface.js
@@ -2059,33 +2059,48 @@ function toggleKometaSettings() {
 
 function toggleSkipLockedCheckbox() {
     const saveToKometa = document.getElementById("save_to_kometa").checked;
-    const globalSetting = document.getElementById("skip_locked_artwork").checked;
-    const skipLockedCheckbox = document.getElementById("option-skip-locked");
-    const skipLockedCheckboxUpload = document.getElementById("upload-option-skip-locked");
-
+    const globalSkipLocked = document.getElementById("skip_locked_artwork");
+    const skipLockedScraperOption = document.getElementById("option-skip-locked");
+    const skipLockedUploadOption = document.getElementById("upload-option-skip-locked");
+    const globalAllowArtistUpdates = document.getElementById("allow_artist_updates");
+    const allowArtistUpdatesScrapeOption = document.getElementById("option-allow-artist-updates");
+    const trackArtworkIDs = document.getElementById("track_artwork_ids").checked;
+    
     // Hide and uncheck the skip locked option if Kometa is enabled
     if (saveToKometa) {
-        skipLockedCheckbox.parentElement.style.display = "none";
-        skipLockedCheckbox.checked = false;
-        skipLockedCheckboxUpload.parentElement.style.display = "none";
-        skipLockedCheckboxUpload.checked = false;
+        skipLockedScraperOption.parentElement.style.display = "none";
+        skipLockedScraperOption.checked = false;
+        skipLockedUploadOption.parentElement.style.display = "none";
+        skipLockedUploadOption.checked = false;
+        globalAllowArtistUpdates.parentElement.style.display = "none";
+        globalAllowArtistUpdates.checked = false;
+        allowArtistUpdatesScrapeOption.parentElement.style.display = "none";
+        allowArtistUpdatesScrapeOption.checked = false;
     } else {
-        if (globalSetting) {
-            skipLockedCheckbox.parentElement.style.display = "none";
-            skipLockedCheckbox.checked = true;
-            skipLockedCheckboxUpload.parentElement.style.display = "none";
-            skipLockedCheckboxUpload.checked = true;
+        if (globalSkipLocked.checked) {
+            skipLockedScraperOption.parentElement.style.display = "none";
+            skipLockedScraperOption.checked = true;
+            skipLockedUploadOption.parentElement.style.display = "none";
+            skipLockedUploadOption.checked = true;
+            globalAllowArtistUpdates.parentElement.style.display = trackArtworkIDs ? "block" : "none";
+            allowArtistUpdatesScrapeOption.parentElement.style.display = globalAllowArtistUpdates.checked ? "none" : "block";
         } else {
-            skipLockedCheckbox.parentElement.style.display = "block";
-            skipLockedCheckbox.checked = false;
-            skipLockedCheckboxUpload.parentElement.style.display = "block";
-            skipLockedCheckboxUpload.checked = false;
+            skipLockedScraperOption.parentElement.style.display = "block";
+            skipLockedScraperOption.checked = false;
+            skipLockedUploadOption.parentElement.style.display = "block";
+            skipLockedUploadOption.checked = false;
+            globalAllowArtistUpdates.parentElement.style.display = "none";
+            globalAllowArtistUpdates.checked = false;
+            allowArtistUpdatesScrapeOption.parentElement.style.display = "none";
+            allowArtistUpdatesScrapeOption.checked = false;
         }
     }
 }
 
 // Add event listener for global skip locked artwork checkbox
 document.getElementById("skip_locked_artwork").addEventListener("change", toggleSkipLockedCheckbox);
+document.getElementById("track_artwork_ids").addEventListener("change", toggleSkipLockedCheckbox);
+document.getElementById("allow_artist_updates").addEventListener("change", toggleSkipLockedCheckbox);
 
 function toggleScraperStageCheckbox() {
     const globalStageSetting = document.getElementById("stage_assets").checked;
@@ -2135,6 +2150,7 @@ function togglePlexOptions() {
     const saveToKometa = document.getElementById("save_to_kometa").checked;
     const trackArtworkIDs = document.getElementById("track_artwork_ids").parentElement;
     const skipLocked = document.getElementById("skip_locked_artwork").parentElement;
+    // const allowArtistUpdates = document.getElementById("allow_artist_updates").parentElement;
     const resetOverlay = document.getElementById("reset_overlay").parentElement;
 
     // Ony show the Track Artwork IDs and Reset Overlay options if Kometa is disabled
@@ -2142,10 +2158,12 @@ function togglePlexOptions() {
         trackArtworkIDs.style.display = "block";
         resetOverlay.style.display = "block";
         skipLocked.style.display = "block";
+        // allowArtistUpdates.style.display = "block";
     } else {
         trackArtworkIDs.style.display = "none";
         resetOverlay.style.display = "none";
         skipLocked.style.display = "none";
+        // allowArtistUpdates.style.display = "none";
         document.getElementById("skip_locked_artwork").checked = false; // Uncheck the skip locked option if Kometa is enabled
         document.getElementById("track_artwork_ids").checked = true;
     }

--- a/templates/web_interface.html
+++ b/templates/web_interface.html
@@ -426,6 +426,13 @@
                                                 required />
                                             <span class="text-body">days</span>
                                         </div>                                        
+                                        <div class="form-check form-switch mb-3">
+                                            <input class="form-check-input" type="checkbox" value="allow_artist_updates" id="allow_artist_updates"/>
+                                            <label for="allow_artist_updates" class="form-check-label">Allow artist updates</label>
+                                            <i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="Lets a run replace artwork it applied earlier when the same artist has posted a newer
+                                            version of it. Artwork you set by hand and artwork from a different artist are left alone, and it only ever moves forward to a newer upload. Needs
+                                            skip locked artwork and track artwork IDs to be on."></i>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
@@ -583,6 +590,11 @@
                                     <input class="form-check-input" type="checkbox" value="--skip-locked" id="option-skip-locked"/>
                                     <label for="option-skip-locked" class="form-check-label">Skip locked artwork</label>
                                     <i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="Skips artwork that is locked in Plex, so scheduled runs only update default artwork"></i>
+                                </div>
+                                <div class="form-check form-switch mb-2">
+                                    <input class="form-check-input" type="checkbox" value="--allow-artist-updates" id="option-allow-artist-updates"/>
+                                    <label for="option-allow-artist-updates" class="form-check-label">Allow artist updates</label>
+                                    <i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="Replaces artwork an earlier run applied when the same artist has posted a newer version, leaving hand-set artwork alone. Needs skip locked artwork"></i>
                                 </div>
                                 <div class="form-check form-switch mb-2">
                                     <input class="form-check-input" type="checkbox" value="--stage" id="option-stage"/>

--- a/templates/web_interface.html
+++ b/templates/web_interface.html
@@ -403,9 +403,9 @@
                                         <div class="form-check form-switch mb-3">
                                             <input class="form-check-input" type="checkbox" value="allow_artist_updates" id="allow_artist_updates"/>
                                             <label for="allow_artist_updates" class="form-check-label">Allow artist updates</label>
-                                            <i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="Lets a run replace artwork it applied earlier when the same artist has posted a newer
+                                            <i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="ThePosterDB only: Lets a run replace artwork it applied earlier when the same artist has posted a newer
                                             version of it. Artwork you set by hand and artwork from a different artist are left alone, and it only ever moves forward to a newer upload. Needs
-                                            skip locked artwork and track artwork IDs enabled."></i>
+                                            skip locked artwork and track artwork IDs enabled. (NOTE: Does not apply to uploaded ZIP files.)"></i>
                                         </div>
                                         <div class="form-check form-switch mb-3">
                                             <input class="form-check-input" type="checkbox" value="local_library_matching" id="local_library_matching"/>
@@ -421,7 +421,7 @@
                                             page scrapes so that periodic scrapes of large user portfolios are much faster"></i>
                                         </div>
                                         <div id="cache_expiry_container" class="mt-2 mb-3 d-flex align-items-center" style="display: d-none;">
-                                            <label for="user_cache_refresh_days" class="form-label me-2 mb-0">Refresh user cache every</label>
+                                            <label for="user_cache_refresh_days" class="form-label me-2 mb-0"><i class="bi bi-recycle""></i>&ensp; Refresh user cache every</label>
                                             <input type="number" 
                                                 class="form-control form-control-sm text-center d-inline-block me-2" 
                                                 id="user_cache_refresh_days" 

--- a/templates/web_interface.html
+++ b/templates/web_interface.html
@@ -386,19 +386,26 @@
                                 <div class="col">
                                     <div class="p-3 border rounded-3 shadow-sm">
                                         <h5 class="mb-3"><i class="bi bi-sliders"></i>&ensp;Additional settings</h5>
+                                        <div class="form-check form-switch mb-3">
+                                            <input class="form-check-input" type="checkbox" value="auto_manage" id="auto_manage_bulk_files"/>
+                                            <label for="auto_manage_bulk_files" class="form-check-label">Sort and label bulk files automatically</label>
+                                        </div>
                                         <div class="form-check form-switch mb-3" style="display: none;">
                                             <input class="form-check-input" type="checkbox" value="--force" id="track_artwork_ids"/>
                                             <label for="track_artwork_ids" class="form-check-label">Track artwork ID in Plex labels</label>
                                             <i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="(Recommended) Tracks artwork IDs through Plex labels, avoiding having to download assets that have already been downloaded and set"></i>
                                         </div>
                                         <div class="form-check form-switch mb-3">
-                                            <input class="form-check-input" type="checkbox" value="auto_manage" id="auto_manage_bulk_files"/>
-                                            <label for="auto_manage_bulk_files" class="form-check-label">Sort and label bulk files automatically</label>
-                                        </div>
-                                        <div class="form-check form-switch mb-3">
                                             <input class="form-check-input" type="checkbox" value="skip_locked_artwork" id="skip_locked_artwork"/>
                                             <label for="skip_locked_artwork" class="form-check-label">Skip locked artwork</label>
                                             <i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="Skips artwork that is locked in Plex, so scheduled runs only update default artwork"></i>
+                                        </div>
+                                        <div class="form-check form-switch mb-3">
+                                            <input class="form-check-input" type="checkbox" value="allow_artist_updates" id="allow_artist_updates"/>
+                                            <label for="allow_artist_updates" class="form-check-label">Allow artist updates</label>
+                                            <i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="Lets a run replace artwork it applied earlier when the same artist has posted a newer
+                                            version of it. Artwork you set by hand and artwork from a different artist are left alone, and it only ever moves forward to a newer upload. Needs
+                                            skip locked artwork and track artwork IDs enabled."></i>
                                         </div>
                                         <div class="form-check form-switch mb-3">
                                             <input class="form-check-input" type="checkbox" value="local_library_matching" id="local_library_matching"/>
@@ -426,13 +433,6 @@
                                                 required />
                                             <span class="text-body">days</span>
                                         </div>                                        
-                                        <div class="form-check form-switch mb-3">
-                                            <input class="form-check-input" type="checkbox" value="allow_artist_updates" id="allow_artist_updates"/>
-                                            <label for="allow_artist_updates" class="form-check-label">Allow artist updates</label>
-                                            <i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="Lets a run replace artwork it applied earlier when the same artist has posted a newer
-                                            version of it. Artwork you set by hand and artwork from a different artist are left alone, and it only ever moves forward to a newer upload. Needs
-                                            skip locked artwork and track artwork IDs to be on."></i>
-                                        </div>
                                     </div>
                                 </div>
                             </div>

--- a/tests/test_artist_assets_plumbing.py
+++ b/tests/test_artist_assets_plumbing.py
@@ -1,0 +1,71 @@
+"""The ownership map (artist_assets) must reach the uploader the way production builds it: the
+ThePosterDBScraper builds it, the Scraper wrapper carries it, and ArtworkProcessor prefers it
+over the collected-artwork fallback. These guard against the map being silently dropped."""
+
+import os
+
+import pytest
+
+from models.callbacks import ProcessingCallbacks
+from models.options import Options
+from services.artwork_processor import ArtworkProcessor
+from utils.utils import calculate_md5
+
+ASSETS = "https://theposterdb.com/api/assets"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cwd(tmp_path, monkeypatch):
+    os.makedirs(tmp_path / "config", exist_ok=True)
+    monkeypatch.chdir(tmp_path)
+
+
+def test_scraper_wrapper_carries_artist_assets_from_theposterdb(monkeypatch):
+    import scrapers.scraper as scraper_module
+    from scrapers.scraper import Scraper
+
+    class _FakeTPDB:
+        def __init__(self, url, callbacks):
+            self.title = self.author = None
+            self.artist_assets = {"abc": 123}
+            self.movie_artwork = self.tv_artwork = self.collection_artwork = []
+            self.skipped = self.exclusions = self.filtered = self.errored = self.total = 0
+
+        def set_options(self, options):
+            pass
+
+        def scrape(self):
+            self.author = "someone"
+
+    monkeypatch.setattr(scraper_module, "ThePosterDBScraper", _FakeTPDB)
+
+    wrapper = Scraper("https://theposterdb.com/user/someone", ProcessingCallbacks())
+    wrapper.source = "theposterdb"
+    wrapper.set_options(Options())
+    wrapper.scrape()
+
+    assert wrapper.artist_assets == {"abc": 123}   # not dropped by the wrapper
+
+
+def test_processor_prefers_the_scrapers_map_over_the_fallback():
+    class _Scraper:
+        artist_assets = {"from": "index"}
+        movie_artwork = tv_artwork = collection_artwork = []
+
+    chosen = _Scraper().artist_assets if getattr(_Scraper, "artist_assets", None) is not None \
+        else ArtworkProcessor._artist_assets_from_scrape(_Scraper())
+    assert chosen == {"from": "index"}
+
+
+def test_fallback_map_is_built_from_collected_artwork():
+    class _Scraper:
+        artist_assets = None
+        movie_artwork = [{"id": 100, "url": f"{ASSETS}/100&_cb=9"}]
+        tv_artwork = [{"id": 200, "url": f"{ASSETS}/200"}]
+        collection_artwork = [{"id": "notanumber", "url": f"{ASSETS}/x"}]
+
+    mapping = ArtworkProcessor._artist_assets_from_scrape(_Scraper())
+
+    assert mapping[calculate_md5(f"{ASSETS}/100")] == 100   # cache buster stripped before md5
+    assert mapping[calculate_md5(f"{ASSETS}/200")] == 200
+    assert len(mapping) == 2                                 # the non-numeric id is skipped

--- a/tests/test_plex_uploader_artist_updates.py
+++ b/tests/test_plex_uploader_artist_updates.py
@@ -1,0 +1,132 @@
+"""Tests for allow_artist_updates: taking an artist's newer poster for artwork the uploader
+applied itself, while leaving hand-set customs and other artists' artwork alone."""
+
+import pytest
+
+from models.options import Options
+from plex.plex_uploader import PlexUploader
+from utils import utils
+
+ASSETS = "https://theposterdb.com/api/assets"
+
+
+@pytest.fixture(autouse=True)
+def _no_rate_limit_sleep(monkeypatch):
+    # upload_to_plex sleeps TPDB_RATE_LIMIT_DELAY after a real upload; skip it in tests.
+    monkeypatch.setattr("plex.plex_uploader.time.sleep", lambda *a: None)
+
+
+def _url(asset_id):
+    return f"{ASSETS}/{asset_id}"
+
+
+def _label(prefix, asset_id):
+    return prefix + utils.calculate_md5(_url(asset_id))
+
+
+class _Field:
+    def __init__(self, name, locked):
+        self.name = name
+        self.locked = locked
+
+
+class _Target:
+    """Minimal stand-in for a plexapi Movie."""
+
+    def __init__(self, labels=(), locked=True, rating_key=1):
+        self.labels = list(labels)
+        self.fields = [_Field("thumb", locked)]
+        self.librarySectionTitle = "Movies"
+        self.ratingKey = rating_key
+        self.uploaded = []
+
+    def uploadPoster(self, url=None, filepath=None):
+        self.uploaded.append(url or filepath)
+
+    def addLabel(self, label):
+        self.labels.append(str(label))
+
+    def removeLabel(self, label, *args):
+        self.labels = [existing for existing in self.labels if str(existing) != str(label)]
+
+    def reload(self):
+        pass
+
+
+# djchrisallen owns two Dark Knight posters: an older one (666275) and a newer one (670744).
+ARTIST_ASSETS = {
+    utils.calculate_md5(_url(666275)): 666275,
+    utils.calculate_md5(_url(670744)): 670744,
+}
+
+
+def _uploader(target, candidate_id, *, allow, artist_assets=ARTIST_ASSETS, skip_locked=True):
+    uploader = PlexUploader(target, "Poster", "PID:")
+    uploader.set_options(Options())
+    uploader.set_artwork({"id": candidate_id, "url": _url(candidate_id), "source": "theposterdb"})
+    uploader.set_description("The Dark Knight")
+    uploader.skip_locked = skip_locked
+    uploader.track_artwork_ids = True
+    uploader.allow_artist_updates = allow
+    uploader.artist_assets = artist_assets
+    return uploader
+
+
+# --- the allow_artist_updates truth table -----------------------------------------------
+
+def test_hand_set_custom_is_never_touched():
+    # A locked field with no artwork-uploader label of this type was set by hand. This must hold
+    # whether the option is on or off - it is the whole safety property.
+    for allow in (False, True):
+        target = _Target(labels=[], locked=True)
+        result = _uploader(target, 670744, allow=allow).upload_to_plex()
+        assert result.startswith("🔒")
+        assert target.uploaded == []
+
+
+def test_a_different_artists_poster_is_not_taken():
+    # The current poster is one WE applied, but from another artist (its md5 is not in this
+    # artist's asset map). Same-artist-only: leave it alone.
+    target = _Target(labels=[_label("PID:", 999999)], locked=True)
+    result = _uploader(target, 670744, allow=True).upload_to_plex()
+    assert result.startswith("🔒")
+    assert target.uploaded == []
+
+
+def test_a_newer_poster_from_the_same_artist_is_taken():
+    target = _Target(labels=[_label("PID:", 666275)], locked=True)
+    result = _uploader(target, 670744, allow=True).upload_to_plex()
+    assert result.startswith("✅")
+    assert target.uploaded == [_url(670744)]
+
+
+def test_an_older_poster_from_the_same_artist_is_refused():
+    # Current is the newer poster; a run offering the older one must not move backwards.
+    target = _Target(labels=[_label("PID:", 670744)], locked=True)
+    result = _uploader(target, 666275, allow=True).upload_to_plex()
+    assert result.startswith("🔒")
+    assert target.uploaded == []
+
+
+def test_the_same_poster_is_left_unchanged():
+    target = _Target(labels=[_label("PID:", 670744)], locked=True)
+    result = _uploader(target, 670744, allow=True).upload_to_plex()
+    assert result.startswith("⏩")
+    assert target.uploaded == []
+
+
+def test_option_off_still_skips_a_locked_item_we_own():
+    target = _Target(labels=[_label("PID:", 666275)], locked=True)
+    result = _uploader(target, 670744, allow=False).upload_to_plex()
+    assert result.startswith("🔒")
+    assert target.uploaded == []
+
+
+def test_a_file_upload_candidate_never_qualifies():
+    # A ZIP/file upload has a non-numeric id, so it can't be compared by asset id - protect.
+    target = _Target(labels=[_label("PID:", 666275)], locked=True)
+    uploader = _uploader(target, 670744, allow=True)
+    uploader.set_artwork({"id": "Upload", "checksum": "abc", "source": "upload"})
+    result = uploader.upload_to_plex()
+    assert result.startswith("🔒")
+    assert target.uploaded == []

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -213,7 +213,7 @@ def parse_url_and_options(line):
                     year == None
                 options.year = year
             # If it's one of these flags it shouldn't have any arguments
-            elif flag in ["add-posters", "add-sets", "add-to-bulk", "force", "kometa", "stage", "temp", "skip-locked", "no-cache"]:
+            elif flag in ["add-posters", "add-sets", "add-to-bulk", "force", "kometa", "stage", "temp", "skip-locked", "allow-artist-updates", "no-cache"]:
                 inv_flags.append(f"--{flag} has too many argumens")
             # If we ge to this point it's not a valid flag
             else:
@@ -222,7 +222,7 @@ def parse_url_and_options(line):
         else:
             if flag in ["filters", "exclude", "year"]:
                 inv_flags.append(f"--{flag} needs at least one argument")
-            elif flag not in ["add-posters", "add-sets" ,"add-to-bulk" ,"force", "kometa", "stage", "temp", "skip-locked", "no-cache"]:
+            elif flag not in ["add-posters", "add-sets" ,"add-to-bulk" ,"force", "kometa", "stage", "temp", "skip-locked", "allow-artist-updates", "no-cache"]:
                 inv_flags.append(f"--{flag} is not a valid flag")
             else:
                 setattr(options, flag.replace("-","_"), True) # Convert add-posters into add_posters as the Options class expects


### PR DESCRIPTION
A proposal rather than a drop, because it touches the locked-artwork guarantee and you may want it
shaped differently.

**The problem.** With `skip_locked_artwork` on, a scheduled scrape never revisits anything it has
already applied. That is correct for artwork the user chose by hand. It also means the library keeps
the old version forever when an artist re-uploads a poster, improves it, or fixes a title treatment.
The only way to take the new one is `--force`, which overwrites hand-set customs too.

**The rule.** A locked field may be updated only when both of these hold:

1. the artwork currently on the item carries one of this tool's artwork ID labels, and that label's
   md5 belongs to the artist being processed
2. the candidate's asset id is greater than or equal to the current one

Anything without a matching label was set by hand and is never touched. A label belonging to a
different artist is never touched. The asset id only moves forward, so repeated scheduled runs settle
on each artist's latest upload instead of flip flopping between two.

Off by default, `allow_artist_updates` in `config.json`, `--allow-artist-updates` per bulk line, and a
toggle in the settings page next to the existing ones. It needs `skip_locked_artwork` and
`track_artwork_ids` on, and logs a debug line if it is enabled without them.

**How ownership is worked out.** `PlexUploader` gets an `artist_assets` map, md5 of asset URL to asset
id, for the artist being processed. With the cached index from #57 that map comes from the index. With
no index it is built from what the scrape itself collected, so the feature works without #57. An asset
the artist has since deleted simply falls back to protected.

**Tests.** `tests/test_plex_uploader_artist_updates.py` covers the truth table:

- a hand set custom is untouched, with the option both on and off
- another artist's poster is refused
- a newer poster from the same artist is taken
- an older one is refused
- the same poster is left unchanged
- the option off still skips a locked item we applied
- a file upload never qualifies, because its id is not comparable

`tests/test_artist_assets_plumbing.py` covers the ownership map reaching the uploader by both routes.

Full suite green apart from the one pre-existing `main` failure that #75 fixes.

**One thing worth flagging.** Because this can replace artwork the tool previously chose, the first
run is worth taking a note of your posters before. I keep a small snapshot and restore script for
that. Happy to offer it separately if you would want it in the repo.

