### PR TITLE
Retry transient upload failures, and make the timeouts configurable

### DIFF
--- a/artwork_uploader.py
+++ b/artwork_uploader.py
@@ -268,6 +268,7 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
     assets_processed = [0]
     cached_counter = [0]
     locked_counter = [0]
+    failed_counter = [0]  # Uploads that failed after exhausting their retries
     errors = 0
 
     try:
@@ -299,7 +300,7 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
                 break
 
             try:
-                scrape_and_upload(instance, parsed_line.url, parsed_line.options, True, success_counter, assets_processed, cached_counter=cached_counter, locked_counter=locked_counter)
+                scrape_and_upload(instance, parsed_line.url, parsed_line.options, True, success_counter, assets_processed, cached_counter=cached_counter, locked_counter=locked_counter, failed_counter=failed_counter)
                 #time.sleep(1)
             except ScraperException as e:
                 update_log(instance, f"❌ Error processing line: '{parsed_line.url}'")
@@ -319,6 +320,11 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
         end_time = time.time()
         elapsed = elapsed_time(end_time - start_time)
 
+        # A line that failed to scrape at all (errors) and an item that failed to upload after
+        # exhausting its retries (failed_counter) both count as errors in the run summary. An
+        # item that succeeded on a retry never reaches failed_counter, so it isn't one.
+        total_errors = errors + failed_counter[0]
+
         if globals.cancel_scrape:
             message = (
                 "🛑 "
@@ -328,21 +334,23 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
                 + (f"{cached_counter[0]} new in cache • " if cached_counter[0] else "")
                 + f"{success_counter[0]} asset(s) updated"
                 + (f" • {locked_counter[0]} asset(s) locked (skipped)" if locked_counter[0] else "")
+                + (f" • {failed_counter[0]} asset(s) failed" if failed_counter[0] else "")
             )
             update_status(instance, message[2:], color=StatusColor.WARNING.value, sticky=False, spinner=False)
             notify_web(instance, "progress_bar", {"percent": 100, "bar_type": "bulk"})
         else:
             message = (
-                ("🏁 " if errors == 0 else "⚠️ ")
+                ("🏁 " if total_errors == 0 else "⚠️ ")
                 + ("Scheduled b" if scheduled else "B")
                 + f"ulk import of '{display_filename}' completed "
-                + (f"successfully in {elapsed} • " if errors == 0 else f"with {errors} error(s) in {elapsed}, check logs for details • ")
+                + (f"successfully in {elapsed} • " if total_errors == 0 else f"with {total_errors} error(s) in {elapsed}, check logs for details • ")
                 + f"{assets_processed[0]} asset(s) processed • "
                 + (f"{cached_counter[0]} new in cache • " if cached_counter[0] else "")
                 + f"{success_counter[0]} asset(s) updated"
                 + (f" • {locked_counter[0]} asset(s) locked (skipped)" if locked_counter[0] else "")
+                + (f" • {failed_counter[0]} asset(s) failed" if failed_counter[0] else "")
             )
-            update_status(instance, message[2:], color=StatusColor.SUCCESS.value if errors == 0 else StatusColor.WARNING.value, sticky=False, spinner=False)
+            update_status(instance, message[2:], color=StatusColor.SUCCESS.value if total_errors == 0 else StatusColor.WARNING.value, sticky=False, spinner=False)
         update_log(instance, message)
         if scheduled:
             debug_me(f"Sending notifications to {len(globals.config.apprise_urls)} notification service(s).")
@@ -361,7 +369,7 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
             globals.scrape_type = "stopped"
 
 # Scraped the URL then uploads what it's scraped to Plex or download to Kometa asset directory
-def scrape_and_upload(instance: Instance, url, options, bulk=False, success_counter=None, assets_processed=None, cached_counter=None, locked_counter=None):
+def scrape_and_upload(instance: Instance, url, options, bulk=False, success_counter=None, assets_processed=None, cached_counter=None, locked_counter=None, failed_counter=None):
     """
     Scrape artwork from a URL and upload to Plex.
 
@@ -401,7 +409,8 @@ def scrape_and_upload(instance: Instance, url, options, bulk=False, success_coun
         success_counter=success_counter,
         assets_processed=assets_processed,
         cached_counter=cached_counter,
-        locked_counter=locked_counter
+        locked_counter=locked_counter,
+        failed_counter=failed_counter
     )
 
     # Use the service to do the actual work

--- a/config/config.json.example
+++ b/config/config.json.example
@@ -60,5 +60,20 @@
     "_schedules_help": "Scheduled bulk import jobs. Configure through the web UI",
 
     "apprise_urls": [],
-    "_apprise_urls": "Comma-separated list of Apprise notification URLs"
+    "_apprise_urls": "Comma-separated list of Apprise notification URLs",
+
+    "plex_connect_timeout": 10,
+    "_plex_connect_timeout_help": "Seconds to wait when connecting to the Plex server (also applies to uploads)",
+
+    "plex_test_connection_timeout": 5,
+    "_plex_test_connection_timeout_help": "Seconds to wait when testing a Plex connection from the web settings",
+
+    "kometa_download_timeout": 5,
+    "_kometa_download_timeout_help": "Seconds to wait when downloading artwork to save to the Kometa asset directory",
+
+    "upload_retry_attempts": 3,
+    "_upload_retry_attempts_help": "Total attempts (including the first) made for a transient upload failure - a timeout or a 5xx",
+
+    "upload_retry_backoff_seconds": 1,
+    "_upload_retry_backoff_seconds_help": "Seconds to wait before the first retry, doubling after each subsequent attempt"
 }

--- a/core/config.py
+++ b/core/config.py
@@ -5,6 +5,13 @@ Application configuration management.
 import json, os
 from core import globals
 from typing import List, Dict, Any
+from core.constants import (
+    DEFAULT_PLEX_CONNECT_TIMEOUT,
+    DEFAULT_PLEX_TEST_CONNECTION_TIMEOUT,
+    DEFAULT_KOMETA_DOWNLOAD_TIMEOUT,
+    DEFAULT_UPLOAD_RETRY_ATTEMPTS,
+    DEFAULT_UPLOAD_RETRY_BACKOFF_SECONDS,
+)
 from core.exceptions import ConfigLoadError, ConfigSaveError, ConfigCreationError
 from utils.notifications import debug_me
 from utils.utils import get_host_path
@@ -44,6 +51,11 @@ class Config:
         webhook_token: Shared secret required on webhook requests
         webhook_tpdb_users: ThePosterDB users to apply cached artwork from on import, in priority order
         webhook_apply_delay: Seconds to wait after an import before applying artwork (lets Plex scan first)
+        plex_connect_timeout: Seconds to wait when connecting to the Plex server (also applies to uploads)
+        plex_test_connection_timeout: Seconds to wait when testing a Plex connection from the web settings
+        kometa_download_timeout: Seconds to wait when downloading artwork to save to the Kometa asset directory
+        upload_retry_attempts: Total attempts (including the first) made for a transient upload failure
+        upload_retry_backoff_seconds: Seconds to wait before the first retry, doubling after each attempt
     """
 
     def __init__(self, config_path: str = "config/config.json") -> None:
