### PR TITLE
Keep the local config out of the Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,8 @@ __pycache__
 Dockerfile
 docker-compose.yml
 bulk_imports/*
+
+# Local runtime state. Both are gitignored, but COPY . . reads the build
+# context rather than git, so a build after a first run bakes them into the image.
+config/config.json
+config/.plex_client_id


### PR DESCRIPTION
Build the image locally after running the app once, and your Plex token ends up inside it.

Two files hold credentials and neither reaches the repository. `config/config.json` carries the Plex
base URL and token, `config/.plex_client_id` carries the client id, and `.gitignore` covers both.

But `.dockerignore` covers neither, and the Dockerfile ends with `COPY . .`, which copies the build
context rather than what git tracks. So the two files a contributor guards most closely are the two
that travel into a layer, and they go wherever that image goes.

This adds both paths to `.dockerignore`.

Nothing changes for a clean checkout, where neither file exists, and nothing changes for the release
workflow, which builds from a fresh `actions/checkout`. It only bites a build run on a machine where
the app has already written its settings.
