### PR TITLE
Keep a history of what each bulk import run did

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,4 @@ DEVELOPER_GUIDE.md
 docker-compose.yml
 config/.plex_client_id
 config/asset_index.db*
+config/run_history.json

--- a/artwork_uploader.py
+++ b/artwork_uploader.py
@@ -62,7 +62,12 @@ from services.run_history import (
     OUTCOME_PARTIAL,
     OUTCOME_STOPPED,
     OUTCOME_FAILED,
-    OUTCOME_SKIPPED
+    OUTCOME_SKIPPED,
+    RUN_TYPE_BULK,
+    RUN_TYPE_SCRAPE,
+    RUN_TYPE_UPLOAD,
+    TRIGGER_MANUAL,
+    TRIGGER_SCHEDULED
 )
 from services.artwork_processor import ArtworkProcessor
 from models.callbacks import ProcessingCallbacks
@@ -190,6 +195,19 @@ def process_scrape_url_from_web(instance: Instance, url: str) -> None:
 
     title = None
 
+    # A single scrape is a run like any other, so it gets the same counters a bulk import
+    # keeps and the same record in the history. The outcome starts as failed: every path
+    # out of here is recorded, including one that raises, and only a scrape that finished
+    # gets to say otherwise.
+    started_at = datetime.now(timezone.utc).isoformat()
+    label = url
+    outcome = OUTCOME_FAILED
+    success_counter = [0]
+    assets_processed = [0]
+    cached_counter = [0]
+    locked_counter = [0]
+    failed_counter = [0]
+
     try:
         # Check if the Plex TV and movie libraries are configured
         if globals.plex.tv_libraries is None or globals.plex.movie_libraries is None:
@@ -202,10 +220,23 @@ def process_scrape_url_from_web(instance: Instance, url: str) -> None:
 
         # Process the URL and options passed from the GUI or website
         parsed_line = parse_url_and_options(url)
+        label = parsed_line.url
         update_status(instance, f"Scraping URL '{parsed_line.url}'", color=StatusColor.INFO.value, sticky=True, spinner=True)
 
-        success_counter = [0]
-        title, author = scrape_and_upload(instance, parsed_line.url, parsed_line.options, False, success_counter)
+        title, author = scrape_and_upload(
+            instance, parsed_line.url, parsed_line.options, False, success_counter, assets_processed,
+            cached_counter=cached_counter, locked_counter=locked_counter, failed_counter=failed_counter
+        )
+
+        # Read the cancel flag here, not in the finally below - that's where it gets cleared
+        if globals.cancel_scrape:
+            outcome = OUTCOME_STOPPED
+        elif failed_counter[0]:
+            outcome = OUTCOME_PARTIAL
+        elif assets_processed[0]:
+            outcome = OUTCOME_SUCCESS
+        else:
+            outcome = OUTCOME_SKIPPED
 
         # Update the web ui bulk list with this URL and artwork (only if it's not already in the bulk list)
         if instance.mode == "web" and parsed_line.options.add_to_bulk and title:
@@ -215,6 +246,14 @@ def process_scrape_url_from_web(instance: Instance, url: str) -> None:
         update_status(instance, f"{scraping_error}", color=StatusColor.DANGER.value)
 
     finally:
+        # Record before the scrape_state broadcast below, not after: that broadcast is what
+        # makes the browser reload the history table, so a record written afterwards would
+        # miss its own refresh and only appear the next time somebody opened the tab.
+        RunHistory().add_run(
+            RUN_TYPE_SCRAPE, label, started_at, datetime.now(timezone.utc).isoformat(),
+            TRIGGER_MANUAL, outcome,
+            assets_processed[0], success_counter[0], cached_counter[0], locked_counter[0], failed_counter[0]
+        )
         globals.scrapes_running -= 1
         if globals.scrapes_running <= 0:
             globals.scrapes_running = 0
