### PR TITLE
Tweak UI for PR #57 (Add a persistent index of ThePosterDB user uploads)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,4 @@ DEVELOPER_GUIDE.md
 .gitignore
 docker-compose.yml
 config/.plex_client_id
+config/asset_index.db*

--- a/static/web_interface.js
+++ b/static/web_interface.js
@@ -774,6 +774,10 @@ function saveConfig() {
     
     // Checkbox for caching ThePosterDB user scrapes
     save_config.cache_user_scrapes = document.getElementById("cache_user_scrapes").checked;
+    toggleUserCacheExpiryField();
+
+    // ThePosterDB user cache expiration threshold
+    save_config.user_cache_refresh_days = parseInt(document.getElementById("user_cache_refresh_days").value);
 
     // Get selected mediux filters
     save_config.mediux_filters = Array.from(document.querySelectorAll('[id^="m_filter-"]:checked'))
@@ -828,7 +832,6 @@ function saveConfig() {
                     color: "success",
                     icon: "check2-circle",
                     broadcast: true
-                    
                 });
                 configureTabs(true);
             } else {
@@ -878,6 +881,7 @@ function updateConfigUI(config) {
     document.getElementById("skip_locked_artwork").checked = config.skip_locked_artwork;
     document.getElementById("local_library_matching").checked = config.local_library_matching;
     document.getElementById("cache_user_scrapes").checked = config.cache_user_scrapes;
+    document.getElementById("user_cache_refresh_days").value = config.user_cache_refresh_days;
     document.getElementById("option-add-to-bulk").checked = config.auto_manage_bulk_files;
     document.getElementById("apprise_urls").value = config.apprise_urls.join(", ");
     
@@ -905,6 +909,9 @@ function updateConfigUI(config) {
     
     // Make sure skip locked artwork option visibility is set correctly on load
     toggleSkipLockedCheckbox();
+
+    // Make sure user asset cache expiry field visibility is seet correctly on load
+    toggleUserCacheExpiryField();
     
     // Show/hide logout button based on auth enabled
     if (config.auth_enabled) {
@@ -2166,3 +2173,16 @@ document.getElementById("temp_dir").addEventListener("input", toggleTempCheckbox
 
 // Add event listener for stage_assets checkbox
 document.getElementById("stage_assets").addEventListener("change", toggleScraperStageCheckbox);
+
+document.getElementById("cache_user_scrapes").addEventListener("change", toggleUserCacheExpiryField);
+
+function toggleUserCacheExpiryField() {
+    const userCacheToggle = document.getElementById("cache_user_scrapes");
+    const cacheExpiryContainer = document.getElementById("cache_expiry_container");
+
+    if (userCacheToggle.checked) {
+        cacheExpiryContainer.classList.remove("d-none");
+    } else {
+        cacheExpiryContainer.classList.add("d-none");
+    }
+}

--- a/templates/web_interface.html
+++ b/templates/web_interface.html
@@ -409,8 +409,23 @@
                                         </div>
                                         <div class="form-check form-switch mb-3">
                                             <input class="form-check-input" type="checkbox" value="cache_user_scrapes" id="cache_user_scrapes"/>
-                                            <label for="cache_user_scrapes" class="form-check-label">Remember each ThePosterDB user's uploads between scrapes, so repeat scrapes only fetch new uploads</label>
+                                            <label for="cache_user_scrapes" class="form-check-label">Cache ThePosterDB user pages</label>
+                                            <i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="ThePosterDB only: Keeps a persistent cache in a SQLite database of TPDb user 
+                                            page scrapes so that periodic scrapes of large user portfolios are much faster"></i>
                                         </div>
+                                        <div id="cache_expiry_container" class="mt-2 mb-3 d-flex align-items-center" style="display: d-none;">
+                                            <label for="user_cache_refresh_days" class="form-label me-2 mb-0">Refresh user cache every</label>
+                                            <input type="number" 
+                                                class="form-control form-control-sm text-center d-inline-block me-2" 
+                                                id="user_cache_refresh_days" 
+                                                name="user_cache_refresh_days"
+                                                min="1" 
+                                                max="365" 
+                                                value="30" 
+                                                style="width: 60px;" 
+                                                required />
+                                            <span class="text-body">days</span>
+                                        </div>                                        
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
- Shorten the UI label and add an explanatory too-tip
- Expose the `user_cache_refresh_days` config variable and dynamically show it only if the `cache_user_scrapes` is on