@@ -76,6 +88,11 @@ class Config:
         self.webhook_token: str = ""
         self.webhook_tpdb_users: List[str] = []
         self.webhook_apply_delay: int = 30
+        self.plex_connect_timeout: int = DEFAULT_PLEX_CONNECT_TIMEOUT
+        self.plex_test_connection_timeout: int = DEFAULT_PLEX_TEST_CONNECTION_TIMEOUT
+        self.kometa_download_timeout: int = DEFAULT_KOMETA_DOWNLOAD_TIMEOUT
+        self.upload_retry_attempts: int = DEFAULT_UPLOAD_RETRY_ATTEMPTS
+        self.upload_retry_backoff_seconds: float = DEFAULT_UPLOAD_RETRY_BACKOFF_SECONDS
 
 
     def load(self) -> None:
@@ -122,6 +139,11 @@ class Config:
             self.webhook_token = config.get("webhook_token", "")
             self.webhook_tpdb_users = config.get("webhook_tpdb_users", [])
             self.webhook_apply_delay = config.get("webhook_apply_delay", 30)
+            self.plex_connect_timeout = config.get("plex_connect_timeout", DEFAULT_PLEX_CONNECT_TIMEOUT)
+            self.plex_test_connection_timeout = config.get("plex_test_connection_timeout", DEFAULT_PLEX_TEST_CONNECTION_TIMEOUT)
+            self.kometa_download_timeout = config.get("kometa_download_timeout", DEFAULT_KOMETA_DOWNLOAD_TIMEOUT)
+            self.upload_retry_attempts = config.get("upload_retry_attempts", DEFAULT_UPLOAD_RETRY_ATTEMPTS)
+            self.upload_retry_backoff_seconds = config.get("upload_retry_backoff_seconds", DEFAULT_UPLOAD_RETRY_BACKOFF_SECONDS)
 
         except Exception as e:
             raise ConfigLoadError(f"Error loading configuration from '{self.path}': {e}") from e
@@ -153,7 +175,12 @@ class Config:
             "enable_webhooks": False,
             "webhook_token": "",
             "webhook_tpdb_users": [],
-            "webhook_apply_delay": 30
+            "webhook_apply_delay": 30,
+            "plex_connect_timeout": DEFAULT_PLEX_CONNECT_TIMEOUT,
+            "plex_test_connection_timeout": DEFAULT_PLEX_TEST_CONNECTION_TIMEOUT,
+            "kometa_download_timeout": DEFAULT_KOMETA_DOWNLOAD_TIMEOUT,
+            "upload_retry_attempts": DEFAULT_UPLOAD_RETRY_ATTEMPTS,
+            "upload_retry_backoff_seconds": DEFAULT_UPLOAD_RETRY_BACKOFF_SECONDS
         }
 
         if globals.docker:
@@ -205,7 +232,12 @@ class Config:
             "enable_webhooks": self.enable_webhooks,
             "webhook_token": self.webhook_token,
             "webhook_tpdb_users": self.webhook_tpdb_users,
-            "webhook_apply_delay": self.webhook_apply_delay
+            "webhook_apply_delay": self.webhook_apply_delay,
+            "plex_connect_timeout": self.plex_connect_timeout,
+            "plex_test_connection_timeout": self.plex_test_connection_timeout,
+            "kometa_download_timeout": self.kometa_download_timeout,
+            "upload_retry_attempts": self.upload_retry_attempts,
+            "upload_retry_backoff_seconds": self.upload_retry_backoff_seconds
         }
 
         try:

--- a/core/constants.py
+++ b/core/constants.py
@@ -145,6 +145,17 @@ SCHEDULER_CHECK_INTERVAL = 60  # 1 minute
 UPLOAD_CHUNK_SIZE = 1024 * 512  # bytes
 UPLOAD_CHUNK_TIMEOUT = 10 # seconds
 