@@ -249,7 +288,10 @@ def run_bulk_import_scrape_in_thread(instance: Instance, web_list = None, filena
     if len(parsed_urls) == 0:
         update_status(instance, "No valid bulk import entries found. Check logs for details", color=StatusColor.DANGER.value, icon="x-circle")
         now = datetime.now(timezone.utc).isoformat()
-        RunHistory().add_run(filename if filename else "bulk_import.txt", now, now, scheduled, OUTCOME_SKIPPED)
+        RunHistory().add_run(
+            RUN_TYPE_BULK, filename if filename else "bulk_import.txt", now, now,
+            TRIGGER_SCHEDULED if scheduled else TRIGGER_MANUAL, OUTCOME_SKIPPED
+        )
         return
 
     # Pass the processing of the parsed URLs off to a thread
@@ -299,6 +341,7 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
     failed_counter = [0]  # Uploads that failed after exhausting their retries
     errors = 0
     started_at = datetime.now(timezone.utc).isoformat()
+    trigger = TRIGGER_SCHEDULED if scheduled else TRIGGER_MANUAL
 
     try:
 
@@ -306,7 +349,10 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
         if globals.plex.tv_libraries is None or globals.plex.movie_libraries is None:
             update_status(instance, "Plex setup incomplete. Please check the settings.", color=StatusColor.DANGER.value)
             now = datetime.now(timezone.utc).isoformat()
-            RunHistory().add_run(filename if filename else "bulk_import.txt", started_at, now, scheduled, OUTCOME_FAILED)
+            RunHistory().add_run(
+                RUN_TYPE_BULK, filename if filename else "bulk_import.txt",
+                started_at, now, trigger, OUTCOME_FAILED
+            )
             return
 
         globals.scrapes_running += 1
@@ -389,7 +435,7 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
             send_notification(instance, message)
 
         RunHistory().add_run(
-            display_filename, started_at, datetime.now(timezone.utc).isoformat(), scheduled, outcome,
+            RUN_TYPE_BULK, display_filename, started_at, datetime.now(timezone.utc).isoformat(), trigger, outcome,
             assets_processed[0], success_counter[0], cached_counter[0], locked_counter[0], errors
         )
 
@@ -397,7 +443,8 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
         notify_web(instance, "progress_bar", { "percent": 100, "bar_type": "bulk" })
         update_status(instance, f"Error during bulk import: {bulk_import_exception}", color=StatusColor.DANGER.value)
         RunHistory().add_run(
-            filename if filename else "bulk_import.txt", started_at, datetime.now(timezone.utc).isoformat(), scheduled, OUTCOME_FAILED,
+            RUN_TYPE_BULK, filename if filename else "bulk_import.txt",
+            started_at, datetime.now(timezone.utc).isoformat(), trigger, OUTCOME_FAILED,
             assets_processed[0], success_counter[0], cached_counter[0], locked_counter[0], errors
         )
 
@@ -503,24 +550,54 @@ def process_uploaded_artwork(instance: Instance, file_list, skipped, zip_title, 
     def debug_callback(message: str, context: str = None):
         debug_me(message, context)
 
+    success_counter = [0]
+    assets_processed = [0]
+    locked_counter = [0]
+    failed_counter = [0]
+
     callbacks = ProcessingCallbacks(
         on_status_update=status_callback,
         on_log_update=log_callback,
         on_progress_update=progress_callback,
-        on_debug=debug_callback
+        on_debug=debug_callback,
+        success_counter=success_counter,
+        assets_processed=assets_processed,
+        locked_counter=locked_counter,
+        failed_counter=failed_counter
     )
 
     # Use the service to do the actual work
     opts = Options(
-        filters=filters, 
-        year=int(plex_year) if plex_year else None, 
-        temp=True if "temp" in options else False, 
-        stage=True if "stage" in options else False, 
+        filters=filters,
+        year=int(plex_year) if plex_year else None,
+        temp=True if "temp" in options else False,
+        stage=True if "stage" in options else False,
         force=True if "force" in options else False,
         skip_locked=True if "skip-locked" in options else False
     )
     processor = ArtworkProcessor(globals.plex, callbacks)
-    processor.process_uploaded_files(file_list, skipped, zip_title, zip_author, zip_source, opts, override_title=plex_title)
+
+    # An uploaded ZIP is a run too, so it lands in the history alongside the scrapes and
+    # the bulk imports. There is no cache crawl behind an upload, so cached stays at zero.
+    started_at = datetime.now(timezone.utc).isoformat()
+    label = plex_title or zip_title or "Uploaded artwork"
+    outcome = OUTCOME_FAILED
+    try:
+        processor.process_uploaded_files(file_list, skipped, zip_title, zip_author, zip_source, opts, override_title=plex_title)
+        if globals.cancel_scrape:
+            outcome = OUTCOME_STOPPED
+        elif failed_counter[0]:
+            outcome = OUTCOME_PARTIAL
+        elif assets_processed[0]:
+            outcome = OUTCOME_SUCCESS
+        else:
+            outcome = OUTCOME_SKIPPED
+    finally:
+        RunHistory().add_run(
+            RUN_TYPE_UPLOAD, label, started_at, datetime.now(timezone.utc).isoformat(),
+            TRIGGER_MANUAL, outcome,
+            assets_processed[0], success_counter[0], 0, locked_counter[0], failed_counter[0]
+        )
 
 
 # * Bulk import file I/O functions ---
@@ -709,20 +786,20 @@ def process_bulk_file_on_schedule(instance: Instance, filename):
             else:
                 update_log(instance, f"⏭️ Scheduled bulk import of '{filename}' skipped • file is empty")
                 now = datetime.now(timezone.utc).isoformat()
-                RunHistory().add_run(filename, now, now, True, OUTCOME_SKIPPED)
+                RunHistory().add_run(RUN_TYPE_BULK, filename, now, now, TRIGGER_SCHEDULED, OUTCOME_SKIPPED)
         else:
             update_log(instance, f"🔴 Bulk file does not exist: {filename}")
             now = datetime.now(timezone.utc).isoformat()
-            RunHistory().add_run(filename, now, now, True, OUTCOME_FAILED)
+            RunHistory().add_run(RUN_TYPE_BULK, filename, now, now, TRIGGER_SCHEDULED, OUTCOME_FAILED)
             return
     except FileNotFoundError:
         update_log(instance, f"🔴 Scheduled bulk import failed due to missing file ({filename})")
         now = datetime.now(timezone.utc).isoformat()
-        RunHistory().add_run(filename, now, now, True, OUTCOME_FAILED)
+        RunHistory().add_run(RUN_TYPE_BULK, filename, now, now, TRIGGER_SCHEDULED, OUTCOME_FAILED)
     except Exception as e:
         update_log(instance, f"🔴 Scheduled bulk import unexpectedly failed ({str(e)})")
         now = datetime.now(timezone.utc).isoformat()
-        RunHistory().add_run(filename, now, now, True, OUTCOME_FAILED)
+        RunHistory().add_run(RUN_TYPE_BULK, filename, now, now, TRIGGER_SCHEDULED, OUTCOME_FAILED)
     finally:
         globals.scheduler_service.finish(filename)
 

--- a/artwork_uploader.py
+++ b/artwork_uploader.py
@@ -1,5 +1,5 @@
 import uuid, os, re, threading, sys, time
-from datetime import datetime
+from datetime import datetime, timezone
 from core import globals
 
 # plexapi builds its X-Plex-Client-Identifier from uuid.getnode(), which can be
@@ -54,7 +54,15 @@ from services import (
     ImageService,
     SchedulerService,
     WebhookService,
-    UtilityService
+    UtilityService,
+    RunHistory
+)
+from services.run_history import (
+    OUTCOME_SUCCESS,
+    OUTCOME_PARTIAL,
+    OUTCOME_STOPPED,
+    OUTCOME_FAILED,
+    OUTCOME_SKIPPED
 )
 from services.artwork_processor import ArtworkProcessor
 from models.callbacks import ProcessingCallbacks
@@ -240,6 +248,8 @@ def run_bulk_import_scrape_in_thread(instance: Instance, web_list = None, filena
                 continue                
     if len(parsed_urls) == 0:
         update_status(instance, "No valid bulk import entries found. Check logs for details", color=StatusColor.DANGER.value, icon="x-circle")
+        now = datetime.now(timezone.utc).isoformat()
+        RunHistory().add_run(filename if filename else "bulk_import.txt", now, now, scheduled, OUTCOME_SKIPPED)
         return
 
     # Pass the processing of the parsed URLs off to a thread
@@ -288,12 +298,15 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
     locked_counter = [0]
     failed_counter = [0]  # Uploads that failed after exhausting their retries
     errors = 0
+    started_at = datetime.now(timezone.utc).isoformat()
 
     try:
 
         # Check if plex setup returned valid values
         if globals.plex.tv_libraries is None or globals.plex.movie_libraries is None:
             update_status(instance, "Plex setup incomplete. Please check the settings.", color=StatusColor.DANGER.value)
+            now = datetime.now(timezone.utc).isoformat()
+            RunHistory().add_run(filename if filename else "bulk_import.txt", started_at, now, scheduled, OUTCOME_FAILED)
             return
 
         globals.scrapes_running += 1
@@ -355,6 +368,7 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
             )
             update_status(instance, message[2:], color=StatusColor.WARNING.value, sticky=False, spinner=False)
             notify_web(instance, "progress_bar", {"percent": 100, "bar_type": "bulk"})
+            outcome = OUTCOME_STOPPED
         else:
             message = (
                 ("🏁 " if total_errors == 0 else "⚠️ ")
@@ -368,14 +382,24 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
                 + (f" • {failed_counter[0]} asset(s) failed" if failed_counter[0] else "")
             )
             update_status(instance, message[2:], color=StatusColor.SUCCESS.value if total_errors == 0 else StatusColor.WARNING.value, sticky=False, spinner=False)
+            outcome = OUTCOME_SUCCESS if total_errors == 0 else OUTCOME_PARTIAL
         update_log(instance, message)
         if scheduled:
             debug_me(f"Sending notifications to {len(globals.config.apprise_urls)} notification service(s).")
             send_notification(instance, message)
 
+        RunHistory().add_run(
+            display_filename, started_at, datetime.now(timezone.utc).isoformat(), scheduled, outcome,
+            assets_processed[0], success_counter[0], cached_counter[0], locked_counter[0], errors
+        )
+
     except Exception as bulk_import_exception:
         notify_web(instance, "progress_bar", { "percent": 100, "bar_type": "bulk" })
         update_status(instance, f"Error during bulk import: {bulk_import_exception}", color=StatusColor.DANGER.value)
+        RunHistory().add_run(
+            filename if filename else "bulk_import.txt", started_at, datetime.now(timezone.utc).isoformat(), scheduled, OUTCOME_FAILED,
+            assets_processed[0], success_counter[0], cached_counter[0], locked_counter[0], errors
+        )
 
     finally:
         globals.scrapes_running -= 1
@@ -682,13 +706,23 @@ def process_bulk_file_on_schedule(instance: Instance, filename):
                 debug_me(f"Scheduled import started for instance {instance.id} mode {instance.mode}")
                 send_notification(instance, f"🕘 Scheduled bulk import started for '{filename}'")
                 run_bulk_import_scrape_in_thread(instance, content, filename, scheduled=True)
+            else:
+                update_log(instance, f"⏭️ Scheduled bulk import of '{filename}' skipped • file is empty")
+                now = datetime.now(timezone.utc).isoformat()
+                RunHistory().add_run(filename, now, now, True, OUTCOME_SKIPPED)
         else:
             update_log(instance, f"🔴 Bulk file does not exist: {filename}")
+            now = datetime.now(timezone.utc).isoformat()
+            RunHistory().add_run(filename, now, now, True, OUTCOME_FAILED)
             return
     except FileNotFoundError:
         update_log(instance, f"🔴 Scheduled bulk import failed due to missing file ({filename})")
+        now = datetime.now(timezone.utc).isoformat()
+        RunHistory().add_run(filename, now, now, True, OUTCOME_FAILED)
     except Exception as e:
         update_log(instance, f"🔴 Scheduled bulk import unexpectedly failed ({str(e)})")
+        now = datetime.now(timezone.utc).isoformat()
+        RunHistory().add_run(filename, now, now, True, OUTCOME_FAILED)
     finally:
         globals.scheduler_service.finish(filename)
 

--- a/core/constants.py
+++ b/core/constants.py
@@ -25,7 +25,8 @@ DEFAULT_BULK_IMPORTS_DIR = "bulk_imports"
 DEFAULT_BULK_IMPORT_FILE = "bulk_import.txt"
 RUN_HISTORY_PATH = "config/run_history.json"
 
-# Run history retention (whichever limit is hit first prunes the record)
+# Run history retention (whichever limit is hit first prunes the record).
+# The entry cap is per run type, so frequent webhook imports can't crowd out bulk runs.
 RUN_HISTORY_MAX_ENTRIES = 200
 RUN_HISTORY_MAX_AGE_DAYS = 90
 

--- a/core/constants.py
+++ b/core/constants.py
@@ -23,6 +23,11 @@ DEFAULT_CONFIG_PATH = "config.json"
 ASSET_INDEX_PATH = "config/asset_index.db"
 DEFAULT_BULK_IMPORTS_DIR = "bulk_imports"
 DEFAULT_BULK_IMPORT_FILE = "bulk_import.txt"
+RUN_HISTORY_PATH = "config/run_history.json"
+
+# Run history retention (whichever limit is hit first prunes the record)
+RUN_HISTORY_MAX_ENTRIES = 200
+RUN_HISTORY_MAX_AGE_DAYS = 90
 
 # Plex library defaults
 DEFAULT_TV_LIBRARY = ["TV Shows"]

--- a/models/callbacks.py
+++ b/models/callbacks.py
@@ -54,3 +54,20 @@ class ProcessingCallbacks:
     def failed(self, count: int):
         if self.failed_counter:
             self.failed_counter[0] += count
+
+    def record_result(self, result: str) -> Optional[str]:
+        """Count one upload result and say what it was.
+
+        The uploader and the Kometa saver both report what happened as a prefixed
+        string, so the prefixes are the only record of an item's fate. Every caller
+        that tallies a run reads them here, so they are written down once."""
+        if result.startswith('✅') or result.startswith('♻️'):
+            self.success(1)
+            return "success"
+        if result.startswith('🔒'):
+            self.locked(1)
+            return "locked"
+        if result.startswith('❌'):
+            self.failed(1)
+            return "failed"
+        return None

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -12,8 +12,8 @@ from .utility_service import UtilityService
 from .authentication_service import AuthenticationService
 from .notify_service import NotifyService
 from .asset_index import AssetIndex
-from .webhook_service import WebhookService
 from .run_history import RunHistory
+from .webhook_service import WebhookService  # imports run_history, so it comes after it
 
 __all__ = [
     'BulkFileService',

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -13,6 +13,7 @@ from .authentication_service import AuthenticationService
 from .notify_service import NotifyService
 from .asset_index import AssetIndex
 from .webhook_service import WebhookService
+from .run_history import RunHistory
 
 __all__ = [
     'BulkFileService',
@@ -22,5 +23,6 @@ __all__ = [
     'AuthenticationService',
     'NotifyService',
     'AssetIndex',
-    'WebhookService'
+    'WebhookService',
+    'RunHistory'
 ]

--- a/services/artwork_processor.py
+++ b/services/artwork_processor.py
@@ -187,6 +187,7 @@ class ArtworkProcessor:
                     self.callbacks.failed(1)
 
             # Log the result
+                self.callbacks.record_result(result)
                 self.callbacks.log(result)
 
         except CollectionNotFound as e:
@@ -321,15 +322,11 @@ class ArtworkProcessor:
                     results = process_func(artwork)
 
                     for result in results:
-                        # Track successful uploads (those starting with ✅ or ♻️)
-                        if result.startswith('✅') or result.startswith('♻️'):
+                        counted = self.callbacks.record_result(result)
+                        if counted == "success":
                             success_counter += 1
-
-                        # Track uploads that failed after exhausting their retries
-                        elif result.startswith('❌'):
+                        elif counted == "failed":
                             failed_counter += 1
-
-                        # Log the result
                         self.callbacks.log(result)
 
                 except CollectionNotFound as e:
@@ -361,6 +358,7 @@ class ArtworkProcessor:
             except OSError:
                 pass
         # Final progress update
+        self.callbacks.assets(count=processed_files)
         failed_note = f" • {failed_counter} asset(s) failed" if failed_counter else ""
         if globals.cancel_scrape:
             self.callbacks.progress(1, 1, "", "main")

--- a/services/run_history.py
+++ b/services/run_history.py
@@ -1,0 +1,119 @@
+"""
+Persistent record of bulk import runs.
+
+A small JSON file (in the config directory) that keeps one entry per run of a bulk
+import file, whether that run was triggered manually from the web UI or by a schedule.
+Container logs rotate; this is what answers "did last night's run actually do
+anything" without needing them.
+"""
+
+import json
+import os
+import threading
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+from core.constants import RUN_HISTORY_PATH, RUN_HISTORY_MAX_ENTRIES, RUN_HISTORY_MAX_AGE_DAYS
+
+# Recorded outcomes for a run
+OUTCOME_SUCCESS = "success"
+OUTCOME_PARTIAL = "partial"    # completed, but one or more URLs errored
+OUTCOME_STOPPED = "stopped"    # cancelled by the user
+OUTCOME_FAILED = "failed"      # an exception aborted the run
+OUTCOME_SKIPPED = "skipped"    # nothing to do (e.g. no valid entries in the file)
+
+# A new RunHistory() is created per call rather than shared, so the read-modify-write in
+# add_run needs a lock keyed by file path (not an instance lock) to stop two runs finishing
+# at the same time - e.g. a schedule firing while a manual run is still in progress - from
+# each loading the same list and one overwriting the other's record.
+_write_locks: Dict[str, threading.Lock] = defaultdict(threading.Lock)
+
+
+class RunHistory:
+    """
+    Append-only log of bulk import runs, capped by both count and age so it cannot
+    grow without limit. Readers and writers each open the file for the duration of
+    the call, matching the short-lived-connection approach used by AssetIndex; writes
+    are serialized per path so two runs finishing at once can't clobber each other.
+    """
+
+    def __init__(
+        self,
+        path: str = RUN_HISTORY_PATH,
+        max_entries: int = RUN_HISTORY_MAX_ENTRIES,
+        max_age_days: int = RUN_HISTORY_MAX_AGE_DAYS,
+    ) -> None:
+        self.path = path
+        self.max_entries = max_entries
+        self.max_age_days = max_age_days
+
+    def _load(self) -> List[Dict[str, Any]]:
+        if not os.path.isfile(self.path):
+            return []
+        try:
+            with open(self.path, "r", encoding="utf-8") as history_file:
+                runs = json.load(history_file)
+            return runs if isinstance(runs, list) else []
+        except (OSError, json.JSONDecodeError) as e:
+            # Lazily imported: utils.notifications pulls in the services package, and this
+            # module is imported from services/__init__.py, so a top-level import would cycle.
+            from utils.notifications import debug_me
+            debug_me(f"Run history at '{self.path}' could not be read, starting fresh: {e}")
+            return []
+
+    def _save(self, runs: List[Dict[str, Any]]) -> None:
+        try:
+            directory = os.path.dirname(self.path)
+            if directory:
+                os.makedirs(directory, exist_ok=True)
+            with open(self.path, "w", encoding="utf-8") as history_file:
+                json.dump(runs, history_file, indent=4)
+        except OSError as e:
+            from utils.notifications import debug_me
+            debug_me(f"Run history could not be saved to '{self.path}': {e}")
+
+    def _prune(self, runs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        if self.max_age_days:
+            cutoff = (datetime.now(timezone.utc) - timedelta(days=self.max_age_days)).isoformat()
+            runs = [run for run in runs if run.get("started_at", "") >= cutoff]
+        if self.max_entries and len(runs) > self.max_entries:
+            runs = runs[-self.max_entries:]
+        return runs
+
+    def add_run(
+        self,
+        filename: str,
+        started_at: str,
+        ended_at: str,
+        scheduled: bool,
+        outcome: str,
+        assets_processed: int = 0,
+        success_count: int = 0,
+        cached_count: int = 0,
+        locked_count: int = 0,
+        error_count: int = 0,
+    ) -> None:
+        """Append a record for one completed (or skipped/failed) run."""
+        with _write_locks[os.path.abspath(self.path)]:
+            runs = self._load()
+            runs.append({
+                "filename": filename,
+                "started_at": started_at,
+                "ended_at": ended_at,
+                "scheduled": scheduled,
+                "outcome": outcome,
+                "assets_processed": assets_processed,
+                "success_count": success_count,
+                "cached_count": cached_count,
+                "locked_count": locked_count,
+                "error_count": error_count,
+            })
+            self._save(self._prune(runs))
+
+    def get_runs(self, limit: Optional[int] = None) -> List[Dict[str, Any]]:
+        """Most recent runs first, optionally capped to `limit`."""
+        runs = list(reversed(self._load()))
+        if limit:
+            runs = runs[:limit]
+        return runs

--- a/services/run_history.py
+++ b/services/run_history.py
@@ -1,10 +1,11 @@
 """
-Persistent record of bulk import runs.
+Persistent record of what the tool has done.
 
-A small JSON file (in the config directory) that keeps one entry per run of a bulk
-import file, whether that run was triggered manually from the web UI or by a schedule.
-Container logs rotate; this is what answers "did last night's run actually do
-anything" without needing them.
+A small JSON file (in the config directory) that keeps one entry per run, whatever
+started it: a bulk import file run manually or by a schedule, a single URL scraped
+from the main tab, an artwork ZIP uploaded through the browser, or a Radarr/Sonarr
+import applied by the webhook. Container logs rotate; this is what answers "did last
+night's run actually do anything" without needing them.
 """
 
 import json
@@ -16,26 +17,40 @@ from typing import Any, Dict, List, Optional
 
 from core.constants import RUN_HISTORY_PATH, RUN_HISTORY_MAX_ENTRIES, RUN_HISTORY_MAX_AGE_DAYS
 
+# What kind of run produced the record
+RUN_TYPE_BULK = "bulk"          # a bulk import file, manual or scheduled
+RUN_TYPE_SCRAPE = "scrape"      # a single URL scraped from the main tab
+RUN_TYPE_UPLOAD = "upload"      # an artwork ZIP uploaded through the browser
+RUN_TYPE_WEBHOOK = "webhook"    # a Radarr/Sonarr import applied from the cache
+
+RUN_TYPES = (RUN_TYPE_BULK, RUN_TYPE_SCRAPE, RUN_TYPE_UPLOAD, RUN_TYPE_WEBHOOK)
+
+# What started the run
+TRIGGER_MANUAL = "manual"
+TRIGGER_SCHEDULED = "scheduled"
+TRIGGER_RADARR = "radarr"
+TRIGGER_SONARR = "sonarr"
+
 # Recorded outcomes for a run
 OUTCOME_SUCCESS = "success"
-OUTCOME_PARTIAL = "partial"    # completed, but one or more URLs errored
+OUTCOME_PARTIAL = "partial"    # completed, but one or more items errored
 OUTCOME_STOPPED = "stopped"    # cancelled by the user
 OUTCOME_FAILED = "failed"      # an exception aborted the run
 OUTCOME_SKIPPED = "skipped"    # nothing to do (e.g. no valid entries in the file)
 
 # A new RunHistory() is created per call rather than shared, so the read-modify-write in
 # add_run needs a lock keyed by file path (not an instance lock) to stop two runs finishing
-# at the same time - e.g. a schedule firing while a manual run is still in progress - from
+# at the same time - e.g. a schedule firing while a webhook applies a new import - from
 # each loading the same list and one overwriting the other's record.
 _write_locks: Dict[str, threading.Lock] = defaultdict(threading.Lock)
 
 
 class RunHistory:
     """
-    Append-only log of bulk import runs, capped by both count and age so it cannot
-    grow without limit. Readers and writers each open the file for the duration of
-    the call, matching the short-lived-connection approach used by AssetIndex; writes
-    are serialized per path so two runs finishing at once can't clobber each other.
+    Append-only log of runs, capped by both count and age so it cannot grow without
+    limit. Readers and writers each open the file for the duration of the call, matching
+    the short-lived-connection approach used by AssetIndex; writes are serialized per path
+    so two runs finishing at once can't clobber each other.
     """
 
     def __init__(
@@ -77,16 +92,28 @@ class RunHistory:
         if self.max_age_days:
             cutoff = (datetime.now(timezone.utc) - timedelta(days=self.max_age_days)).isoformat()
             runs = [run for run in runs if run.get("started_at", "") >= cutoff]
-        if self.max_entries and len(runs) > self.max_entries:
-            runs = runs[-self.max_entries:]
+        if self.max_entries:
+            # The count cap is per run type. A busy library can take dozens of webhook
+            # imports a day, and a single shared cap would push a nightly bulk import out
+            # of the history within the week - the run people most want to look back at.
+            kept_per_type: Dict[str, int] = defaultdict(int)
+            kept: List[Dict[str, Any]] = []
+            for run in reversed(runs):
+                run_type = run.get("run_type", RUN_TYPE_BULK)
+                if kept_per_type[run_type] >= self.max_entries:
+                    continue
+                kept_per_type[run_type] += 1
+                kept.append(run)
+            runs = list(reversed(kept))
         return runs
 
     def add_run(
         self,
-        filename: str,
+        run_type: str,
+        label: str,
         started_at: str,
         ended_at: str,
-        scheduled: bool,
+        trigger: str,
         outcome: str,
         assets_processed: int = 0,
         success_count: int = 0,
@@ -94,14 +121,18 @@ class RunHistory:
         locked_count: int = 0,
         error_count: int = 0,
     ) -> None:
-        """Append a record for one completed (or skipped/failed) run."""
+        """Append a record for one completed (or skipped/failed) run.
+
+        `label` is what the run was about: the bulk file name, the scraped URL, the
+        uploaded ZIP name, or the title the webhook imported."""
         with _write_locks[os.path.abspath(self.path)]:
             runs = self._load()
             runs.append({
-                "filename": filename,
+                "run_type": run_type,
+                "label": label,
                 "started_at": started_at,
                 "ended_at": ended_at,
-                "scheduled": scheduled,
+                "trigger": trigger,
                 "outcome": outcome,
                 "assets_processed": assets_processed,
                 "success_count": success_count,
@@ -111,9 +142,28 @@ class RunHistory:
             })
             self._save(self._prune(runs))
 
-    def get_runs(self, limit: Optional[int] = None) -> List[Dict[str, Any]]:
-        """Most recent runs first, optionally capped to `limit`."""
-        runs = list(reversed(self._load()))
+    @staticmethod
+    def _normalise(run: Dict[str, Any]) -> Dict[str, Any]:
+        """Fill in the fields a record written by an older version doesn't carry, so an
+        existing history file keeps rendering. Those records were all bulk imports and
+        held the file name as `filename` and the trigger as a `scheduled` boolean."""
+        normalised = dict(run)
+        if not normalised.get("run_type"):
+            normalised["run_type"] = RUN_TYPE_BULK
+        if not normalised.get("label"):
+            normalised["label"] = run.get("filename", "")
+        if not normalised.get("trigger"):
+            normalised["trigger"] = TRIGGER_SCHEDULED if run.get("scheduled") else TRIGGER_MANUAL
+        return normalised
+
+    def get_runs(self, limit: Optional[int] = None, run_type: Optional[str] = None) -> List[Dict[str, Any]]:
+        """Most recent runs first, optionally narrowed to one run type and capped to `limit`.
+
+        The type filter is applied before the limit, so asking for bulk imports returns the
+        last `limit` bulk imports rather than the bulk imports among the last `limit` runs."""
+        runs = [self._normalise(run) for run in reversed(self._load())]
+        if run_type:
+            runs = [run for run in runs if run["run_type"] == run_type]
         if limit:
             runs = runs[:limit]
         return runs

--- a/services/webhook_service.py
+++ b/services/webhook_service.py
@@ -11,15 +11,30 @@ code a normal scrape uses, so the webhook inherits all of it without re-implemen
 import threading
 import time
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import FrozenSet, List, Optional, Union
 
 from core import globals
 from core.constants import WEBHOOK_RETRY_DELAYS
 from core.enums import ScraperSource
 from core.exceptions import MovieNotFound, ShowNotFound
+from models.callbacks import ProcessingCallbacks
 from models.instance import Instance
 from models.options import Options
 from services.asset_index import AssetIndex, normalize_title
+from services.run_history import (
+    RunHistory,
+    RUN_TYPE_WEBHOOK,
+    TRIGGER_RADARR,
+    TRIGGER_SONARR,
+    OUTCOME_SUCCESS,
+    OUTCOME_PARTIAL,
+    OUTCOME_FAILED,
+    OUTCOME_SKIPPED,
+)
+
+# The *arr app that sent the event, as the history records it
+_TRIGGER_BY_SOURCE = {"radarr": TRIGGER_RADARR, "sonarr": TRIGGER_SONARR}
 
 
 def _log(text: str) -> None:
@@ -111,11 +126,17 @@ class WebhookService:
                 _debug(f"Import for {event.label()} is already pending, ignoring the duplicate")
                 return
             self._inflight.add(key)
+        # One history record covers the whole event, retries included, so the run starts
+        # counting from the moment it was accepted and the tally survives every attempt.
+        started_at = datetime.now(timezone.utc).isoformat()
+        tally = ProcessingCallbacks(
+            success_counter=[0], assets_processed=[0], locked_counter=[0], failed_counter=[0]
+        )
         # Wait a configurable delay before the first attempt: the *arr apps fire the webhook the
         # moment they import a file, usually before Plex has scanned it in, so give Plex a head
         # start. If it is still not ready by then, the retry ladder takes over.
         delay = max(0, globals.config.webhook_apply_delay or 0)
-        timer = threading.Timer(delay, self._attempt, args=(event, key))
+        timer = threading.Timer(delay, self._attempt, args=(event, key, started_at, tally))
         timer.daemon = True
         timer.start()
 
@@ -128,19 +149,21 @@ class WebhookService:
         with self._lock:
             self._inflight.discard(key)
 
-    def _attempt(self, event: WebhookEvent, key, attempt: int = 0,
-                 artwork: Optional[List[dict]] = None) -> None:
+    def _attempt(self, event: WebhookEvent, key, started_at: str, tally: ProcessingCallbacks,
+                 attempt: int = 0, artwork: Optional[List[dict]] = None) -> None:
         # UploadProcessor pulls in the processors -> plex chain; import it here so the services
         # package does not drag that in at start-up (mirrors the app's own lazy-import pattern).
         from processors.upload_processor import UploadProcessor
+        outcome = OUTCOME_FAILED
         try:
             if artwork is None:
                 artwork = self._collect_artwork(event)
                 if not artwork:
                     _log(f"📥 Webhook | No cached artwork for '{event.label()}' from the configured users")
-                    self._release(key)
+                    self._finish(event, key, started_at, tally, OUTCOME_SKIPPED)
                     return
                 _log(f"📥 Webhook | {event.source.title()} import: {event.label()}")
+                tally.assets(len(artwork))
             globals.plex.connect()
             processor = UploadProcessor(globals.plex)
             processor.set_options(Options())
@@ -166,22 +189,58 @@ class WebhookService:
                         pending.append(item)
                     else:
                         for result in results:
+                            tally.record_result(result)
                             _log(result)
                 except (MovieNotFound, ShowNotFound):
                     pending.append(item)          # not in Plex yet, retry it
                 except Exception as error:
+                    tally.failed(1)
                     _log(f"❌ Webhook | {event.label()}: {error}")
             if pending and attempt < len(WEBHOOK_RETRY_DELAYS):
                 delay = WEBHOOK_RETRY_DELAYS[attempt]
                 _debug(f"{event.label()} not in Plex yet, retrying in {delay}s")
-                timer = threading.Timer(delay, self._attempt, args=(event, key, attempt + 1, pending))
+                timer = threading.Timer(
+                    delay, self._attempt, args=(event, key, started_at, tally, attempt + 1, pending)
+                )
                 timer.daemon = True
                 timer.start()
                 return                            # keep the in-flight key until the chain ends
             if pending:
                 _log(f"⚠️ Webhook | '{event.label()}' has not appeared in Plex, leaving it for the next scheduled run")
+                # Artwork still pending when the ladder runs out never got applied, so it counts
+                # against the run the same way an upload that exhausted its retries does.
+                tally.failed(len(pending))
+            if not tally.failed_counter[0]:
+                outcome = OUTCOME_SUCCESS
+            elif tally.success_counter[0]:
+                outcome = OUTCOME_PARTIAL
+            else:
+                outcome = OUTCOME_FAILED
         except Exception as error:
             _debug(f"Webhook apply failed for {event.label()}: {error}")
+            outcome = OUTCOME_FAILED
+        self._finish(event, key, started_at, tally, outcome)
+
+    def _finish(self, event: WebhookEvent, key, started_at: str,
+                tally: ProcessingCallbacks, outcome: str) -> None:
+        """Record the run and let the next event for this title through."""
+        try:
+            RunHistory().add_run(
+                RUN_TYPE_WEBHOOK, event.label(), started_at,
+                datetime.now(timezone.utc).isoformat(),
+                _TRIGGER_BY_SOURCE.get(event.source, event.source), outcome,
+                tally.assets_processed[0], tally.success_counter[0], 0,
+                tally.locked_counter[0], tally.failed_counter[0],
+            )
+            # Nothing else tells an open History tab that this happened. A scrape and a
+            # bulk import both end with a scrape_state broadcast the browser reacts to;
+            # an import applied in the background raises no such event.
+            from utils.notifications import notify_web
+            notify_web(Instance(broadcast=True), "run_history_updated", silent=True)
+        except Exception as error:
+            # A history write must never cost an in-flight key, which would deadlock every
+            # future import of this title behind the dedupe guard.
+            _debug(f"Could not record the webhook run for {event.label()}: {error}")
         self._release(key)
 
     def _collect_artwork(self, event: WebhookEvent) -> List[dict]:

--- a/static/web_interface.js
+++ b/static/web_interface.js
@@ -430,13 +430,17 @@ function scrapeState(running, type) {
             btnElement.querySelector("i").className = btnElement.querySelector("i").dataset.originalIcon || "bi bi-gear";
         }
 
-        if (type == "bulk") {
-            loadRunHistory();
-        }
+        // Every run kind lands in the history now, not just bulk imports
+        loadRunHistory();
     }
 }
 socket.on("scrape_state", (data) => {
     scrapeState(data.running, data.type)
+});
+
+// A webhook import finishes without a scrape_state change, so it says so itself
+socket.on("run_history_updated", () => {
+    loadRunHistory();
 });
 
 
@@ -1654,6 +1658,20 @@ const RUN_HISTORY_OUTCOME_LABELS = {
     skipped: { text: "Skipped", className: "text-muted" }
 };
 
+const RUN_HISTORY_TYPE_LABELS = {
+    bulk: "Bulk import",
+    scrape: "Scrape",
+    upload: "Upload",
+    webhook: "Webhook"
+};
+
+const RUN_HISTORY_TRIGGER_LABELS = {
+    manual: "Manual",
+    scheduled: "Scheduled",
+    radarr: "Radarr",
+    sonarr: "Sonarr"
+};
+
 function formatRunDuration(startedAt, endedAt) {
     const start = new Date(startedAt);
     const end = new Date(endedAt);
@@ -1663,9 +1681,19 @@ function formatRunDuration(startedAt, endedAt) {
     return minutes > 0 ? `${minutes}m ${remainder}s` : `${remainder}s`;
 }
 
+document.addEventListener("DOMContentLoaded", () => {
+    const typeFilter = document.getElementById("run_history_type");
+    if (typeFilter) {
+        typeFilter.addEventListener("change", loadRunHistory);
+    }
+});
+
 function loadRunHistory() {
 
-    socket.emit("load_run_history", { instance_id: instanceId });
+    const typeFilter = document.getElementById("run_history_type");
+    const runType = typeFilter ? typeFilter.value : "";
+
+    socket.emit("load_run_history", { instance_id: instanceId, run_type: runType });
 
     socket.once("load_run_history", (data) => {
         if (!validResponse(data)) { return; }
@@ -1678,9 +1706,9 @@ function loadRunHistory() {
         if (runs.length === 0) {
             const row = document.createElement("tr");
             const cell = document.createElement("td");
-            cell.colSpan = 10;
+            cell.colSpan = 11;
             cell.className = "text-muted";
-            cell.textContent = "No runs recorded yet.";
+            cell.textContent = runType ? "No runs of this type recorded yet." : "No runs recorded yet.";
             row.appendChild(cell);
             body.appendChild(row);
             return;
@@ -1692,8 +1720,9 @@ function loadRunHistory() {
 
             const cells = [
                 new Date(run.started_at).toLocaleString(),
-                run.filename,
-                run.scheduled ? "Scheduled" : "Manual",
+                RUN_HISTORY_TYPE_LABELS[run.run_type] || run.run_type,
+                run.label,
+                RUN_HISTORY_TRIGGER_LABELS[run.trigger] || run.trigger,
                 outcome.text,
                 run.assets_processed,
                 run.success_count,
@@ -1704,11 +1733,11 @@ function loadRunHistory() {
             ];
 
             // Indexes match the header row: detail columns collapse on narrow screens
-            const narrowHidden = [2, 4, 5, 6, 7, 9];
+            const narrowHidden = [3, 5, 6, 7, 8, 10];
             cells.forEach((value, index) => {
                 const cell = document.createElement("td");
                 cell.textContent = value;
-                if (index === 3) { cell.className = outcome.className; }
+                if (index === 4) { cell.className = outcome.className; }
                 if (narrowHidden.includes(index)) { cell.classList.add("d-none", "d-md-table-cell"); }
                 row.appendChild(cell);
             });

--- a/static/web_interface.js
+++ b/static/web_interface.js
@@ -429,6 +429,10 @@ function scrapeState(running, type) {
         if (btnElement) {
             btnElement.querySelector("i").className = btnElement.querySelector("i").dataset.originalIcon || "bi bi-gear";
         }
+
+        if (type == "bulk") {
+            loadRunHistory();
+        }
     }
 }
 socket.on("scrape_state", (data) => {
@@ -1338,6 +1342,7 @@ function updateConfigUI(config) {
     schedules = config.schedules;
     
     loadBulkFileList(); // For the switcher
+    loadRunHistory();
 };
 
 // Load configuration
@@ -1517,6 +1522,7 @@ if (scrapeUrlInput) {
 
 function configureTabs(afterSave = false) {
         document.getElementById('scraping-log-tab').classList.add("show");
+        document.getElementById('run-history-tab').classList.add("show");
         document.getElementById('about-tab').classList.add("show");
         if (config.base_url && config.token) {
             document.getElementById('bulk-import-tab').classList.add("show");
@@ -1635,6 +1641,77 @@ function loadBulkFileList() {
                 selectElement.appendChild(placeholder);
             }
         }
+    });
+}
+
+/* Loading the run history */
+
+const RUN_HISTORY_OUTCOME_LABELS = {
+    success: { text: "Completed", className: "text-success" },
+    partial: { text: "Completed with errors", className: "text-warning" },
+    stopped: { text: "Stopped", className: "text-warning" },
+    failed: { text: "Failed", className: "text-danger" },
+    skipped: { text: "Skipped", className: "text-muted" }
+};
+
+function formatRunDuration(startedAt, endedAt) {
+    const start = new Date(startedAt);
+    const end = new Date(endedAt);
+    const seconds = Math.max(0, Math.round((end - start) / 1000));
+    const minutes = Math.floor(seconds / 60);
+    const remainder = seconds % 60;
+    return minutes > 0 ? `${minutes}m ${remainder}s` : `${remainder}s`;
+}
+
+function loadRunHistory() {
+
+    socket.emit("load_run_history", { instance_id: instanceId });
+
+    socket.once("load_run_history", (data) => {
+        if (!validResponse(data)) { return; }
+
+        const body = document.getElementById("run_history_body");
+        body.innerHTML = "";
+
+        const runs = data.runs || [];
+
+        if (runs.length === 0) {
+            const row = document.createElement("tr");
+            const cell = document.createElement("td");
+            cell.colSpan = 10;
+            cell.className = "text-muted";
+            cell.textContent = "No runs recorded yet.";
+            row.appendChild(cell);
+            body.appendChild(row);
+            return;
+        }
+
+        runs.forEach((run) => {
+            const row = document.createElement("tr");
+            const outcome = RUN_HISTORY_OUTCOME_LABELS[run.outcome] || { text: run.outcome, className: "" };
+
+            const cells = [
+                new Date(run.started_at).toLocaleString(),
+                run.filename,
+                run.scheduled ? "Scheduled" : "Manual",
+                outcome.text,
+                run.assets_processed,
+                run.success_count,
+                run.cached_count,
+                run.locked_count,
+                run.error_count,
+                formatRunDuration(run.started_at, run.ended_at)
+            ];
+
+            cells.forEach((value, index) => {
+                const cell = document.createElement("td");
+                cell.textContent = value;
+                if (index === 3) { cell.className = outcome.className; }
+                row.appendChild(cell);
+            });
+
+            body.appendChild(row);
+        });
     });
 }
 

--- a/static/web_interface.js
+++ b/static/web_interface.js
@@ -1703,10 +1703,13 @@ function loadRunHistory() {
                 formatRunDuration(run.started_at, run.ended_at)
             ];
 
+            // Indexes match the header row: detail columns collapse on narrow screens
+            const narrowHidden = [2, 4, 5, 6, 7, 9];
             cells.forEach((value, index) => {
                 const cell = document.createElement("td");
                 cell.textContent = value;
                 if (index === 3) { cell.className = outcome.className; }
+                if (narrowHidden.includes(index)) { cell.classList.add("d-none", "d-md-table-cell"); }
                 row.appendChild(cell);
             });
 

--- a/templates/web_interface.html
+++ b/templates/web_interface.html
@@ -1182,14 +1182,14 @@
                             <tr>
                                 <th>Started</th>
                                 <th>File</th>
-                                <th>Trigger</th>
+                                <th class="d-none d-md-table-cell">Trigger</th>
                                 <th>Outcome</th>
-                                <th>Processed</th>
-                                <th>Updated</th>
-                                <th>Cached</th>
-                                <th>Locked</th>
+                                <th class="d-none d-md-table-cell">Processed</th>
+                                <th class="d-none d-md-table-cell">Updated</th>
+                                <th class="d-none d-md-table-cell">Cached</th>
+                                <th class="d-none d-md-table-cell">Locked</th>
                                 <th>Errors</th>
-                                <th>Duration</th>
+                                <th class="d-none d-md-table-cell">Duration</th>
                             </tr>
                         </thead>
                         <tbody id="run_history_body">

--- a/templates/web_interface.html
+++ b/templates/web_interface.html
@@ -116,7 +116,10 @@
 
             <a class="nav-link collapse" id="scraping-log-tab" data-bs-toggle="tab" data-bs-target="#scraping-log" type="button"
             role="tab" aria-controls="scraping-log" aria-selected="false"><span class="d-none d-sm-inline-block"></span><i class="bi bi-activity"></i>&ensp;Log</a>
-            
+
+            <a class="nav-link collapse" id="run-history-tab" data-bs-toggle="tab" data-bs-target="#run-history" type="button"
+            role="tab" aria-controls="run-history" aria-selected="false"><i class="bi bi-clock-history"></i>&ensp;History</a>
+
             <a class="nav-link collapse" id="about-tab" data-bs-toggle="tab" data-bs-target="#about" type="button"
             role="tab" aria-controls="about" aria-selected="false"><i class="bi bi-code-slash"></i>&ensp;About</a>
             
@@ -1168,6 +1171,31 @@
                             </li>
                         </ul>
                     </div>
+                </div>
+            </div>
+
+            <!-- Run History Tab -->
+            <div class="tab-pane fade" id="run-history" role="tabpanel" aria-labelledby="run-history-tab" tabindex="0">
+                <div class="mt-3 table-responsive">
+                    <table class="table table-sm align-middle">
+                        <thead>
+                            <tr>
+                                <th>Started</th>
+                                <th>File</th>
+                                <th>Trigger</th>
+                                <th>Outcome</th>
+                                <th>Processed</th>
+                                <th>Updated</th>
+                                <th>Cached</th>
+                                <th>Locked</th>
+                                <th>Errors</th>
+                                <th>Duration</th>
+                            </tr>
+                        </thead>
+                        <tbody id="run_history_body">
+                            <tr><td colspan="10" class="text-muted">No runs recorded yet.</td></tr>
+                        </tbody>
+                    </table>
                 </div>
             </div>
 

--- a/templates/web_interface.html
+++ b/templates/web_interface.html
@@ -1176,12 +1176,23 @@
 
             <!-- Run History Tab -->
             <div class="tab-pane fade" id="run-history" role="tabpanel" aria-labelledby="run-history-tab" tabindex="0">
+                <div class="mt-3 d-flex align-items-center gap-2">
+                    <label for="run_history_type" class="col-form-label">Show</label>
+                    <select class="form-select form-select-sm w-auto" id="run_history_type" aria-label="Filter run history by type">
+                        <option value="" selected>All runs</option>
+                        <option value="bulk">Bulk imports</option>
+                        <option value="scrape">Scrapes</option>
+                        <option value="upload">Uploads</option>
+                        <option value="webhook">Webhook imports</option>
+                    </select>
+                </div>
                 <div class="mt-3 table-responsive">
                     <table class="table table-sm align-middle">
                         <thead>
                             <tr>
                                 <th>Started</th>
-                                <th>File</th>
+                                <th>Type</th>
+                                <th>Run</th>
                                 <th class="d-none d-md-table-cell">Trigger</th>
                                 <th>Outcome</th>
                                 <th class="d-none d-md-table-cell">Processed</th>
@@ -1193,7 +1204,7 @@
                             </tr>
                         </thead>
                         <tbody id="run_history_body">
-                            <tr><td colspan="10" class="text-muted">No runs recorded yet.</td></tr>
+                            <tr><td colspan="11" class="text-muted">No runs recorded yet.</td></tr>
                         </tbody>
                     </table>
                 </div>

--- a/tests/test_run_counters.py
+++ b/tests/test_run_counters.py
@@ -1,7 +1,29 @@
-"""Unit tests for the bulk-import run-summary counters."""
+"""Unit tests for the run-summary counters."""
+
+import pytest
 
 from models.callbacks import ProcessingCallbacks
 from services.artwork_processor import ArtworkProcessor
+
+
+@pytest.mark.parametrize("result, expected", [
+    ("✅ A Movie | Poster updated in Movies", "success"),
+    ("♻️ A Movie | Poster forced update in Movies", "success"),
+    ("🔒 A Movie | Poster locked, skipped in Movies", "locked"),
+    ("❌ A Movie | Failed to update Poster in Movies", "failed"),
+    ("⏩ A Movie | Poster unchanged in Movies", None),
+    ("⚠️ A Movie | Poster skipped - artwork is for a different title", None),
+])
+def test_record_result_reads_the_uploader_prefixes(result, expected):
+    """Every caller that tallies a run reads these prefixes, so they are checked once
+    here rather than restated in each one."""
+    counters = ProcessingCallbacks(success_counter=[0], locked_counter=[0], failed_counter=[0])
+
+    assert counters.record_result(result) == expected
+
+
+def test_record_result_is_a_no_op_without_counters():
+    assert ProcessingCallbacks().record_result("✅ A Movie | Poster updated") == "success"
 
 
 def test_locked_counter_increments():

--- a/tests/test_run_history.py
+++ b/tests/test_run_history.py
@@ -1,0 +1,145 @@
+"""Unit tests for the persistent bulk-import run history (services/run_history.py)."""
+
+import json
+import threading
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from services.run_history import (
+    RunHistory,
+    OUTCOME_SUCCESS,
+    OUTCOME_PARTIAL,
+    OUTCOME_STOPPED,
+    OUTCOME_FAILED,
+    OUTCOME_SKIPPED,
+)
+
+
+def _iso(offset_days=0):
+    return (datetime.now(timezone.utc) - timedelta(days=offset_days)).isoformat()
+
+
+@pytest.fixture
+def history(tmp_path):
+    return RunHistory(str(tmp_path / "run_history.json"))
+
+
+@pytest.mark.unit
+def test_add_run_persists_the_record(history):
+    history.add_run(
+        "bulk_import.txt", _iso(), _iso(), scheduled=True, outcome=OUTCOME_SUCCESS,
+        assets_processed=5, success_count=4, cached_count=1, locked_count=0, error_count=0
+    )
+
+    runs = history.get_runs()
+
+    assert len(runs) == 1
+    run = runs[0]
+    assert run["filename"] == "bulk_import.txt"
+    assert run["scheduled"] is True
+    assert run["outcome"] == OUTCOME_SUCCESS
+    assert run["assets_processed"] == 5
+    assert run["success_count"] == 4
+    assert run["cached_count"] == 1
+    assert run["locked_count"] == 0
+    assert run["error_count"] == 0
+
+
+@pytest.mark.unit
+def test_get_runs_returns_most_recent_first(history):
+    history.add_run("first.txt", _iso(2), _iso(2), False, OUTCOME_SUCCESS)
+    history.add_run("second.txt", _iso(1), _iso(1), False, OUTCOME_SUCCESS)
+    history.add_run("third.txt", _iso(0), _iso(0), False, OUTCOME_SUCCESS)
+
+    filenames = [run["filename"] for run in history.get_runs()]
+
+    assert filenames == ["third.txt", "second.txt", "first.txt"]
+
+
+@pytest.mark.unit
+def test_get_runs_respects_limit(history):
+    for n in range(5):
+        history.add_run(f"file{n}.txt", _iso(), _iso(), False, OUTCOME_SUCCESS)
+
+    assert len(history.get_runs(limit=2)) == 2
+
+
+@pytest.mark.unit
+def test_records_every_outcome(history):
+    for outcome in (OUTCOME_SUCCESS, OUTCOME_PARTIAL, OUTCOME_STOPPED, OUTCOME_FAILED, OUTCOME_SKIPPED):
+        history.add_run("bulk_import.txt", _iso(), _iso(), False, outcome)
+
+    outcomes = {run["outcome"] for run in history.get_runs()}
+
+    assert outcomes == {OUTCOME_SUCCESS, OUTCOME_PARTIAL, OUTCOME_STOPPED, OUTCOME_FAILED, OUTCOME_SKIPPED}
+
+
+@pytest.mark.unit
+def test_prunes_by_entry_count(tmp_path):
+    history = RunHistory(str(tmp_path / "run_history.json"), max_entries=3, max_age_days=0)
+
+    for n in range(5):
+        history.add_run(f"file{n}.txt", _iso(), _iso(), False, OUTCOME_SUCCESS)
+
+    runs = history.get_runs()
+
+    assert len(runs) == 3
+    assert [run["filename"] for run in runs] == ["file4.txt", "file3.txt", "file2.txt"]
+
+
+@pytest.mark.unit
+def test_prunes_by_age(tmp_path):
+    history = RunHistory(str(tmp_path / "run_history.json"), max_entries=0, max_age_days=30)
+
+    history.add_run("old.txt", _iso(60), _iso(60), False, OUTCOME_SUCCESS)
+    history.add_run("recent.txt", _iso(1), _iso(1), False, OUTCOME_SUCCESS)
+
+    filenames = [run["filename"] for run in history.get_runs()]
+
+    assert filenames == ["recent.txt"]
+
+
+@pytest.mark.unit
+def test_survives_across_instances(tmp_path):
+    path = str(tmp_path / "run_history.json")
+    RunHistory(path).add_run("bulk_import.txt", _iso(), _iso(), False, OUTCOME_SUCCESS)
+
+    assert len(RunHistory(path).get_runs()) == 1
+
+
+@pytest.mark.unit
+def test_get_runs_on_missing_file_returns_empty_list(tmp_path):
+    history = RunHistory(str(tmp_path / "does_not_exist.json"))
+
+    assert history.get_runs() == []
+
+
+@pytest.mark.unit
+def test_self_heals_from_a_corrupted_file(tmp_path):
+    path = tmp_path / "run_history.json"
+    path.write_text("not valid json", encoding="utf-8")
+
+    history = RunHistory(str(path))
+    history.add_run("bulk_import.txt", _iso(), _iso(), False, OUTCOME_SUCCESS)
+
+    assert len(history.get_runs()) == 1
+    assert json.loads(path.read_text(encoding="utf-8"))
+
+
+@pytest.mark.unit
+def test_concurrent_runs_finishing_together_do_not_lose_a_record(tmp_path):
+    """A scheduled run landing at the same moment as a manual one must not have one
+    read-modify-write clobber the other's record - see the schedules a day can carry."""
+    path = str(tmp_path / "run_history.json")
+
+    def add(n):
+        RunHistory(path).add_run(f"file{n}.txt", _iso(), _iso(), False, OUTCOME_SUCCESS)
+
+    threads = [threading.Thread(target=add, args=(n,)) for n in range(20)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert len(RunHistory(path).get_runs()) == 20

--- a/tests/test_run_history.py
+++ b/tests/test_run_history.py
@@ -1,4 +1,4 @@
-"""Unit tests for the persistent bulk-import run history (services/run_history.py)."""
+"""Unit tests for the persistent run history (services/run_history.py)."""
 
 import json
 import threading
@@ -13,6 +13,13 @@ from services.run_history import (
     OUTCOME_STOPPED,
     OUTCOME_FAILED,
     OUTCOME_SKIPPED,
+    RUN_TYPE_BULK,
+    RUN_TYPE_SCRAPE,
+    RUN_TYPE_UPLOAD,
+    RUN_TYPE_WEBHOOK,
+    TRIGGER_MANUAL,
+    TRIGGER_SCHEDULED,
+    TRIGGER_RADARR,
 )
 
 
@@ -28,7 +35,7 @@ def history(tmp_path):
 @pytest.mark.unit
 def test_add_run_persists_the_record(history):
     history.add_run(
-        "bulk_import.txt", _iso(), _iso(), scheduled=True, outcome=OUTCOME_SUCCESS,
+        RUN_TYPE_BULK, "bulk_import.txt", _iso(), _iso(), trigger=TRIGGER_SCHEDULED, outcome=OUTCOME_SUCCESS,
         assets_processed=5, success_count=4, cached_count=1, locked_count=0, error_count=0
     )
 
@@ -36,8 +43,9 @@ def test_add_run_persists_the_record(history):
 
     assert len(runs) == 1
     run = runs[0]
-    assert run["filename"] == "bulk_import.txt"
-    assert run["scheduled"] is True
+    assert run["run_type"] == RUN_TYPE_BULK
+    assert run["label"] == "bulk_import.txt"
+    assert run["trigger"] == TRIGGER_SCHEDULED
     assert run["outcome"] == OUTCOME_SUCCESS
     assert run["assets_processed"] == 5
     assert run["success_count"] == 4
@@ -48,27 +56,61 @@ def test_add_run_persists_the_record(history):
 
 @pytest.mark.unit
 def test_get_runs_returns_most_recent_first(history):
-    history.add_run("first.txt", _iso(2), _iso(2), False, OUTCOME_SUCCESS)
-    history.add_run("second.txt", _iso(1), _iso(1), False, OUTCOME_SUCCESS)
-    history.add_run("third.txt", _iso(0), _iso(0), False, OUTCOME_SUCCESS)
+    history.add_run(RUN_TYPE_BULK, "first.txt", _iso(2), _iso(2), TRIGGER_MANUAL, OUTCOME_SUCCESS)
+    history.add_run(RUN_TYPE_BULK, "second.txt", _iso(1), _iso(1), TRIGGER_MANUAL, OUTCOME_SUCCESS)
+    history.add_run(RUN_TYPE_BULK, "third.txt", _iso(0), _iso(0), TRIGGER_MANUAL, OUTCOME_SUCCESS)
 
-    filenames = [run["filename"] for run in history.get_runs()]
+    labels = [run["label"] for run in history.get_runs()]
 
-    assert filenames == ["third.txt", "second.txt", "first.txt"]
+    assert labels == ["third.txt", "second.txt", "first.txt"]
 
 
 @pytest.mark.unit
 def test_get_runs_respects_limit(history):
     for n in range(5):
-        history.add_run(f"file{n}.txt", _iso(), _iso(), False, OUTCOME_SUCCESS)
+        history.add_run(RUN_TYPE_BULK, f"file{n}.txt", _iso(), _iso(), TRIGGER_MANUAL, OUTCOME_SUCCESS)
 
     assert len(history.get_runs(limit=2)) == 2
 
 
 @pytest.mark.unit
+def test_records_every_run_type(history):
+    for run_type in (RUN_TYPE_BULK, RUN_TYPE_SCRAPE, RUN_TYPE_UPLOAD, RUN_TYPE_WEBHOOK):
+        history.add_run(run_type, f"{run_type} run", _iso(), _iso(), TRIGGER_MANUAL, OUTCOME_SUCCESS)
+
+    run_types = {run["run_type"] for run in history.get_runs()}
+
+    assert run_types == {RUN_TYPE_BULK, RUN_TYPE_SCRAPE, RUN_TYPE_UPLOAD, RUN_TYPE_WEBHOOK}
+
+
+@pytest.mark.unit
+def test_get_runs_filters_by_run_type(history):
+    history.add_run(RUN_TYPE_BULK, "nightly.txt", _iso(3), _iso(3), TRIGGER_SCHEDULED, OUTCOME_SUCCESS)
+    history.add_run(RUN_TYPE_WEBHOOK, "The Matrix (1999)", _iso(2), _iso(2), TRIGGER_RADARR, OUTCOME_SUCCESS)
+    history.add_run(RUN_TYPE_SCRAPE, "https://theposterdb.com/set/1", _iso(1), _iso(1), TRIGGER_MANUAL, OUTCOME_SUCCESS)
+
+    webhook_runs = history.get_runs(run_type=RUN_TYPE_WEBHOOK)
+
+    assert [run["label"] for run in webhook_runs] == ["The Matrix (1999)"]
+
+
+@pytest.mark.unit
+def test_the_type_filter_is_applied_before_the_limit(history):
+    """Asking for bulk imports must return the last N bulk imports, not the bulk imports
+    among the last N runs - otherwise a burst of webhook imports hides them."""
+    history.add_run(RUN_TYPE_BULK, "nightly.txt", _iso(5), _iso(5), TRIGGER_SCHEDULED, OUTCOME_SUCCESS)
+    for n in range(10):
+        history.add_run(RUN_TYPE_WEBHOOK, f"Import {n}", _iso(1), _iso(1), TRIGGER_RADARR, OUTCOME_SUCCESS)
+
+    runs = history.get_runs(limit=3, run_type=RUN_TYPE_BULK)
+
+    assert [run["label"] for run in runs] == ["nightly.txt"]
+
+
+@pytest.mark.unit
 def test_records_every_outcome(history):
     for outcome in (OUTCOME_SUCCESS, OUTCOME_PARTIAL, OUTCOME_STOPPED, OUTCOME_FAILED, OUTCOME_SKIPPED):
-        history.add_run("bulk_import.txt", _iso(), _iso(), False, outcome)
+        history.add_run(RUN_TYPE_BULK, "bulk_import.txt", _iso(), _iso(), TRIGGER_MANUAL, outcome)
 
     outcomes = {run["outcome"] for run in history.get_runs()}
 
@@ -80,30 +122,81 @@ def test_prunes_by_entry_count(tmp_path):
     history = RunHistory(str(tmp_path / "run_history.json"), max_entries=3, max_age_days=0)
 
     for n in range(5):
-        history.add_run(f"file{n}.txt", _iso(), _iso(), False, OUTCOME_SUCCESS)
+        history.add_run(RUN_TYPE_BULK, f"file{n}.txt", _iso(), _iso(), TRIGGER_MANUAL, OUTCOME_SUCCESS)
 
     runs = history.get_runs()
 
     assert len(runs) == 3
-    assert [run["filename"] for run in runs] == ["file4.txt", "file3.txt", "file2.txt"]
+    assert [run["label"] for run in runs] == ["file4.txt", "file3.txt", "file2.txt"]
+
+
+@pytest.mark.unit
+def test_the_entry_cap_is_counted_per_run_type(tmp_path):
+    """A busy library takes dozens of webhook imports a day. They must not push the
+    nightly bulk import out of the history."""
+    history = RunHistory(str(tmp_path / "run_history.json"), max_entries=3, max_age_days=0)
+
+    history.add_run(RUN_TYPE_BULK, "nightly.txt", _iso(), _iso(), TRIGGER_SCHEDULED, OUTCOME_SUCCESS)
+    for n in range(10):
+        history.add_run(RUN_TYPE_WEBHOOK, f"Import {n}", _iso(), _iso(), TRIGGER_RADARR, OUTCOME_SUCCESS)
+
+    assert [run["label"] for run in history.get_runs(run_type=RUN_TYPE_BULK)] == ["nightly.txt"]
+    assert len(history.get_runs(run_type=RUN_TYPE_WEBHOOK)) == 3
 
 
 @pytest.mark.unit
 def test_prunes_by_age(tmp_path):
     history = RunHistory(str(tmp_path / "run_history.json"), max_entries=0, max_age_days=30)
 
-    history.add_run("old.txt", _iso(60), _iso(60), False, OUTCOME_SUCCESS)
-    history.add_run("recent.txt", _iso(1), _iso(1), False, OUTCOME_SUCCESS)
+    history.add_run(RUN_TYPE_BULK, "old.txt", _iso(60), _iso(60), TRIGGER_MANUAL, OUTCOME_SUCCESS)
+    history.add_run(RUN_TYPE_BULK, "recent.txt", _iso(1), _iso(1), TRIGGER_MANUAL, OUTCOME_SUCCESS)
 
-    filenames = [run["filename"] for run in history.get_runs()]
+    labels = [run["label"] for run in history.get_runs()]
 
-    assert filenames == ["recent.txt"]
+    assert labels == ["recent.txt"]
+
+
+@pytest.mark.unit
+def test_records_written_before_run_types_still_render(tmp_path):
+    """An existing history file holds bulk imports keyed by filename and a scheduled
+    boolean. Reading one must fill in the fields the table now expects."""
+    path = tmp_path / "run_history.json"
+    path.write_text(json.dumps([{
+        "filename": "bulk_import.txt",
+        "started_at": _iso(1),
+        "ended_at": _iso(1),
+        "scheduled": True,
+        "outcome": OUTCOME_SUCCESS,
+        "assets_processed": 3,
+        "success_count": 3,
+        "cached_count": 0,
+        "locked_count": 0,
+        "error_count": 0,
+    }]), encoding="utf-8")
+
+    run = RunHistory(str(path)).get_runs()[0]
+
+    assert run["run_type"] == RUN_TYPE_BULK
+    assert run["label"] == "bulk_import.txt"
+    assert run["trigger"] == TRIGGER_SCHEDULED
+    assert run["assets_processed"] == 3
+
+
+@pytest.mark.unit
+def test_an_old_manual_record_reads_as_manually_triggered(tmp_path):
+    path = tmp_path / "run_history.json"
+    path.write_text(json.dumps([{
+        "filename": "bulk_import.txt", "started_at": _iso(1), "ended_at": _iso(1),
+        "scheduled": False, "outcome": OUTCOME_SUCCESS,
+    }]), encoding="utf-8")
+
+    assert RunHistory(str(path)).get_runs()[0]["trigger"] == TRIGGER_MANUAL
 
 
 @pytest.mark.unit
 def test_survives_across_instances(tmp_path):
     path = str(tmp_path / "run_history.json")
-    RunHistory(path).add_run("bulk_import.txt", _iso(), _iso(), False, OUTCOME_SUCCESS)
+    RunHistory(path).add_run(RUN_TYPE_BULK, "bulk_import.txt", _iso(), _iso(), TRIGGER_MANUAL, OUTCOME_SUCCESS)
 
     assert len(RunHistory(path).get_runs()) == 1
 
@@ -121,7 +214,7 @@ def test_self_heals_from_a_corrupted_file(tmp_path):
     path.write_text("not valid json", encoding="utf-8")
 
     history = RunHistory(str(path))
-    history.add_run("bulk_import.txt", _iso(), _iso(), False, OUTCOME_SUCCESS)
+    history.add_run(RUN_TYPE_BULK, "bulk_import.txt", _iso(), _iso(), TRIGGER_MANUAL, OUTCOME_SUCCESS)
 
     assert len(history.get_runs()) == 1
     assert json.loads(path.read_text(encoding="utf-8"))
@@ -129,12 +222,12 @@ def test_self_heals_from_a_corrupted_file(tmp_path):
 
 @pytest.mark.unit
 def test_concurrent_runs_finishing_together_do_not_lose_a_record(tmp_path):
-    """A scheduled run landing at the same moment as a manual one must not have one
-    read-modify-write clobber the other's record - see the schedules a day can carry."""
+    """A scheduled run landing at the same moment as a webhook import must not have one
+    read-modify-write clobber the other's record."""
     path = str(tmp_path / "run_history.json")
 
     def add(n):
-        RunHistory(path).add_run(f"file{n}.txt", _iso(), _iso(), False, OUTCOME_SUCCESS)
+        RunHistory(path).add_run(RUN_TYPE_BULK, f"file{n}.txt", _iso(), _iso(), TRIGGER_MANUAL, OUTCOME_SUCCESS)
 
     threads = [threading.Thread(target=add, args=(n,)) for n in range(20)]
     for thread in threads:

--- a/tests/test_run_history_recording.py
+++ b/tests/test_run_history_recording.py
@@ -130,7 +130,7 @@ def test_no_valid_urls_in_the_file_is_recorded_as_skipped(history):
     runs = history.get_runs()
     assert len(runs) == 1
     assert runs[0]["outcome"] == OUTCOME_SKIPPED
-    assert runs[0]["filename"] == "no_urls.txt"
+    assert runs[0]["label"] == "no_urls.txt"
 
 
 @pytest.mark.unit
@@ -141,4 +141,4 @@ def test_no_filename_falls_back_to_the_default_bulk_file_name(history):
 
     runs = history.get_runs()
     assert len(runs) == 1
-    assert runs[0]["filename"] == "bulk_import.txt"
+    assert runs[0]["label"] == "bulk_import.txt"

--- a/tests/test_run_history_recording.py
+++ b/tests/test_run_history_recording.py
@@ -39,7 +39,7 @@ def test_successful_run_is_recorded_with_its_counters(history):
     globals.plex = MagicMock(tv_libraries=MagicMock(), movie_libraries=MagicMock())
     globals.config = MagicMock(apprise_urls=[])
 
-    def fake_scrape(instance, url, options, bulk, success_counter, assets_processed, cached_counter=None, locked_counter=None, failed_counter=None):
+    def fake_scrape(instance, url, options, bulk, success_counter, assets_processed, cached_counter=None, locked_counter=None):
         assets_processed[0] += 1
         success_counter[0] += 1
         cached_counter[0] += 1

--- a/tests/test_run_history_recording.py
+++ b/tests/test_run_history_recording.py
@@ -1,0 +1,144 @@
+"""
+Covers the run history record process_bulk_import_from_ui writes for each outcome it
+can reach: a clean run, a run with per-URL errors, a run that never starts because Plex
+isn't configured, and a run that dies on an unexpected exception. test_stop_scrape.py
+already covers the cancelled ("stopped") branch; this file covers the rest so every
+outcome value RunHistory can be given is actually exercised somewhere.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import core.globals as globals
+from artwork_uploader import process_bulk_import_from_ui, run_bulk_import_scrape_in_thread
+from models.instance import Instance
+from services.run_history import RunHistory, OUTCOME_SUCCESS, OUTCOME_PARTIAL, OUTCOME_FAILED, OUTCOME_SKIPPED
+
+
+@pytest.fixture
+def history(tmp_path, monkeypatch):
+    real_history = RunHistory(str(tmp_path / "run_history.json"))
+    monkeypatch.setattr("artwork_uploader.RunHistory", lambda: real_history)
+    return real_history
+
+
+@pytest.fixture(autouse=True)
+def reset_globals():
+    try:
+        yield
+    finally:
+        globals.cancel_scrape = False
+        globals.scrapes_running = 0
+        globals.plex = None
+        globals.config = None
+
+
+@pytest.mark.unit
+def test_successful_run_is_recorded_with_its_counters(history):
+    globals.plex = MagicMock(tv_libraries=MagicMock(), movie_libraries=MagicMock())
+    globals.config = MagicMock(apprise_urls=[])
+
+    def fake_scrape(instance, url, options, bulk, success_counter, assets_processed, cached_counter=None, locked_counter=None, failed_counter=None):
+        assets_processed[0] += 1
+        success_counter[0] += 1
+        cached_counter[0] += 1
+
+    with (
+        patch("artwork_uploader.scrape_and_upload", side_effect=fake_scrape),
+        patch("artwork_uploader.notify_web"),
+        patch("artwork_uploader.update_log"),
+        patch("artwork_uploader.update_status"),
+        patch("artwork_uploader.debug_me"),
+    ):
+        process_bulk_import_from_ui(Instance(mode="cli"), [MagicMock()], "ok.txt", scheduled=False)
+
+    runs = history.get_runs()
+    assert len(runs) == 1
+    assert runs[0]["outcome"] == OUTCOME_SUCCESS
+    assert runs[0]["assets_processed"] == 1
+    assert runs[0]["success_count"] == 1
+    assert runs[0]["cached_count"] == 1
+    assert runs[0]["error_count"] == 0
+
+
+@pytest.mark.unit
+def test_run_with_scraper_errors_is_recorded_as_partial(history):
+    from core.exceptions import ScraperException
+
+    globals.plex = MagicMock(tv_libraries=MagicMock(), movie_libraries=MagicMock())
+    globals.config = MagicMock(apprise_urls=[])
+
+    with (
+        patch("artwork_uploader.scrape_and_upload", side_effect=ScraperException("bad url")),
+        patch("artwork_uploader.notify_web"),
+        patch("artwork_uploader.update_log"),
+        patch("artwork_uploader.update_status"),
+        patch("artwork_uploader.debug_me"),
+    ):
+        process_bulk_import_from_ui(Instance(mode="cli"), [MagicMock()], "errors.txt", scheduled=False)
+
+    runs = history.get_runs()
+    assert len(runs) == 1
+    assert runs[0]["outcome"] == OUTCOME_PARTIAL
+    assert runs[0]["error_count"] == 1
+
+
+@pytest.mark.unit
+def test_plex_not_configured_is_recorded_as_failed_without_scraping(history):
+    globals.plex = MagicMock(tv_libraries=None, movie_libraries=None)
+    globals.config = MagicMock(apprise_urls=[])
+
+    with (
+        patch("artwork_uploader.scrape_and_upload") as mock_scrape,
+        patch("artwork_uploader.update_status"),
+    ):
+        process_bulk_import_from_ui(Instance(mode="cli"), [MagicMock()], "unconfigured.txt", scheduled=False)
+
+    mock_scrape.assert_not_called()
+    runs = history.get_runs()
+    assert len(runs) == 1
+    assert runs[0]["outcome"] == OUTCOME_FAILED
+    assert runs[0]["assets_processed"] == 0
+
+
+@pytest.mark.unit
+def test_unexpected_exception_mid_run_is_recorded_as_failed(history):
+    globals.plex = MagicMock(tv_libraries=MagicMock(), movie_libraries=MagicMock())
+    globals.config = MagicMock(apprise_urls=[])
+
+    with (
+        patch("artwork_uploader.scrape_and_upload"),
+        patch("artwork_uploader.notify_web"),
+        patch("artwork_uploader.update_log"),
+        patch("artwork_uploader.update_status"),
+        patch("artwork_uploader.debug_me"),
+        patch("artwork_uploader.elapsed_time", side_effect=RuntimeError("boom")),
+    ):
+        process_bulk_import_from_ui(Instance(mode="cli"), [MagicMock()], "crash.txt", scheduled=False)
+
+    runs = history.get_runs()
+    assert len(runs) == 1
+    assert runs[0]["outcome"] == OUTCOME_FAILED
+
+
+@pytest.mark.unit
+def test_no_valid_urls_in_the_file_is_recorded_as_skipped(history):
+    with patch("artwork_uploader.update_status"):
+        run_bulk_import_scrape_in_thread(Instance(mode="cli"), "# just a comment\n", "no_urls.txt", scheduled=False)
+
+    runs = history.get_runs()
+    assert len(runs) == 1
+    assert runs[0]["outcome"] == OUTCOME_SKIPPED
+    assert runs[0]["filename"] == "no_urls.txt"
+
+
+@pytest.mark.unit
+def test_no_filename_falls_back_to_the_default_bulk_file_name(history):
+    """A None filename must not land in the history (and the UI table) as the string 'null'."""
+    with patch("artwork_uploader.update_status"):
+        run_bulk_import_scrape_in_thread(Instance(mode="cli"), "# just a comment\n", None, scheduled=False)
+
+    runs = history.get_runs()
+    assert len(runs) == 1
+    assert runs[0]["filename"] == "bulk_import.txt"

--- a/tests/test_run_history_scheduling.py
+++ b/tests/test_run_history_scheduling.py
@@ -1,0 +1,65 @@
+"""
+A scheduled run that never gets as far as scraping a URL - missing bulk file, empty
+file, or an unexpected error before parsing starts - must still leave a run history
+record. Otherwise the answer to "did last night's run do anything" stays "check the
+logs" for exactly the runs that did the least.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import core.globals as globals
+from artwork_uploader import process_bulk_file_on_schedule
+from models.instance import Instance
+from services.run_history import RunHistory, OUTCOME_FAILED, OUTCOME_SKIPPED
+
+
+@pytest.fixture(autouse=True)
+def scheduler_service():
+    # The overlap guard merged from issue 8 releases the scheduler service in a
+    # finally block, so these direct calls need a service present.
+    with patch.object(globals, "scheduler_service", MagicMock()) as service:
+        yield service
+
+
+@pytest.fixture
+def history(tmp_path, monkeypatch):
+    real_history = RunHistory(str(tmp_path / "run_history.json"))
+    monkeypatch.setattr("artwork_uploader.RunHistory", lambda: real_history)
+    return real_history
+
+
+@pytest.mark.unit
+def test_missing_bulk_file_is_recorded_as_failed(history):
+    with patch("artwork_uploader.find_bulk_file", return_value=None):
+        process_bulk_file_on_schedule(Instance(mode="cli"), "missing.txt")
+
+    runs = history.get_runs()
+    assert len(runs) == 1
+    assert runs[0]["filename"] == "missing.txt"
+    assert runs[0]["outcome"] == OUTCOME_FAILED
+    assert runs[0]["scheduled"] is True
+
+
+@pytest.mark.unit
+def test_empty_bulk_file_is_recorded_as_skipped(history, tmp_path):
+    empty_file = tmp_path / "empty.txt"
+    empty_file.write_text("", encoding="utf-8")
+
+    with patch("artwork_uploader.find_bulk_file", return_value=str(empty_file)):
+        process_bulk_file_on_schedule(Instance(mode="cli"), "empty.txt")
+
+    runs = history.get_runs()
+    assert len(runs) == 1
+    assert runs[0]["outcome"] == OUTCOME_SKIPPED
+
+
+@pytest.mark.unit
+def test_unexpected_failure_before_parsing_is_recorded(history):
+    with patch("artwork_uploader.find_bulk_file", side_effect=RuntimeError("boom")):
+        process_bulk_file_on_schedule(Instance(mode="cli"), "broken.txt")
+
+    runs = history.get_runs()
+    assert len(runs) == 1
+    assert runs[0]["outcome"] == OUTCOME_FAILED

--- a/tests/test_run_history_scheduling.py
+++ b/tests/test_run_history_scheduling.py
@@ -5,7 +5,7 @@ record. Otherwise the answer to "did last night's run do anything" stays "check 
 logs" for exactly the runs that did the least.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -13,14 +13,6 @@ import core.globals as globals
 from artwork_uploader import process_bulk_file_on_schedule
 from models.instance import Instance
 from services.run_history import RunHistory, OUTCOME_FAILED, OUTCOME_SKIPPED
-
-
-@pytest.fixture(autouse=True)
-def scheduler_service():
-    # The overlap guard merged from issue 8 releases the scheduler service in a
-    # finally block, so these direct calls need a service present.
-    with patch.object(globals, "scheduler_service", MagicMock()) as service:
-        yield service
 
 
 @pytest.fixture

--- a/tests/test_run_history_scheduling.py
+++ b/tests/test_run_history_scheduling.py
@@ -12,7 +12,7 @@ import pytest
 import core.globals as globals
 from artwork_uploader import process_bulk_file_on_schedule
 from models.instance import Instance
-from services.run_history import RunHistory, OUTCOME_FAILED, OUTCOME_SKIPPED
+from services.run_history import RunHistory, TRIGGER_SCHEDULED, OUTCOME_FAILED, OUTCOME_SKIPPED
 
 
 @pytest.fixture
@@ -29,9 +29,9 @@ def test_missing_bulk_file_is_recorded_as_failed(history):
 
     runs = history.get_runs()
     assert len(runs) == 1
-    assert runs[0]["filename"] == "missing.txt"
+    assert runs[0]["label"] == "missing.txt"
     assert runs[0]["outcome"] == OUTCOME_FAILED
-    assert runs[0]["scheduled"] is True
+    assert runs[0]["trigger"] == TRIGGER_SCHEDULED
 
 
 @pytest.mark.unit

--- a/tests/test_run_history_scrape.py
+++ b/tests/test_run_history_scrape.py
@@ -1,0 +1,196 @@
+"""
+Covers the run history record process_scrape_url_from_web writes.
+
+A single URL scraped from the main tab does the same work to Plex a bulk import line
+does, so it leaves the same kind of record. Every way out of the function is exercised
+here, including the ones that never reach the scraper, because a run that failed to
+start is exactly the run somebody goes looking for afterwards.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import core.globals as globals
+from artwork_uploader import process_scrape_url_from_web
+from models.instance import Instance
+from services.run_history import (
+    RunHistory,
+    OUTCOME_SUCCESS,
+    OUTCOME_PARTIAL,
+    OUTCOME_STOPPED,
+    OUTCOME_FAILED,
+    OUTCOME_SKIPPED,
+    RUN_TYPE_SCRAPE,
+    TRIGGER_MANUAL,
+)
+
+URL = "https://theposterdb.com/set/12345"
+
+
+@pytest.fixture
+def history(tmp_path, monkeypatch):
+    real_history = RunHistory(str(tmp_path / "run_history.json"))
+    monkeypatch.setattr("artwork_uploader.RunHistory", lambda: real_history)
+    return real_history
+
+
+@pytest.fixture(autouse=True)
+def reset_globals():
+    try:
+        yield
+    finally:
+        globals.cancel_scrape = False
+        globals.scrapes_running = 0
+        globals.plex = None
+        globals.config = None
+
+
+@pytest.fixture
+def configured_plex():
+    globals.plex = MagicMock(tv_libraries=MagicMock(), movie_libraries=MagicMock())
+    globals.config = MagicMock(apprise_urls=[])
+    return globals.plex
+
+
+def _scrape(**counts):
+    """A stand-in for scrape_and_upload that moves the counters it is handed."""
+    def fake_scrape(instance, url, options, bulk, success_counter, assets_processed=None,
+                    cached_counter=None, locked_counter=None, failed_counter=None):
+        counters = {
+            "assets": assets_processed, "success": success_counter,
+            "cached": cached_counter, "locked": locked_counter, "failed": failed_counter,
+        }
+        for name, count in counts.items():
+            counters[name][0] += count
+        return "A Set", "someone"
+    return fake_scrape
+
+
+@pytest.mark.unit
+def test_a_scrape_is_recorded_with_its_counters(history, configured_plex):
+    with (
+        patch("artwork_uploader.scrape_and_upload", side_effect=_scrape(assets=3, success=2, cached=1, locked=1)),
+        patch("artwork_uploader.notify_web"),
+        patch("artwork_uploader.update_status"),
+    ):
+        process_scrape_url_from_web(Instance(mode="cli"), URL)
+
+    runs = history.get_runs()
+    assert len(runs) == 1
+    assert runs[0]["run_type"] == RUN_TYPE_SCRAPE
+    assert runs[0]["trigger"] == TRIGGER_MANUAL
+    assert runs[0]["label"] == URL
+    assert runs[0]["outcome"] == OUTCOME_SUCCESS
+    assert runs[0]["assets_processed"] == 3
+    assert runs[0]["success_count"] == 2
+    assert runs[0]["cached_count"] == 1
+    assert runs[0]["locked_count"] == 1
+    assert runs[0]["error_count"] == 0
+
+
+@pytest.mark.unit
+def test_the_options_are_stripped_from_the_recorded_url(history, configured_plex):
+    """The main tab appends the chosen options to the URL. The history records the URL
+    that was scraped, not the whole command line."""
+    with (
+        patch("artwork_uploader.scrape_and_upload", side_effect=_scrape(assets=1, success=1)),
+        patch("artwork_uploader.notify_web"),
+        patch("artwork_uploader.update_status"),
+    ):
+        process_scrape_url_from_web(Instance(mode="cli"), f"{URL} --force --year 2021")
+
+    assert history.get_runs()[0]["label"] == URL
+
+
+@pytest.mark.unit
+def test_an_upload_that_exhausted_its_retries_is_recorded_as_partial(history, configured_plex):
+    with (
+        patch("artwork_uploader.scrape_and_upload", side_effect=_scrape(assets=2, success=1, failed=1)),
+        patch("artwork_uploader.notify_web"),
+        patch("artwork_uploader.update_status"),
+    ):
+        process_scrape_url_from_web(Instance(mode="cli"), URL)
+
+    runs = history.get_runs()
+    assert runs[0]["outcome"] == OUTCOME_PARTIAL
+    assert runs[0]["error_count"] == 1
+
+
+@pytest.mark.unit
+def test_a_scrape_that_processed_nothing_is_recorded_as_skipped(history, configured_plex):
+    with (
+        patch("artwork_uploader.scrape_and_upload", side_effect=_scrape()),
+        patch("artwork_uploader.notify_web"),
+        patch("artwork_uploader.update_status"),
+    ):
+        process_scrape_url_from_web(Instance(mode="cli"), URL)
+
+    assert history.get_runs()[0]["outcome"] == OUTCOME_SKIPPED
+
+
+@pytest.mark.unit
+def test_a_cancelled_scrape_is_recorded_as_stopped(history, configured_plex):
+    def cancel_midway(*args, **kwargs):
+        globals.cancel_scrape = True
+        return None, None
+
+    with (
+        patch("artwork_uploader.scrape_and_upload", side_effect=cancel_midway),
+        patch("artwork_uploader.notify_web"),
+        patch("artwork_uploader.update_status"),
+    ):
+        process_scrape_url_from_web(Instance(mode="cli"), URL)
+
+    assert history.get_runs()[0]["outcome"] == OUTCOME_STOPPED
+
+
+@pytest.mark.unit
+def test_a_scraper_error_is_recorded_as_failed(history, configured_plex):
+    from core.exceptions import ScraperException
+
+    with (
+        patch("artwork_uploader.scrape_and_upload", side_effect=ScraperException("nothing there")),
+        patch("artwork_uploader.notify_web"),
+        patch("artwork_uploader.update_status"),
+    ):
+        process_scrape_url_from_web(Instance(mode="cli"), URL)
+
+    assert history.get_runs()[0]["outcome"] == OUTCOME_FAILED
+
+
+@pytest.mark.unit
+def test_plex_not_configured_is_recorded_as_failed_without_scraping(history):
+    globals.plex = MagicMock(tv_libraries=None, movie_libraries=None)
+
+    with (
+        patch("artwork_uploader.scrape_and_upload") as mock_scrape,
+        patch("artwork_uploader.notify_web"),
+        patch("artwork_uploader.update_status"),
+    ):
+        process_scrape_url_from_web(Instance(mode="cli"), URL)
+
+    mock_scrape.assert_not_called()
+    runs = history.get_runs()
+    assert len(runs) == 1
+    assert runs[0]["outcome"] == OUTCOME_FAILED
+    assert runs[0]["label"] == URL
+
+
+@pytest.mark.unit
+def test_an_invalid_url_is_still_recorded(history, configured_plex):
+    """InvalidUrl isn't a ScraperException, so it leaves through the finally. The run
+    still has to land in the history rather than vanish."""
+    from core.exceptions import InvalidUrl
+
+    with (
+        patch("artwork_uploader.notify_web"),
+        patch("artwork_uploader.update_status"),
+        pytest.raises(InvalidUrl),
+    ):
+        process_scrape_url_from_web(Instance(mode="cli"), "not a url at all")
+
+    runs = history.get_runs()
+    assert len(runs) == 1
+    assert runs[0]["outcome"] == OUTCOME_FAILED
+    assert runs[0]["label"] == "not a url at all"

--- a/tests/test_run_history_socket.py
+++ b/tests/test_run_history_socket.py
@@ -1,0 +1,72 @@
+"""Unit test for the load_run_history Socket.IO handler (web_routes.py)."""
+
+import re
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+
+import core.globals as globals
+import web_routes
+from services.run_history import RunHistory, OUTCOME_SUCCESS
+
+
+def _iso():
+    return datetime.now(timezone.utc).isoformat()
+
+
+class _StubSocket:
+    """Records handlers registered via @socket.on(event) instead of a real Socket.IO server."""
+
+    def __init__(self):
+        self.handlers = {}
+
+    def on(self, event):
+        def register(func):
+            self.handlers[event] = func
+            return func
+        return register
+
+
+@pytest.fixture
+def stub_socket(monkeypatch):
+    socket = _StubSocket()
+    monkeypatch.setattr(globals, "web_socket", socket)
+    web_routes.setup_socket_handlers(config=None, filename_pattern=re.compile(r".*"))
+    return socket
+
+
+@pytest.mark.unit
+def test_load_run_history_emits_recent_runs(tmp_path, stub_socket, monkeypatch):
+    history = RunHistory(str(tmp_path / "run_history.json"))
+    history.add_run("bulk_import.txt", _iso(), _iso(), False, OUTCOME_SUCCESS)
+    monkeypatch.setattr(web_routes, "RunHistory", lambda: history)
+
+    emitted = {}
+
+    def fake_notify_web(instance, event, data=None, silent=False):
+        emitted["event"] = event
+        emitted["data"] = data
+
+    with patch("web_routes.notify_web", side_effect=fake_notify_web):
+        stub_socket.handlers["load_run_history"]({"instance_id": "abc"})
+
+    assert emitted["event"] == "load_run_history"
+    assert len(emitted["data"]["runs"]) == 1
+    assert emitted["data"]["runs"][0]["filename"] == "bulk_import.txt"
+
+
+@pytest.mark.unit
+def test_load_run_history_with_no_runs_emits_an_empty_list(tmp_path, stub_socket, monkeypatch):
+    history = RunHistory(str(tmp_path / "run_history.json"))
+    monkeypatch.setattr(web_routes, "RunHistory", lambda: history)
+
+    emitted = {}
+
+    def fake_notify_web(instance, event, data=None, silent=False):
+        emitted["data"] = data
+
+    with patch("web_routes.notify_web", side_effect=fake_notify_web):
+        stub_socket.handlers["load_run_history"]({"instance_id": "abc"})
+
+    assert emitted["data"]["runs"] == []

--- a/tests/test_run_history_socket.py
+++ b/tests/test_run_history_socket.py
@@ -8,7 +8,14 @@ import pytest
 
 import core.globals as globals
 import web_routes
-from services.run_history import RunHistory, OUTCOME_SUCCESS
+from services.run_history import (
+    RunHistory,
+    OUTCOME_SUCCESS,
+    RUN_TYPE_BULK,
+    RUN_TYPE_WEBHOOK,
+    TRIGGER_MANUAL,
+    TRIGGER_RADARR,
+)
 
 
 def _iso():
@@ -39,7 +46,7 @@ def stub_socket(monkeypatch):
 @pytest.mark.unit
 def test_load_run_history_emits_recent_runs(tmp_path, stub_socket, monkeypatch):
     history = RunHistory(str(tmp_path / "run_history.json"))
-    history.add_run("bulk_import.txt", _iso(), _iso(), False, OUTCOME_SUCCESS)
+    history.add_run(RUN_TYPE_BULK, "bulk_import.txt", _iso(), _iso(), TRIGGER_MANUAL, OUTCOME_SUCCESS)
     monkeypatch.setattr(web_routes, "RunHistory", lambda: history)
 
     emitted = {}
@@ -53,7 +60,47 @@ def test_load_run_history_emits_recent_runs(tmp_path, stub_socket, monkeypatch):
 
     assert emitted["event"] == "load_run_history"
     assert len(emitted["data"]["runs"]) == 1
-    assert emitted["data"]["runs"][0]["filename"] == "bulk_import.txt"
+    assert emitted["data"]["runs"][0]["label"] == "bulk_import.txt"
+    assert emitted["data"]["run_type"] == "all"
+
+
+@pytest.mark.unit
+def test_load_run_history_narrows_to_the_requested_run_type(tmp_path, stub_socket, monkeypatch):
+    history = RunHistory(str(tmp_path / "run_history.json"))
+    history.add_run(RUN_TYPE_BULK, "bulk_import.txt", _iso(), _iso(), TRIGGER_MANUAL, OUTCOME_SUCCESS)
+    history.add_run(RUN_TYPE_WEBHOOK, "The Matrix (1999)", _iso(), _iso(), TRIGGER_RADARR, OUTCOME_SUCCESS)
+    monkeypatch.setattr(web_routes, "RunHistory", lambda: history)
+
+    emitted = {}
+
+    def fake_notify_web(instance, event, data=None, silent=False):
+        emitted["data"] = data
+
+    with patch("web_routes.notify_web", side_effect=fake_notify_web):
+        stub_socket.handlers["load_run_history"]({"instance_id": "abc", "run_type": RUN_TYPE_WEBHOOK})
+
+    assert [run["label"] for run in emitted["data"]["runs"]] == ["The Matrix (1999)"]
+    assert emitted["data"]["run_type"] == RUN_TYPE_WEBHOOK
+
+
+@pytest.mark.unit
+def test_an_unknown_run_type_falls_back_to_every_run(tmp_path, stub_socket, monkeypatch):
+    """The filter comes off the wire, so a value that isn't a run type must not silently
+    return nothing - it shows everything, the way the unfiltered table does."""
+    history = RunHistory(str(tmp_path / "run_history.json"))
+    history.add_run(RUN_TYPE_BULK, "bulk_import.txt", _iso(), _iso(), TRIGGER_MANUAL, OUTCOME_SUCCESS)
+    monkeypatch.setattr(web_routes, "RunHistory", lambda: history)
+
+    emitted = {}
+
+    def fake_notify_web(instance, event, data=None, silent=False):
+        emitted["data"] = data
+
+    with patch("web_routes.notify_web", side_effect=fake_notify_web):
+        stub_socket.handlers["load_run_history"]({"instance_id": "abc", "run_type": "nonsense"})
+
+    assert len(emitted["data"]["runs"]) == 1
+    assert emitted["data"]["run_type"] == "all"
 
 
 @pytest.mark.unit

--- a/tests/test_run_history_upload.py
+++ b/tests/test_run_history_upload.py
@@ -1,0 +1,169 @@
+"""
+Covers the run history record process_uploaded_artwork writes.
+
+Artwork uploaded as a ZIP goes to Plex through the same uploader a scrape uses, so it
+leaves the same kind of record. There is no cache crawl behind an upload, so the cached
+count on one of these rows is always zero.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import core.globals as globals
+from artwork_uploader import process_uploaded_artwork
+from models.instance import Instance
+from services.run_history import (
+    RunHistory,
+    OUTCOME_SUCCESS,
+    OUTCOME_PARTIAL,
+    OUTCOME_STOPPED,
+    OUTCOME_FAILED,
+    OUTCOME_SKIPPED,
+    RUN_TYPE_UPLOAD,
+    TRIGGER_MANUAL,
+)
+
+
+@pytest.fixture
+def history(tmp_path, monkeypatch):
+    real_history = RunHistory(str(tmp_path / "run_history.json"))
+    monkeypatch.setattr("artwork_uploader.RunHistory", lambda: real_history)
+    return real_history
+
+
+@pytest.fixture(autouse=True)
+def reset_globals():
+    globals.plex = MagicMock()
+    globals.config = MagicMock(apprise_urls=[])
+    try:
+        yield
+    finally:
+        globals.cancel_scrape = False
+        globals.scrapes_running = 0
+        globals.plex = None
+        globals.config = None
+
+
+def _processor(**counts):
+    """An ArtworkProcessor stand-in that moves the counters it was handed."""
+    class _FakeProcessor:
+        def __init__(self, _plex, callbacks):
+            self.callbacks = callbacks
+
+        def process_uploaded_files(self, *args, **kwargs):
+            for name, count in counts.items():
+                getattr(self.callbacks, name)(count)
+    return _FakeProcessor
+
+
+def _upload(instance_mode="cli", title="A Set"):
+    process_uploaded_artwork(
+        Instance(mode=instance_mode), [MagicMock()], 0, title, "someone", "theposterdb", [], []
+    )
+
+
+@pytest.mark.unit
+def test_an_upload_is_recorded_with_its_counters(history):
+    with (
+        patch("artwork_uploader.ArtworkProcessor", _processor(assets=4, success=3, locked=1)),
+        patch("artwork_uploader.notify_web"),
+        patch("artwork_uploader.update_status"),
+        patch("artwork_uploader.update_log"),
+    ):
+        _upload()
+
+    runs = history.get_runs()
+    assert len(runs) == 1
+    assert runs[0]["run_type"] == RUN_TYPE_UPLOAD
+    assert runs[0]["trigger"] == TRIGGER_MANUAL
+    assert runs[0]["label"] == "A Set"
+    assert runs[0]["outcome"] == OUTCOME_SUCCESS
+    assert runs[0]["assets_processed"] == 4
+    assert runs[0]["success_count"] == 3
+    assert runs[0]["locked_count"] == 1
+    assert runs[0]["cached_count"] == 0
+
+
+@pytest.mark.unit
+def test_an_upload_with_failed_assets_is_recorded_as_partial(history):
+    with (
+        patch("artwork_uploader.ArtworkProcessor", _processor(assets=2, success=1, failed=1)),
+        patch("artwork_uploader.notify_web"),
+        patch("artwork_uploader.update_status"),
+        patch("artwork_uploader.update_log"),
+    ):
+        _upload()
+
+    runs = history.get_runs()
+    assert runs[0]["outcome"] == OUTCOME_PARTIAL
+    assert runs[0]["error_count"] == 1
+
+
+@pytest.mark.unit
+def test_an_upload_that_processed_nothing_is_recorded_as_skipped(history):
+    with (
+        patch("artwork_uploader.ArtworkProcessor", _processor()),
+        patch("artwork_uploader.notify_web"),
+        patch("artwork_uploader.update_status"),
+        patch("artwork_uploader.update_log"),
+    ):
+        _upload()
+
+    assert history.get_runs()[0]["outcome"] == OUTCOME_SKIPPED
+
+
+@pytest.mark.unit
+def test_a_cancelled_upload_is_recorded_as_stopped(history):
+    class _CancellingProcessor:
+        def __init__(self, _plex, callbacks):
+            self.callbacks = callbacks
+
+        def process_uploaded_files(self, *args, **kwargs):
+            self.callbacks.assets(1)
+            globals.cancel_scrape = True
+
+    with (
+        patch("artwork_uploader.ArtworkProcessor", _CancellingProcessor),
+        patch("artwork_uploader.notify_web"),
+        patch("artwork_uploader.update_status"),
+        patch("artwork_uploader.update_log"),
+    ):
+        _upload()
+
+    assert history.get_runs()[0]["outcome"] == OUTCOME_STOPPED
+
+
+@pytest.mark.unit
+def test_an_upload_that_raised_is_recorded_as_failed(history):
+    class _ExplodingProcessor:
+        def __init__(self, _plex, callbacks):
+            pass
+
+        def process_uploaded_files(self, *args, **kwargs):
+            raise RuntimeError("boom")
+
+    with (
+        patch("artwork_uploader.ArtworkProcessor", _ExplodingProcessor),
+        patch("artwork_uploader.notify_web"),
+        patch("artwork_uploader.update_status"),
+        patch("artwork_uploader.update_log"),
+        pytest.raises(RuntimeError),
+    ):
+        _upload()
+
+    assert history.get_runs()[0]["outcome"] == OUTCOME_FAILED
+
+
+@pytest.mark.unit
+def test_an_untitled_zip_still_gets_a_label(history):
+    """A ZIP with no title must not land in the table as an empty cell."""
+    with (
+        patch("artwork_uploader.ArtworkProcessor", _processor(assets=1, success=1)),
+        patch("artwork_uploader.notify_web"),
+        patch("artwork_uploader.update_status"),
+        patch("artwork_uploader.update_log"),
+    ):
+        _upload(title=None)
+
+    assert history.get_runs()[0]["label"] == "Uploaded artwork"

--- a/tests/test_stop_scrape.py
+++ b/tests/test_stop_scrape.py
@@ -20,6 +20,7 @@ from models.instance import Instance
 from models.options import Options
 from scrapers.theposterdb_scraper import ThePosterDBScraper
 from services.artwork_processor import ArtworkProcessor
+from services.run_history import RunHistory, OUTCOME_STOPPED
 from models.callbacks import ProcessingCallbacks
 
 
@@ -108,7 +109,7 @@ def test_cancel_scrape_breaks_crawl_and_blocks_partial_upload():
 
 
 @pytest.mark.unit
-def test_cancelled_bulk_run_reports_stopped_not_success():
+def test_cancelled_bulk_run_reports_stopped_not_success(tmp_path, monkeypatch):
     """
     P3: once cancel_scrape is armed, the bulk summary must report an honest
     "stopped" message - never the green "completed successfully" wording a
@@ -118,7 +119,14 @@ def test_cancelled_bulk_run_reports_stopped_not_success():
     globals.cancel_scrape, not a mock of it. scheduled=True so the
     notification branch runs too - a suppressed notification on a cancelled
     scheduled run would leave a dangling "started" with no terminal event.
+
+    Also drives the outcome the run gets recorded with: a cancelled run must
+    be filed as OUTCOME_STOPPED, never OUTCOME_SUCCESS, so the run history
+    tells the truth about a run the user actually stopped.
     """
+    history = RunHistory(str(tmp_path / "run_history.json"))
+    monkeypatch.setattr("artwork_uploader.RunHistory", lambda: history)
+
     try:
         globals.cancel_scrape = True
         globals.scrapes_running = 0
@@ -171,6 +179,10 @@ def test_cancelled_bulk_run_reports_stopped_not_success():
             if len(c.args) >= 3 and c.args[1] == "progress_bar" and c.args[2].get("percent") == 100
         ]
         assert progress_hides, "a cancelled bulk run must clear the progress bar (emit percent 100)"
+
+        runs = history.get_runs()
+        assert len(runs) == 1
+        assert runs[0]["outcome"] == OUTCOME_STOPPED, "a cancelled run must be recorded as stopped, not success"
     finally:
         globals.cancel_scrape = False
         globals.scrapes_running = 0

--- a/tests/test_webhook_service.py
+++ b/tests/test_webhook_service.py
@@ -1,12 +1,16 @@
 """Unit tests for the Sonarr/Radarr import webhook (services/webhook_service.py)."""
 
+from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
 import pytest
 
+import services.webhook_service as webhook_service_module
 from core.constants import ARTWORK_ID_MAP, ARTWORK_TYPE_MAP
+from models.callbacks import ProcessingCallbacks
 from plex.plex_uploader import PlexUploader
 from services.asset_index import AssetIndex
+from services.run_history import RunHistory
 from services.webhook_service import WebhookEvent, WebhookService, parse_event
 
 FAR_FUTURE = "2999-01-01T00:00:00+00:00"
@@ -15,6 +19,24 @@ FAR_FUTURE = "2999-01-01T00:00:00+00:00"
 @pytest.fixture
 def index(tmp_path):
     return AssetIndex(str(tmp_path / "asset_index.db"))
+
+
+@pytest.fixture
+def history(tmp_path, monkeypatch):
+    """Keep the webhook's history writes inside the test's own tmp directory."""
+    real_history = RunHistory(str(tmp_path / "run_history.json"))
+    monkeypatch.setattr(webhook_service_module, "RunHistory", lambda: real_history)
+    return real_history
+
+
+def _tally():
+    return ProcessingCallbacks(
+        success_counter=[0], assets_processed=[0], locked_counter=[0], failed_counter=[0]
+    )
+
+
+def _now():
+    return datetime.now(timezone.utc).isoformat()
 
 
 def _rec(index, user, asset_id, title, year, media_type, season=None):
@@ -165,7 +187,7 @@ def test_artwork_dict_carries_the_file_type_key_the_processor_reads(artwork_type
 # --------------------------- allow_artist_updates ---------------------------
 
 @pytest.mark.unit
-def test_attempt_forces_allow_artist_updates_off(monkeypatch):
+def test_attempt_forces_allow_artist_updates_off(monkeypatch, history):
     """The webhook must never inherit allow_artist_updates from the global config.
 
     set_options resolves the flag as `self.options.allow_artist_updates or
@@ -200,7 +222,108 @@ def test_attempt_forces_allow_artist_updates_off(monkeypatch):
     service = WebhookService()
     event = parse_event({"eventType": "Download",
                          "movie": {"title": "Dune", "year": 2021, "tmdbId": 438631}})
-    service._attempt(event, ("movie", 438631), artwork=[{"id": 1, "file_type": "movie_poster"}])
+    service._attempt(event, ("movie", 438631), _now(), _tally(),
+                     artwork=[{"id": 1, "file_type": "movie_poster"}])
 
     assert seen.get("at_upload") is False, \
         "the webhook reached the uploader with allow_artist_updates still on"
+
+
+# ------------------------------- run history -------------------------------
+
+def _applying_service(monkeypatch, results):
+    """A WebhookService whose uploader returns `results` for every artwork item."""
+    import processors.upload_processor as upload_processor_module
+    from core import globals as app_globals
+
+    class _FakeProcessor:
+        def __init__(self, _plex):
+            self.allow_artist_updates = True
+
+        def set_options(self, _options):
+            pass
+
+        def process_movie_artwork(self, _item):
+            return list(results)
+
+    monkeypatch.setattr(upload_processor_module, "UploadProcessor", _FakeProcessor)
+    monkeypatch.setattr(app_globals, "plex", MagicMock())
+    return WebhookService()
+
+
+def _dune():
+    return parse_event({"eventType": "Download",
+                        "movie": {"title": "Dune", "year": 2021, "tmdbId": 438631}})
+
+
+@pytest.mark.unit
+def test_an_applied_import_is_recorded_as_a_successful_webhook_run(monkeypatch, history):
+    service = _applying_service(monkeypatch, ["✅ Dune (2021) • someone | Poster updated in Movies"])
+    tally = _tally()
+    tally.assets(1)
+
+    service._attempt(_dune(), ("movie", 438631), _now(), tally,
+                     artwork=[{"id": 1, "file_type": "movie_poster"}])
+
+    runs = history.get_runs()
+    assert len(runs) == 1
+    assert runs[0]["run_type"] == "webhook"
+    assert runs[0]["trigger"] == "radarr"
+    assert runs[0]["label"] == "Dune (2021)"
+    assert runs[0]["outcome"] == "success"
+    assert runs[0]["assets_processed"] == 1
+    assert runs[0]["success_count"] == 1
+    assert runs[0]["error_count"] == 0
+
+
+@pytest.mark.unit
+def test_a_failed_upload_is_recorded_as_a_failed_webhook_run(monkeypatch, history):
+    service = _applying_service(monkeypatch, ["❌ Dune (2021) • someone | Failed to update Poster"])
+
+    service._attempt(_dune(), ("movie", 438631), _now(), _tally(),
+                     artwork=[{"id": 1, "file_type": "movie_poster"}])
+
+    runs = history.get_runs()
+    assert runs[0]["outcome"] == "failed"
+    assert runs[0]["error_count"] == 1
+
+
+@pytest.mark.unit
+def test_artwork_that_never_appeared_in_plex_is_recorded_as_an_error(monkeypatch, history):
+    """The retry ladder is exhausted here (attempt is past its end), so the item is
+    given up on. A run that applied nothing has failed, whatever the logs said."""
+    service = _applying_service(monkeypatch, ["Poster not available on Plex"])
+
+    service._attempt(_dune(), ("movie", 438631), _now(), _tally(),
+                     attempt=99, artwork=[{"id": 1, "file_type": "movie_poster"}])
+
+    runs = history.get_runs()
+    assert runs[0]["outcome"] == "failed"
+    assert runs[0]["error_count"] == 1
+
+
+@pytest.mark.unit
+def test_a_retry_does_not_record_a_run_of_its_own(monkeypatch, history):
+    """One import is one run. The record waits for the ladder to finish, or the tab
+    fills up with a row per retry."""
+    service = _applying_service(monkeypatch, ["Poster not available on Plex"])
+
+    service._attempt(_dune(), ("movie", 438631), _now(), _tally(),
+                     attempt=0, artwork=[{"id": 1, "file_type": "movie_poster"}])
+
+    assert history.get_runs() == []
+
+
+@pytest.mark.unit
+def test_an_import_with_no_cached_artwork_is_recorded_as_skipped(monkeypatch, history):
+    from core import globals as app_globals
+
+    monkeypatch.setattr(app_globals, "config", MagicMock(webhook_tpdb_users=[]))
+    service = WebhookService()
+
+    service._attempt(_dune(), ("movie", 438631), _now(), _tally())
+
+    runs = history.get_runs()
+    assert len(runs) == 1
+    assert runs[0]["outcome"] == "skipped"
+    assert runs[0]["assets_processed"] == 0

--- a/web_routes.py
+++ b/web_routes.py
@@ -24,7 +24,7 @@ from core.config import Config
 from core.enums import FileType, MediaType, ScraperSource, StatusColor
 from processors.media_metadata import parse_title
 from utils.notifications import update_log, update_status, notify_web, debug_me
-from services import UtilityService, AuthenticationService
+from services import UtilityService, AuthenticationService, RunHistory
 from services.webhook_service import parse_event
 from core.constants import UPLOAD_CHUNK_SIZE, UPLOAD_CHUNK_TIMEOUT, WEBHOOK_TOKEN_HEADER
 
@@ -356,6 +356,13 @@ def setup_socket_handlers(
         except (FileNotFoundError, PermissionError) as e:
             debug_me(f"Error loading bulk import file list: {e}")
         notify_web(instance, "load_bulk_filelist", {"bulk_files": bulk_files})
+
+    @globals.web_socket.on("load_run_history")
+    def load_run_history(data):
+        """Load recent bulk import run history."""
+        instance = Instance(data.get("instance_id"), "web")
+        runs = RunHistory().get_runs(limit=50)
+        notify_web(instance, "load_run_history", {"runs": runs})
 
     @globals.web_socket.on("load_bulk_import")
     def load_bulk_import(data):

--- a/web_routes.py
+++ b/web_routes.py
@@ -25,6 +25,7 @@ from core.enums import FileType, MediaType, ScraperSource, StatusColor
 from processors.media_metadata import parse_title
 from utils.notifications import update_log, update_status, notify_web, debug_me
 from services import UtilityService, AuthenticationService, RunHistory
+from services.run_history import RUN_TYPES
 from services.webhook_service import parse_event
 from core.constants import UPLOAD_CHUNK_SIZE, UPLOAD_CHUNK_TIMEOUT, WEBHOOK_TOKEN_HEADER
 
@@ -359,10 +360,13 @@ def setup_socket_handlers(
 
     @globals.web_socket.on("load_run_history")
     def load_run_history(data):
-        """Load recent bulk import run history."""
+        """Load recent run history, optionally narrowed to one run type."""
         instance = Instance(data.get("instance_id"), "web")
-        runs = RunHistory().get_runs(limit=50)
-        notify_web(instance, "load_run_history", {"runs": runs})
+        run_type = data.get("run_type") or None
+        if run_type not in RUN_TYPES:
+            run_type = None
+        runs = RunHistory().get_runs(limit=50, run_type=run_type)
+        notify_web(instance, "load_run_history", {"runs": runs, "run_type": run_type or "all"})
 
     @globals.web_socket.on("load_bulk_import")
     def load_bulk_import(data):


### PR DESCRIPTION
Every run, manual or scheduled, lands in a rolling history. Each row holds start and end times, the trigger, the asset counters, and the outcome (completed, completed with errors, stopped, failed, skipped). A History tab shows the log.

The runs that never start leave a row too: a missing or empty bulk file records failed or skipped. Those are exactly the runs with no other trace. The question this answers is whether last night's run did anything, without reading the session log.

The history lives in config/run_history.json with a bounded length, oldest rows dropped first. On phones the six detail columns collapse, leaving Started, File, Outcome and Errors.
