### PR TITLE
Turn allow_artist_updates off when artwork ID tracking is off

### DIFF
--- a/processors/upload_processor.py
+++ b/processors/upload_processor.py
@@ -31,8 +31,12 @@ class UploadProcessor:
         self.options = options
         self.kometa: bool = self.options.kometa or globals.config.save_to_kometa
         self.skip_locked: bool = self.options.skip_locked or globals.config.skip_locked_artwork
-        self.allow_artist_updates: bool = self.options.allow_artist_updates or globals.config.allow_artist_updates
-        if self.allow_artist_updates and not self.config.track_artwork_ids:
+        requested_artist_updates: bool = self.options.allow_artist_updates or globals.config.allow_artist_updates
+        # Artist updates read the artwork ID labels to tell our own artwork from a hand-set custom.
+        # Without track_artwork_ids there are no fresh labels to read, and labels left behind by an
+        # earlier tracked run would let a locked field be replaced on stale information.
+        self.allow_artist_updates: bool = requested_artist_updates and self.config.track_artwork_ids
+        if requested_artist_updates and not self.config.track_artwork_ids:
             debug_me("allow_artist_updates has no effect while track_artwork_ids is off - without "
                      "artwork IDs there's no way to tell artwork we applied from artwork set by "
                      "hand, so locked items are all left alone.", "UploadProcessor/set_options")

--- a/tests/test_upload_processor_artist_update_gating.py
+++ b/tests/test_upload_processor_artist_update_gating.py
@@ -1,0 +1,71 @@
+"""allow_artist_updates has to be off whenever track_artwork_ids is off.
+
+The uploader skips a locked field unless allow_artist_updates and candidate_supersedes_current()
+both hold, and candidate_supersedes_current() reads the artwork ID labels on the Plex item. With
+track_artwork_ids off nothing writes fresh labels, but labels from an earlier tracked run stay on
+the item, so a locked field could be replaced on stale information. Resolving the option at
+set_options time keeps that out of the uploader entirely."""
+
+import pytest
+
+from core import globals
+from models.options import Options
+from processors.upload_processor import UploadProcessor
+
+
+class _Config:
+    def __init__(self, track_artwork_ids, allow_artist_updates=False):
+        self.track_artwork_ids = track_artwork_ids
+        self.allow_artist_updates = allow_artist_updates
+        self.save_to_kometa = False
+        self.skip_locked_artwork = True
+
+
+@pytest.fixture
+def processor():
+    # UploadProcessor.__init__ connects to Plex and loads config.json from disk; set_options is
+    # the only thing under test, so build the instance without running it.
+    return UploadProcessor.__new__(UploadProcessor)
+
+
+def _set_options(processor, monkeypatch, *, config, option_on=False):
+    monkeypatch.setattr(globals, "config", config)
+    processor.config = config
+    options = Options()
+    options.allow_artist_updates = option_on
+    processor.set_options(options)
+
+
+@pytest.mark.parametrize("option_on, config_on", [(True, False), (False, True), (True, True)])
+def test_artist_updates_are_off_without_artwork_id_tracking(processor, monkeypatch, option_on, config_on):
+    # However the option is asked for, per scrape or globally, tracking has the final say.
+    _set_options(processor, monkeypatch,
+                 config=_Config(track_artwork_ids=False, allow_artist_updates=config_on),
+                 option_on=option_on)
+    assert processor.allow_artist_updates is False
+
+
+@pytest.mark.parametrize("option_on, config_on", [(True, False), (False, True), (True, True)])
+def test_artist_updates_stay_on_with_tracking(processor, monkeypatch, option_on, config_on):
+    _set_options(processor, monkeypatch,
+                 config=_Config(track_artwork_ids=True, allow_artist_updates=config_on),
+                 option_on=option_on)
+    assert processor.allow_artist_updates is True
+
+
+def test_artist_updates_stay_off_when_nobody_asked(processor, monkeypatch):
+    _set_options(processor, monkeypatch,
+                 config=_Config(track_artwork_ids=True, allow_artist_updates=False),
+                 option_on=False)
+    assert processor.allow_artist_updates is False
+
+
+def test_the_debug_message_still_fires_when_the_option_is_dropped(processor, monkeypatch):
+    # The message explains why the option did nothing, so it has to survive the option being
+    # resolved to False before the check.
+    messages = []
+    monkeypatch.setattr("processors.upload_processor.debug_me",
+                        lambda message, *args, **kwargs: messages.append(message))
+    _set_options(processor, monkeypatch,
+                 config=_Config(track_artwork_ids=False, allow_artist_updates=True))
+    assert any("track_artwork_ids is off" in message for message in messages)


### PR DESCRIPTION
Follow-up to #79, for the `track_artwork_ids` point you raised on that thread.

## The gap

`UploadProcessor.set_options` resolved the option from the scrape flag or the global config, then logged a debug line when `track_artwork_ids` was off:

```python
self.allow_artist_updates: bool = self.options.allow_artist_updates or globals.config.allow_artist_updates
if self.allow_artist_updates and not self.config.track_artwork_ids:
    debug_me("allow_artist_updates has no effect while track_artwork_ids is off - without "
             "artwork IDs there's no way to tell artwork we applied from artwork set by "
             "hand, so locked items are all left alone.", "UploadProcessor/set_options")
```

That message says the option has no effect. It can still have one.

`PlexUploader` leaves a locked field alone unless `allow_artist_updates and candidate_supersedes_current()` both hold. `candidate_supersedes_current()` calls `current_artwork_id()`, which reads the artwork ID labels already on the item. With tracking off nothing writes fresh labels, but `artwork_exists_on_plex()` only removes a label when it matches the new one exactly (`plex/plex_uploader.py:117`). Labels written by an earlier tracked run stay where they are.

So: run once with tracking on, turn tracking off, leave artist updates on. The uploader can then replace a locked field on the strength of a label the current run never wrote.

Your web UI change hides the toggle and clears it when tracking is off. `config.json` and `--allow-artist-updates` reach the flag without passing through the UI.

## The change

Resolve the option against `track_artwork_ids` in `set_options`, so `PlexUploader` never sees it enabled without the labels it depends on.

The one-liner in your comment would have silenced the debug message, because the `if` under it tests the same attribute. Holding the requested value in a local keeps the message firing on exactly the case it describes.

## Tests

`tests/test_upload_processor_artist_update_gating.py`. Eight cases across the per-scrape flag, the global setting and `track_artwork_ids`, plus one that the debug message survives. Three fail without the change. Full suite is 53 passing.