+# Network timeouts (seconds)
+DEFAULT_PLEX_CONNECT_TIMEOUT = 10  # PlexConnector.connect()
+DEFAULT_PLEX_TEST_CONNECTION_TIMEOUT = 5  # "Test connection" in the web settings
+DEFAULT_KOMETA_DOWNLOAD_TIMEOUT = 5  # Downloading artwork to save to the Kometa asset directory
+
+# Upload retry behaviour: a transient failure (timeout, connection error, 5xx) is retried this many
+# times in total, waiting backoff seconds and doubling that wait after each attempt. A 401 or 404
+# is never transient and is not retried.
+DEFAULT_UPLOAD_RETRY_ATTEMPTS = 3
+DEFAULT_UPLOAD_RETRY_BACKOFF_SECONDS = 1
+
 # Web UI colors (Bootstrap)
 BOOTSTRAP_COLORS = {
     'primary': {'bg': '#0d6efd', 'fg': '#ffffff', 'ansi': '\033[0m'},

--- a/core/retry.py
+++ b/core/retry.py
@@ -1,0 +1,52 @@
+"""
+Retry helper for the upload path (Plex uploads and Kometa asset downloads).
+
+A transient failure - a timeout, a dropped connection, or a 5xx response - is worth trying again.
+An authentication or not-found error is not: retrying it wastes the attempts budget on something
+that will never succeed.
+"""
+
+import re
+import time
+import requests
+import plexapi.exceptions
+
+
+def is_transient_error(exc: Exception) -> bool:
+    """True for a timeout, connection failure, or 5xx response. False for everything else,
+       including a 401 or a 404."""
+    if isinstance(exc, (requests.exceptions.Timeout, requests.exceptions.ConnectionError)):
+        return True
+
+    if isinstance(exc, requests.exceptions.HTTPError):
+        status = exc.response.status_code if exc.response is not None else None
+        return status is not None and 500 <= status < 600
+
+    # plexapi doesn't raise requests.exceptions.HTTPError for a bad status code from the Plex
+    # server - it raises BadRequest (or Unauthorized, a subclass of BadRequest, for a 401) with
+    # the status code embedded in the message as "(NNN) ...".
+    if isinstance(exc, plexapi.exceptions.BadRequest) and not isinstance(exc, plexapi.exceptions.Unauthorized):
+        match = re.match(r"\((\d{3})\)", str(exc))
+        return bool(match) and 500 <= int(match.group(1)) < 600
+
+    return False
+
+
+def call_with_retry(func, attempts: int, backoff: float):
+    """
+    Calls func(), retrying on a transient error until it succeeds or `attempts` attempts (the
+    first call plus any retries) have been made. Waits `backoff * 2 ** n` seconds between
+    attempts, doubling each time.
+
+    Returns (result, attempts_made) on success. On failure, re-raises the last exception with an
+    `attempts` attribute set to the number of attempts made, so the caller can report it.
+    """
+    attempts = max(attempts, 1)
+    for attempt in range(1, attempts + 1):
+        try:
+            return func(), attempt
+        except Exception as e:
+            if attempt >= attempts or not is_transient_error(e):
+                e.attempts = attempt
+                raise
+            time.sleep(backoff * (2 ** (attempt - 1)))

--- a/kometa/kometa_saver.py
+++ b/kometa/kometa_saver.py
@@ -3,7 +3,8 @@ from typing import Optional
 from utils.notifications import debug_me
 from models.options import Options
 from core.enums import ScraperSource
-from core.constants import IMAGE_EXTENSIONS
+from core.constants import IMAGE_EXTENSIONS, DEFAULT_KOMETA_DOWNLOAD_TIMEOUT, DEFAULT_UPLOAD_RETRY_ATTEMPTS, DEFAULT_UPLOAD_RETRY_BACKOFF_SECONDS
+from core.retry import call_with_retry
 from models.artwork_types import AnyArtwork
 
 class KometaSaver:
@@ -24,6 +25,9 @@ class KometaSaver:
         self.artwork: Optional[AnyArtwork] = None
         self.options: Options = Options()
         self.confirm_match = None
+        self.download_timeout: int = DEFAULT_KOMETA_DOWNLOAD_TIMEOUT
+        self.retry_attempts: int = DEFAULT_UPLOAD_RETRY_ATTEMPTS
+        self.retry_backoff: float = DEFAULT_UPLOAD_RETRY_BACKOFF_SECONDS
 
     def set_artwork(self, artwork: AnyArtwork) -> None:
         self.artwork = artwork
@@ -96,24 +100,38 @@ class KometaSaver:
         try:
             url = self.artwork["url"]
             debug_me(f"Downloading {self.artwork_type.lower()} from URL: {url}")
-            r = requests.get(url, headers=headers, stream=True, timeout=5)
-            r.raise_for_status()
+
+            def _fetch():
+                response = requests.get(url, headers=headers, stream=True, timeout=self.download_timeout)
+                response.raise_for_status()
+                return response
+
+            # A timeout, dropped connection, or 5xx is worth trying again; anything else (a 429,
+            # a 404) fails immediately rather than burning the retry budget.
+            r, _ = call_with_retry(_fetch, self.retry_attempts, self.retry_backoff)
             content_type = r.headers.get('Content-Type', '')
             ext = mimetypes.guess_extension(content_type.split(';')[0])
             self.dest_file_ext = ext if ext is not None else self.dest_file_ext
         except requests.exceptions.Timeout as e:
-            debug_me(f"Downloading asset from {url} timed out (5 seconds): {str(e)}")
-            return f"❌ {self.description} | Error saving {self.artwork_type.lower()}: Asset download timed out (5 seconds)"
+            attempts = getattr(e, "attempts", 1)
+            attempts_note = f" after {attempts} attempt(s)" if attempts > 1 else ""
+            debug_me(f"Downloading asset from {url} timed out ({self.download_timeout} seconds){attempts_note}: {str(e)}")
+            return f"❌ {self.description} | Error saving {self.artwork_type.lower()}: Asset download timed out ({self.download_timeout} seconds){attempts_note}"
         except requests.exceptions.ConnectionError as e:
-            debug_me(f"Connection error: {str(e)}")
-            return f"❌ {self.description} | Error saving {self.artwork_type.lower()}: Could not connect to server, check your internet connection or the site's status"
-        except requests.exceptions.HTTPError:
-            if r.status_code == 429:
+            attempts = getattr(e, "attempts", 1)
+            attempts_note = f" after {attempts} attempt(s)" if attempts > 1 else ""
+            debug_me(f"Connection error{attempts_note}: {str(e)}")
+            return f"❌ {self.description} | Error saving {self.artwork_type.lower()}: Could not connect to server, check your internet connection or the site's status{attempts_note}"
+        except requests.exceptions.HTTPError as e:
+            status = e.response.status_code if e.response is not None else None
+            attempts = getattr(e, "attempts", 1)
+            attempts_note = f" after {attempts} attempt(s)" if attempts > 1 else ""
+            if status == 429:
                 debug_me(f"Obtained error 429: too many requests (connection has been rate-limited)")
                 return f"❌ {self.description} | Error saving {self.artwork_type.lower()}: Too many requets (connection rate-limtied)"
             else:
-                debug_me(f"HTTP status code {r.status_code}")
-                return f"❌ {self.description} | Error saving {self.artwork_type.lower()}: HTTP Error: {r.status_code}"
+                debug_me(f"HTTP status code {status}{attempts_note}")
+                return f"❌ {self.description} | Error saving {self.artwork_type.lower()}: HTTP Error: {status}{attempts_note}"
         except Exception as e:
             debug_me(f"❌ {self.description} | Error saving {self.artwork_type.lower()}: Unknown error")
             raise

--- a/models/callbacks.py
+++ b/models/callbacks.py
@@ -17,6 +17,7 @@ class ProcessingCallbacks:
     assets_processed: Optional[list] = None  # Mutable list to track total assets processed (contains count as single element)
     cached_counter: Optional[list] = None  # Mutable list to track assets newly added to the user cache (contains count as single element)
     locked_counter: Optional[list] = None  # Mutable list to track artwork skipped because the Plex field was locked (contains count as single element)
+    failed_counter: Optional[list] = None  # Mutable list to track uploads that failed after exhausting their retries (contains count as single element)
 
     def status(self, message: str, color: str = "info", spinner: bool = False, sticky: bool = False):
         if self.on_status_update:
@@ -49,3 +50,7 @@ class ProcessingCallbacks:
     def locked(self, count: int):
         if self.locked_counter:
             self.locked_counter[0] += count
+
+    def failed(self, count: int):
+        if self.failed_counter:
+            self.failed_counter[0] += count

--- a/plex/plex_connector.py
+++ b/plex/plex_connector.py
@@ -1,6 +1,8 @@
 import requests, plexapi.exceptions, xml.etree.ElementTree, re
 from typing import Optional, List, Tuple, Union, Literal
+from core import globals
 from core.enums import MediaType
+from core.constants import DEFAULT_PLEX_CONNECT_TIMEOUT
 from plexapi.server import PlexServer
 from plexapi.library import MovieSection, ShowSection
 from plexapi.video import Movie, Show
@@ -48,14 +50,16 @@ class PlexConnector:
             if not self.base_url or not self.token:
                 raise PlexConnectorException("Invalid Plex token or base URL. Please provide valid values in config.json or via the GUI.")
 
+            timeout = globals.config.plex_connect_timeout if globals.config else DEFAULT_PLEX_CONNECT_TIMEOUT
+
             try:
-                self.plex = PlexServer(self.base_url, self.token, timeout=10)  # Initialize the Plex server connection with 10 second timeout
+                self.plex = PlexServer(self.base_url, self.token, timeout=timeout)  # Also governs the timeout for uploads, which reuse this connection
 
             except requests.exceptions.Timeout as e:
                 # Handle timeout errors specifically
                 self.plex = None
                 raise PlexConnectorException(
-                    f'Connection to Plex server at {self.base_url} timed out after 10 seconds. Please check that the server is running and accessible.',
+                    f'Connection to Plex server at {self.base_url} timed out after {timeout} seconds. Please check that the server is running and accessible.',
                     f"Plex connection timeout: {str(e)}")
 
             except requests.exceptions.RequestException as e:

--- a/plex/plex_uploader.py
+++ b/plex/plex_uploader.py
@@ -5,7 +5,8 @@ from plexapi.collection import Collection
 from utils import utils
 from models.options import Options
 from core.enums import ScraperSource, ArtworkIDPrefix
-from core.constants import TPDB_RATE_LIMIT_DELAY, KOMETA_OVERLAY_LABEL
+from core.constants import TPDB_RATE_LIMIT_DELAY, KOMETA_OVERLAY_LABEL, DEFAULT_UPLOAD_RETRY_ATTEMPTS, DEFAULT_UPLOAD_RETRY_BACKOFF_SECONDS
+from core.retry import call_with_retry
 from models.artwork_types import AnyArtwork
 
 class PlexUploader:
@@ -31,6 +32,8 @@ class PlexUploader:
         self.artist_assets: Optional[dict] = None  # {md5(asset url): asset id} for the artist being processed
         self.confirm_match = None
         self.stale_labels: list = []
+        self.retry_attempts: int = DEFAULT_UPLOAD_RETRY_ATTEMPTS
+        self.retry_backoff: float = DEFAULT_UPLOAD_RETRY_BACKOFF_SECONDS
 
     def set_artwork(self, artwork: AnyArtwork) -> None:
         self.artwork = artwork
@@ -72,27 +75,28 @@ class PlexUploader:
 
                 if self.artwork_id == ArtworkIDPrefix.BACKGROUND.value:
                     if self.type == "file":
-                        self.upload_target.uploadArt(filepath = self.artwork['path'])
+                        upload_call = lambda: self.upload_target.uploadArt(filepath = self.artwork['path'])
                     else:
-                        self.upload_target.uploadArt(url = self.artwork["url"])
-                    if self.track_artwork_ids:
-                        self.upload_target.addLabel(self.label)
+                        upload_call = lambda: self.upload_target.uploadArt(url = self.artwork["url"])
 
                 elif self.artwork_id == ArtworkIDPrefix.SQUARE_ART.value:
                     if self.type == "file":
-                        self.upload_target.uploadSquareArt(filepath = self.artwork['path'])
+                        upload_call = lambda: self.upload_target.uploadSquareArt(filepath = self.artwork['path'])
                     else:
-                        self.upload_target.uploadSquareArt(url = self.artwork["url"])
-                    if self.track_artwork_ids:
-                        self.upload_target.addLabel(self.label)
+                        upload_call = lambda: self.upload_target.uploadSquareArt(url = self.artwork["url"])
 
                 else:
                     if self.type == "file":
-                        self.upload_target.uploadPoster(filepath = self.artwork['path'])
+                        upload_call = lambda: self.upload_target.uploadPoster(filepath = self.artwork['path'])
                     else:
-                        self.upload_target.uploadPoster(url = self.artwork["url"])
-                    if self.track_artwork_ids:
-                        self.upload_target.addLabel(self.label)
+                        upload_call = lambda: self.upload_target.uploadPoster(url = self.artwork["url"])
+
+                # A timeout, dropped connection, or 5xx from Plex is worth trying again; anything
+                # else (a 401, a 404) fails immediately rather than burning the retry budget.
+                call_with_retry(upload_call, self.retry_attempts, self.retry_backoff)
+
+                if self.track_artwork_ids:
+                    self.upload_target.addLabel(self.label)
                 # Remove the labels for the artwork we just replaced only AFTER the new one is on
                 # the item, so a failed upload leaves the old label in place and the item stays
                 # recognisable as ours, rather than looking like artwork set by hand
@@ -103,7 +107,9 @@ class PlexUploader:
             else:
                 return f'⏩ {self.description} | {self.artwork_type} unchanged in {self.upload_target.librarySectionTitle}'
         except Exception as e:
-            return f'❌ {self.description} | Failed to update {self.artwork_type} in {self.upload_target.librarySectionTitle}: {str(e)}'
+            attempts = getattr(e, "attempts", 1)
+            attempts_note = f" after {attempts} attempt(s)" if attempts > 1 else ""
+            return f'❌ {self.description} | Failed to update {self.artwork_type} in {self.upload_target.librarySectionTitle}{attempts_note}: {str(e)}'
 
     def artwork_exists_on_plex(self) -> bool:
         existing_artwork = False

--- a/processors/upload_processor.py
+++ b/processors/upload_processor.py
@@ -141,6 +141,9 @@ class UploadProcessor:
                 if self.kometa:
                     asset_folder = collection_item.title.replace("/", "").replace(":", "")
                     saver = KometaSaver(artwork_type, library)
+                    saver.download_timeout = self.config.kometa_download_timeout
+                    saver.retry_attempts = self.config.upload_retry_attempts
+                    saver.retry_backoff = self.config.upload_retry_backoff_seconds
                     saver.set_artwork(artwork)
                     base_dir = ("/temp" if self.options.temp else "/assets") if globals.docker else getattr(globals.config, "temp_dir" if self.options.temp else "kometa_base", None)
                     saver.dest_dir = os.path.join(base_dir, library, asset_folder)
@@ -159,6 +162,8 @@ class UploadProcessor:
                     uploader.skip_locked = self.skip_locked
                     uploader.allow_artist_updates = self.allow_artist_updates
                     uploader.artist_assets = self.artist_assets
+                    uploader.retry_attempts = self.config.upload_retry_attempts
+                    uploader.retry_backoff = self.config.upload_retry_backoff_seconds
                     uploader.set_description(description)
                     uploader.set_options(self.options)
                     result = uploader.upload_to_plex()
@@ -198,6 +203,9 @@ class UploadProcessor:
                     path_parts = get_path_parts(item_path)
                     asset_folder = path_parts[-2]
                     saver = KometaSaver(artwork_type, library)
+                    saver.download_timeout = self.config.kometa_download_timeout
+                    saver.retry_attempts = self.config.upload_retry_attempts
+                    saver.retry_backoff = self.config.upload_retry_backoff_seconds
                     saver.set_artwork(artwork)
                     base_dir = ("/temp" if self.options.temp else "/assets") if globals.docker else getattr(globals.config, "temp_dir" if self.options.temp else "kometa_base", None)
                     saver.dest_dir = os.path.join(base_dir, library, asset_folder)
@@ -218,6 +226,8 @@ class UploadProcessor:
                     uploader.skip_locked = self.skip_locked
                     uploader.allow_artist_updates = self.allow_artist_updates
                     uploader.artist_assets = self.artist_assets
+                    uploader.retry_attempts = self.config.upload_retry_attempts
+                    uploader.retry_backoff = self.config.upload_retry_backoff_seconds
                     if locally_matched:
                         uploader.confirm_match = lambda a=artwork, item=movie_item: self._artwork_matches_item(a, item, "movie")
                     uploader.set_description(desc)
@@ -335,6 +345,9 @@ class UploadProcessor:
                 try:
                     if self.kometa:
                         saver = KometaSaver(artwork_type, library)
+                        saver.download_timeout = self.config.kometa_download_timeout
+                        saver.retry_attempts = self.config.upload_retry_attempts
+                        saver.retry_backoff = self.config.upload_retry_backoff_seconds
                         saver.set_artwork(artwork)
                         base_dir = ("/temp" if self.options.temp else "/assets") if globals.docker else getattr(globals.config, 'temp_dir' if self.options.temp else 'kometa_base', None)
                         saver.dest_dir = os.path.join(base_dir, library, asset_folder)
@@ -356,6 +369,8 @@ class UploadProcessor:
                         uploader.skip_locked = self.skip_locked
                         uploader.allow_artist_updates = self.allow_artist_updates
                         uploader.artist_assets = self.artist_assets
+                        uploader.retry_attempts = self.config.upload_retry_attempts
+                        uploader.retry_backoff = self.config.upload_retry_backoff_seconds
                         if locally_matched:
                             uploader.confirm_match = lambda a=artwork, item=tv_show: self._artwork_matches_item(a, item, "tv")
                         uploader.set_description(desc)

--- a/services/artwork_processor.py
+++ b/services/artwork_processor.py
@@ -136,7 +136,8 @@ class ArtworkProcessor:
                 self.callbacks.status(f"Process canceled {f'{title} by {scraper.author}' if title else f"for {scraper.author}'s TPDb portfolio"}", "warning")
         else:
             self.callbacks.assets(count=(scraper.total - scraper.skipped))
-            self.callbacks.log(f"✔️ {description} | {scraper.total - scraper.skipped} asset(s) processed in {elapsed} • {self.callbacks.success_counter[0]} asset(s) updated")
+            failed_note = f" • {self.callbacks.failed_counter[0]} asset(s) failed" if self.callbacks.failed_counter and self.callbacks.failed_counter[0] else ""
+            self.callbacks.log(f"✔️ {description} | {scraper.total - scraper.skipped} asset(s) processed in {elapsed} • {self.callbacks.success_counter[0]} asset(s) updated{failed_note}")
             if not bulk:
                 self.callbacks.status(f"Process completed {f'{title} by {scraper.author}' if title else f"for {scraper.author}'s TPDb portfolio"}", "success")
         return scraper.title, scraper.author
@@ -180,6 +181,10 @@ class ArtworkProcessor:
             # Track artwork left alone because its Plex field was locked
                 elif result.startswith('🔒'):
                     self.callbacks.locked(1)
+
+            # Track uploads that failed after exhausting their retries
+                elif result.startswith('❌'):
+                    self.callbacks.failed(1)
 
             # Log the result
                 self.callbacks.log(result)
@@ -251,6 +256,7 @@ class ArtworkProcessor:
         
         processed_files = 0
         success_counter = 0  # Mutable counter to track successful uploads
+        failed_counter = 0  # Mutable counter to track uploads that failed after exhausting their retries
 
         # Initial progress update
         self.callbacks.debug("Processing uploaded file...")
@@ -319,6 +325,10 @@ class ArtworkProcessor:
                         if result.startswith('✅') or result.startswith('♻️'):
                             success_counter += 1
 
+                        # Track uploads that failed after exhausting their retries
+                        elif result.startswith('❌'):
+                            failed_counter += 1
+
                         # Log the result
                         self.callbacks.log(result)
 
@@ -351,10 +361,11 @@ class ArtworkProcessor:
             except OSError:
                 pass
         # Final progress update
+        failed_note = f" • {failed_counter} asset(s) failed" if failed_counter else ""
         if globals.cancel_scrape:
             self.callbacks.progress(1, 1, "", "main")
-            self.callbacks.log(f"🛑 {title}{f' ({year})' if year else ''} • {author} | Stopped by user. {processed_files} file(s) processed • {success_counter} asset(s) updated.")
+            self.callbacks.log(f"🛑 {title}{f' ({year})' if year else ''} • {author} | Stopped by user. {processed_files} file(s) processed • {success_counter} asset(s) updated{failed_note}.")
 
         else:
-            self.callbacks.log(f"✔️ {title}{f' ({year})' if year else ''} • {author} | {total_files} file(s) processed • {success_counter} asset(s) updated.")
+            self.callbacks.log(f"✔️ {title}{f' ({year})' if year else ''} • {author} | {total_files} file(s) processed • {success_counter} asset(s) updated{failed_note}.")
             self.callbacks.progress(total_files, total_files, f"Processing ZIP file • {total_files} of {total_files}")

--- a/static/web_interface.js
+++ b/static/web_interface.js
@@ -1107,6 +1107,13 @@ function getCurrentConfigForm() {
     // ThePosterDB user cache expiration threshold
     current_form.user_cache_refresh_days = parseInt(document.getElementById("user_cache_refresh_days").value) || 0;
 
+    // Timeouts and retries
+    current_form.plex_connect_timeout = parseInt(document.getElementById("plex_connect_timeout").value) || 10;
+    current_form.plex_test_connection_timeout = parseInt(document.getElementById("plex_test_connection_timeout").value) || 5;
+    current_form.kometa_download_timeout = parseInt(document.getElementById("kometa_download_timeout").value) || 5;
+    current_form.upload_retry_attempts = parseInt(document.getElementById("upload_retry_attempts").value) || 3;
+    current_form.upload_retry_backoff_seconds = parseFloat(document.getElementById("upload_retry_backoff_seconds").value) || 0;
+
     // Checkbox for taking an artist's newer artwork for posters we applied
     current_form.allow_artist_updates = document.getElementById("allow_artist_updates").checked;
 
@@ -1231,6 +1238,11 @@ function updateConfigUI(config) {
     document.getElementById("local_library_matching").checked = config.local_library_matching;
     document.getElementById("cache_user_scrapes").checked = config.cache_user_scrapes;
     document.getElementById("user_cache_refresh_days").value = config.user_cache_refresh_days ?? 7;
+    document.getElementById("plex_connect_timeout").value = config.plex_connect_timeout ?? 10;
+    document.getElementById("plex_test_connection_timeout").value = config.plex_test_connection_timeout ?? 5;
+    document.getElementById("kometa_download_timeout").value = config.kometa_download_timeout ?? 5;
+    document.getElementById("upload_retry_attempts").value = config.upload_retry_attempts ?? 3;
+    document.getElementById("upload_retry_backoff_seconds").value = config.upload_retry_backoff_seconds ?? 1;
     document.getElementById("allow_artist_updates").checked = config.allow_artist_updates;
     document.getElementById("option-add-to-bulk").checked = config.auto_manage_bulk_files;
     

--- a/templates/web_interface.html
+++ b/templates/web_interface.html
@@ -490,6 +490,45 @@
                                     </div>
                                 </div>
                             </div>
+                            <!-- Timeouts and retries -->
+                            <div class="row mb-3">
+                                <div class="col">
+                                    <div class="p-3 border rounded-4 shadow-sm">
+                                        <h5 class="mb-3"><i class="bi bi-stopwatch"></i>&ensp;Timeouts and retries</h5>
+                                        <div class="mt-2 d-flex align-items-center">
+                                            <label for="plex_connect_timeout" class="form-label me-2 mb-0">Wait for a Plex connection or upload for</label>
+                                            <input type="number" class="form-control form-control-sm text-center d-inline-block me-2 input-monospace"
+                                                id="plex_connect_timeout" name="plex_connect_timeout" min="1" max="300" value="10" style="width: 60px;" required />
+                                            <span class="text-body">seconds</span>
+                                        </div>
+                                        <div class="mt-2 d-flex align-items-center">
+                                            <label for="plex_test_connection_timeout" class="form-label me-2 mb-0">Wait for a settings connection test for</label>
+                                            <input type="number" class="form-control form-control-sm text-center d-inline-block me-2 input-monospace"
+                                                id="plex_test_connection_timeout" name="plex_test_connection_timeout" min="1" max="60" value="5" style="width: 60px;" required />
+                                            <span class="text-body">seconds</span>
+                                        </div>
+                                        <div class="mt-2 d-flex align-items-center">
+                                            <label for="kometa_download_timeout" class="form-label me-2 mb-0">Wait for a Kometa artwork download for</label>
+                                            <input type="number" class="form-control form-control-sm text-center d-inline-block me-2 input-monospace"
+                                                id="kometa_download_timeout" name="kometa_download_timeout" min="1" max="300" value="5" style="width: 60px;" required />
+                                            <span class="text-body">seconds</span>
+                                        </div>
+                                        <div class="mt-2 d-flex align-items-center">
+                                            <label for="upload_retry_attempts" class="form-label me-2 mb-0">Attempt a failed upload</label>
+                                            <input type="number" class="form-control form-control-sm text-center d-inline-block me-2 input-monospace"
+                                                id="upload_retry_attempts" name="upload_retry_attempts" min="1" max="10" value="3" style="width: 60px;" required />
+                                            <span class="text-body">times in total</span>
+                                            <i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="Only transient failures are retried: a timeout or a server error. The count includes the first attempt."></i>
+                                        </div>
+                                        <div class="mt-2 mb-3 d-flex align-items-center">
+                                            <label for="upload_retry_backoff_seconds" class="form-label me-2 mb-0">Wait before the first retry for</label>
+                                            <input type="number" class="form-control form-control-sm text-center d-inline-block me-2 input-monospace"
+                                                id="upload_retry_backoff_seconds" name="upload_retry_backoff_seconds" min="0" max="60" step="0.5" value="1" style="width: 60px;" required />
+                                            <span class="text-body">seconds, doubling each retry</span>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
                             <!-- Notifications settings -->
                             <div class="row mb-3">
                                 <div class="col">

--- a/tests/test_kometa_saver_retry.py
+++ b/tests/test_kometa_saver_retry.py
@@ -1,0 +1,88 @@
+"""Tests that saving artwork to the Kometa asset directory retries a transient download failure,
+the same as a direct Plex upload does.
+"""
+
+import requests
+
+from kometa.kometa_saver import KometaSaver
+from models.options import Options
+
+
+class _FakeResponse:
+    def __init__(self, status_code=200, content_type="image/jpeg", body=b"fake-image-bytes"):
+        self.status_code = status_code
+        self.headers = {"Content-Type": content_type}
+        self._body = body
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.exceptions.HTTPError(f"{self.status_code} error", response=self)
+
+    def iter_content(self, chunk_size):
+        yield self._body
+
+
+def _saver(tmp_path, retry_attempts=3):
+    saver = KometaSaver("Poster", "Movies")
+    saver.set_artwork({"id": 123, "url": "https://theposterdb.com/api/assets/123", "source": "theposterdb"})
+    saver.set_description("The Dark Knight")
+    saver.set_options(Options())
+    saver.dest_dir = str(tmp_path)
+    saver.dest_file_name = "poster"
+    saver.dest_file_ext = ".jpg"
+    saver.retry_attempts = retry_attempts
+    saver.retry_backoff = 1
+    return saver
+
+
+def test_transient_failure_that_recovers_is_saved_and_not_reported_as_an_error(tmp_path, monkeypatch):
+    monkeypatch.setattr("kometa.kometa_saver.time.sleep", lambda *a: None)
+    calls = {"n": 0}
+
+    def flaky_get(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise requests.exceptions.ConnectionError("dropped")
+        return _FakeResponse()
+
+    monkeypatch.setattr("kometa.kometa_saver.requests.get", flaky_get)
+
+    result = _saver(tmp_path).save_to_kometa()
+
+    assert result.startswith("✅")
+    assert calls["n"] == 3
+    assert (tmp_path / "poster.jpg").exists()
+
+
+def test_exhausted_retries_are_reported_as_an_error_with_attempt_count(tmp_path, monkeypatch):
+    monkeypatch.setattr("kometa.kometa_saver.time.sleep", lambda *a: None)
+    calls = {"n": 0}
+
+    def always_503(*args, **kwargs):
+        calls["n"] += 1
+        return _FakeResponse(status_code=503)
+
+    monkeypatch.setattr("kometa.kometa_saver.requests.get", always_503)
+
+    result = _saver(tmp_path, retry_attempts=3).save_to_kometa()
+
+    assert result.startswith("❌")
+    assert calls["n"] == 3
+    assert "after 3 attempt(s)" in result
+
+
+def test_404_is_not_retried(tmp_path, monkeypatch):
+    monkeypatch.setattr("kometa.kometa_saver.time.sleep", lambda *a: None)
+    calls = {"n": 0}
+
+    def always_404(*args, **kwargs):
+        calls["n"] += 1
+        return _FakeResponse(status_code=404)
+
+    monkeypatch.setattr("kometa.kometa_saver.requests.get", always_404)
+
+    result = _saver(tmp_path, retry_attempts=3).save_to_kometa()
+
+    assert result.startswith("❌")
+    assert calls["n"] == 1
+    assert "attempt(s)" not in result

--- a/tests/test_plex_connector_timeout.py
+++ b/tests/test_plex_connector_timeout.py
@@ -1,0 +1,39 @@
+"""Tests that PlexConnector.connect() uses the configurable connect timeout, and falls back to
+today's hardcoded default when no config has been loaded yet.
+"""
+
+from core import globals
+from plex.plex_connector import PlexConnector
+
+
+class _FakePlexServer:
+    """Stands in for plexapi.server.PlexServer, recording the timeout it was constructed with."""
+
+    last_timeout = None
+
+    def __init__(self, base_url, token, timeout=None):
+        _FakePlexServer.last_timeout = timeout
+
+
+def test_connect_uses_the_configured_timeout(monkeypatch):
+    monkeypatch.setattr("plex.plex_connector.PlexServer", _FakePlexServer)
+
+    class _FakeConfig:
+        plex_connect_timeout = 42
+
+    monkeypatch.setattr(globals, "config", _FakeConfig())
+
+    connector = PlexConnector("http://plex.example:32400", "token")
+    connector.connect()
+
+    assert _FakePlexServer.last_timeout == 42
+
+
+def test_connect_falls_back_to_the_default_timeout_when_config_is_unset(monkeypatch):
+    monkeypatch.setattr("plex.plex_connector.PlexServer", _FakePlexServer)
+    monkeypatch.setattr(globals, "config", None)
+
+    connector = PlexConnector("http://plex.example:32400", "token")
+    connector.connect()
+
+    assert _FakePlexServer.last_timeout == 10

--- a/tests/test_run_counters.py
+++ b/tests/test_run_counters.py
@@ -30,3 +30,31 @@ def test_locked_results_are_counted_and_successes_still_are():
 
     assert locked[0] == 2
     assert success[0] == 1
+
+
+def test_failed_counter_increments():
+    failed = [0]
+    callbacks = ProcessingCallbacks(failed_counter=failed)
+    callbacks.failed(1)
+    callbacks.failed(2)
+    assert failed[0] == 3
+
+
+def test_failed_is_a_no_op_without_a_counter():
+    ProcessingCallbacks().failed(1)   # must not raise
+
+
+def test_failed_uploads_are_counted_and_do_not_count_as_success():
+    # An upload that exhausted its retries returns a ❌ result - it must be counted as a failure
+    # and must not also be counted as a success.
+    success, failed = [0], [0]
+    callbacks = ProcessingCallbacks(success_counter=success, failed_counter=failed)
+    processor = ArtworkProcessor(plex=None, callbacks=callbacks)
+
+    processor._process_single_artwork({}, lambda artwork: [
+        "✅ A Movie | Poster updated in Movies",
+        "❌ B Movie | Failed to update Poster in Movies after 3 attempt(s): timed out",
+    ])
+
+    assert success[0] == 1
+    assert failed[0] == 1

--- a/tests/test_upload_retry.py
+++ b/tests/test_upload_retry.py
@@ -1,0 +1,212 @@
+"""Tests for retrying a transient upload failure with backoff.
+
+A timeout, a dropped connection, or a 5xx from Plex is worth trying again - that's the exact
+failure upstream issue #51 reported ("Uploading gives Read timed out error, but still works,
+albeit very slowly"). A 401 or a 404 never is, so it must fail on the first attempt rather than
+burn the retry budget. An item that eventually succeeds must read back as a normal success, not as
+an error - only one that exhausts its retries counts as an error, and it must say how many
+attempts it had.
+"""
+
+import pytest
+import requests
+import plexapi.exceptions
+
+from core.config import Config
+from core.retry import is_transient_error, call_with_retry
+from models.options import Options
+from plex.plex_uploader import PlexUploader
+from utils import utils
+
+
+def test_config_defaults_match_todays_hardcoded_timeouts(tmp_path):
+    # Nothing changes for anyone who doesn't touch these settings: the defaults must match the
+    # values that were hardcoded before they became configurable.
+    config = Config(config_path=str(tmp_path / "config.json"))
+    assert config.plex_connect_timeout == 10
+    assert config.plex_test_connection_timeout == 5
+    assert config.kometa_download_timeout == 5
+    assert config.upload_retry_attempts == 3
+    assert config.upload_retry_backoff_seconds == 1
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    # Retries wait between attempts; skip the wait so the tests run instantly.
+    monkeypatch.setattr("core.retry.time.sleep", lambda *a: None)
+    monkeypatch.setattr("plex.plex_uploader.time.sleep", lambda *a: None)
+
+
+# ---------------------- is_transient_error ----------------------
+
+def test_timeout_and_connection_error_are_transient():
+    assert is_transient_error(requests.exceptions.Timeout())
+    assert is_transient_error(requests.exceptions.ConnectionError())
+
+
+def test_5xx_http_error_is_transient():
+    response = requests.Response()
+    response.status_code = 503
+    assert is_transient_error(requests.exceptions.HTTPError(response=response))
+
+
+def test_401_and_404_are_not_transient():
+    response_401 = requests.Response()
+    response_401.status_code = 401
+    response_404 = requests.Response()
+    response_404.status_code = 404
+    assert not is_transient_error(requests.exceptions.HTTPError(response=response_401))
+    assert not is_transient_error(requests.exceptions.HTTPError(response=response_404))
+    assert not is_transient_error(plexapi.exceptions.Unauthorized("(401) Unauthorized; ..."))
+    assert not is_transient_error(plexapi.exceptions.BadRequest("(404) Not Found; ..."))
+
+
+def test_http_error_without_a_response_is_not_transient():
+    # raise_for_status() always attaches a response, but is_transient_error() must not crash if
+    # something else raises an HTTPError bare.
+    assert not is_transient_error(requests.exceptions.HTTPError("no response attached"))
+
+
+def test_5xx_plexapi_bad_request_is_transient():
+    assert is_transient_error(plexapi.exceptions.BadRequest("(500) Internal Server Error; ..."))
+
+
+def test_unrelated_error_is_not_transient():
+    assert not is_transient_error(RuntimeError("boom"))
+
+
+# ---------------------- call_with_retry ----------------------
+
+def test_succeeds_first_try_without_retrying():
+    result, attempts = call_with_retry(lambda: "ok", attempts=3, backoff=1)
+    assert result == "ok"
+    assert attempts == 1
+
+
+def test_retries_a_transient_failure_then_succeeds():
+    calls = {"n": 0}
+
+    def flaky():
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise requests.exceptions.Timeout("slow")
+        return "ok"
+
+    result, attempts = call_with_retry(flaky, attempts=3, backoff=1)
+    assert result == "ok"
+    assert attempts == 3
+
+
+def test_does_not_retry_a_non_transient_failure():
+    calls = {"n": 0}
+
+    def unauthorized():
+        calls["n"] += 1
+        raise plexapi.exceptions.Unauthorized("(401) Unauthorized; ...")
+
+    with pytest.raises(plexapi.exceptions.Unauthorized) as excinfo:
+        call_with_retry(unauthorized, attempts=3, backoff=1)
+    assert calls["n"] == 1
+    assert excinfo.value.attempts == 1
+
+
+def test_raises_after_exhausting_attempts():
+    calls = {"n": 0}
+
+    def always_times_out():
+        calls["n"] += 1
+        raise requests.exceptions.Timeout("slow")
+
+    with pytest.raises(requests.exceptions.Timeout) as excinfo:
+        call_with_retry(always_times_out, attempts=3, backoff=1)
+    assert calls["n"] == 3
+    assert excinfo.value.attempts == 3
+
+
+# ---------------------- PlexUploader.upload_to_plex integration ----------------------
+
+ASSETS = "https://theposterdb.com/api/assets"
+
+
+def _url(asset_id):
+    return f"{ASSETS}/{asset_id}"
+
+
+def _label(prefix, asset_id):
+    return prefix + utils.calculate_md5(_url(asset_id))
+
+
+class _Field:
+    def __init__(self, name, locked):
+        self.name = name
+        self.locked = locked
+
+
+class _Target:
+    """Minimal stand-in for a plexapi Movie whose uploadPoster fails a set number of times
+       before succeeding, or fails every time."""
+
+    def __init__(self, labels=(), fail_times=0, fail_exception=None):
+        self.labels = list(labels)
+        self.fields = [_Field("thumb", False)]
+        self.librarySectionTitle = "Movies"
+        self.uploaded = []
+        self.fail_times = fail_times
+        self.fail_exception = fail_exception or requests.exceptions.Timeout("slow")
+        self.calls = 0
+
+    def uploadPoster(self, url=None, filepath=None):
+        self.calls += 1
+        if self.calls <= self.fail_times:
+            raise self.fail_exception
+        self.uploaded.append(url or filepath)
+
+    def addLabel(self, label):
+        self.labels.append(str(label))
+
+    def removeLabel(self, label, *args):
+        self.labels = [existing for existing in self.labels if str(existing) != str(label)]
+
+    def reload(self):
+        pass
+
+
+def _uploader(target, candidate_id, retry_attempts=3):
+    uploader = PlexUploader(target, "Poster", "PID:")
+    uploader.set_options(Options())
+    uploader.set_artwork({"id": candidate_id, "url": _url(candidate_id), "source": "theposterdb"})
+    uploader.set_description("The Dark Knight")
+    uploader.track_artwork_ids = True
+    uploader.retry_attempts = retry_attempts
+    uploader.retry_backoff = 1
+    return uploader
+
+
+def test_transient_failure_that_recovers_is_not_reported_as_an_error():
+    target = _Target(fail_times=2)  # fails twice, succeeds on the third attempt
+
+    result = _uploader(target, 670744).upload_to_plex()
+
+    assert result.startswith("✅")
+    assert target.calls == 3
+    assert target.uploaded == [_url(670744)]
+
+
+def test_exhausted_retries_are_reported_as_an_error_with_attempt_count():
+    target = _Target(fail_times=99)  # never succeeds
+
+    result = _uploader(target, 670744, retry_attempts=3).upload_to_plex()
+
+    assert result.startswith("❌")
+    assert target.calls == 3
+    assert "after 3 attempt(s)" in result
+
+
+def test_non_transient_failure_is_not_retried():
+    target = _Target(fail_times=99, fail_exception=RuntimeError("Plex upload failed"))
+
+    result = _uploader(target, 670744, retry_attempts=3).upload_to_plex()
+
+    assert result.startswith("❌")
+    assert target.calls == 1
+    assert "attempt(s)" not in result

--- a/web_routes.py
+++ b/web_routes.py
@@ -438,7 +438,7 @@ def setup_socket_handlers(
         token = data.get("token", "")
 
         try:
-            plex_server = PlexServer(url, token, timeout=5)
+            plex_server = PlexServer(url, token, timeout=globals.config.plex_test_connection_timeout)
             debug_me(f"Successfully connected to Plex server at '{url}'")
         except Exception as e:
             debug_me(f"Failed to connect to Plex server at '{url}'")


### PR DESCRIPTION
An upload that fails on a timeout or a 5xx now retries with exponential backoff instead of failing the asset outright. The run summary reports any assets that still failed after their retries, so a flaky night is visible rather than silent.

Five values become config.json settings on a small Settings tab card. They are the Plex connect timeout, the connection test timeout, the Kometa download timeout, the retry count and the backoff. Every default matches today's hardcoded value. Nothing changes for existing installs until someone turns a knob.

Tests cover the retry decision (what counts as transient), the backoff sequence, and the timeout plumbing for the Plex connector and the Kometa saver.
