### PR TITLE
Multiple schedules per bulk file, missed run catch-up, and single flight imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,11 +162,11 @@ With ```cache_user_scrapes``` enabled, the app already knows every poster your f
 On an import the title is looked up in the cached index; if one of the configured users covers it, that single poster (plus season covers for the imported seasons, on TV) is applied through the same processing path as a normal scrape, so artwork labels, locked-artwork skips and Kometa asset mode all behave the same.  Imports usually reach the webhook before Plex has scanned the new file, so the apply retries quietly for a few minutes, then gives up and leaves it to the next scheduled run.  Ambiguous title matches (for example same-name remakes) are skipped rather than guessed, and nothing is applied when no configured user has the title.  The endpoints return 404 if ```enable_webhooks``` is disabled.
 
 ### Scheduler with Apprise notifications
-Basic scheduler, so that you can leave this running and update all your artwork every day. 
+Basic scheduler, so that you can leave this running and update all your artwork automatically.
 
-The basic version is available now on the bulk imports page, click on the clock to enable or disable per file.  
+Available now on the bulk imports page, click on the clock to add, edit or remove schedules for the file you have open. A file can carry more than one schedule, and each one either runs daily at a fixed time or repeats every N hours or days, so a large nightly run and a smaller one twice a day can share the same list without needing separate files.
 
-It's there for when we have API access (and works for scrapers in the meantime) but is limited to running once a day which should be fine.  If you enable ```cache_user_scrapes```, a daily scheduled user scrape only fetches uploads that are new since the last run, so scheduled full-catalogue runs stay fast.
+It's there for when we have API access (and works for scrapers in the meantime).  If you enable ```cache_user_scrapes```, a scheduled user scrape only fetches uploads that are new since the last run, so scheduled full-catalogue runs stay fast.
 
 If you enable ```skip_locked_artwork```, a scheduled user or bulk scrape will only fill items that are still on their default artwork and leave anything you've set by hand untouched, so it's safe to leave running against a curated library.
 

--- a/artwork_uploader.py
+++ b/artwork_uploader.py
@@ -263,6 +263,20 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
         filename:       The filename of the bulk import file being processed.
     """
 
+    display_filename = filename if filename else "bulk_import.txt"
+
+    # Single-flight guard: two bulk imports racing against the same Plex library is worse than
+    # a skipped one - the artwork ID label and locked-field logic both assume a single writer.
+    # A second run is refused rather than queued, so it doesn't silently pile up if schedules
+    # collide repeatedly; the caller (a schedule or the user) simply tries again later.
+    if not globals.bulk_import_lock.acquire(blocking=False):
+        message = f"⚠️ Bulk import of '{display_filename}' refused - another bulk import is already running"
+        update_log(instance, message)
+        update_status(instance, "Bulk import refused: another bulk import is already running", color=StatusColor.WARNING.value)
+        if scheduled:
+            send_notification(instance, message)
+        return
+
     # Track successful poster uploads (those with ✅ or ♻️)
     success_counter = [0]
     assets_processed = [0]
@@ -284,7 +298,6 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
 
         start_time = time.time()
         # Log the start of the bulk import process
-        display_filename = filename if filename else "bulk_import.txt"
 
         # Show the progress bar on the web UI
         message = f"{display_filename} • 0 of {len(parsed_urls)}"
@@ -367,6 +380,7 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
             globals.cancel_scrape = False
             notify_web(instance, "scrape_state", {"running": False, "type": globals.scrape_type})
             globals.scrape_type = "stopped"
+        globals.bulk_import_lock.release()
 
 # Scraped the URL then uploads what it's scraped to Plex or download to Kometa asset directory
 def scrape_and_upload(instance: Instance, url, options, bulk=False, success_counter=None, assets_processed=None, cached_counter=None, locked_counter=None, failed_counter=None):

--- a/artwork_uploader.py
+++ b/artwork_uploader.py
@@ -1,4 +1,5 @@
 import uuid, os, re, threading, sys, time
+from datetime import datetime
 from core import globals
 
 # plexapi builds its X-Plex-Client-Identifier from uuid.getnode(), which can be
@@ -628,8 +629,29 @@ def get_latest_version():
     return globals.update_service.get_latest_version() if globals.update_service else None
 
 def add_file_to_schedule_thread(instance: Instance, filename):
-    if instance:
-        threading.Thread(target=process_bulk_file_on_schedule, args=(instance, filename,)).start()
+    if not instance:
+        return
+
+    # Overlap guard: don't let a catch-up run and a normally scheduled run for the
+    # same file execute at the same time.
+    if not globals.scheduler_service.try_start(filename):
+        update_log(instance, f"⏳ Scheduled bulk import for '{filename}' skipped, a run is already in progress")
+        debug_me(f"Skipped scheduled run for '{filename}': already in progress")
+        return
+
+    record_schedule_run(filename)
+    threading.Thread(target=process_bulk_file_on_schedule, args=(instance, filename,)).start()
+
+def record_schedule_run(filename):
+    """Record that a scheduled run for this bulk file has just started, so a future
+    restart can tell whether a run was missed."""
+    if globals.config is None:
+        return
+    for each_schedule in globals.config.schedules:
+        if each_schedule.get("file") == filename:
+            each_schedule["last_run"] = datetime.now().isoformat()
+            break
+    globals.config.save()
 
 def process_bulk_file_on_schedule(instance: Instance, filename):
 
@@ -652,6 +674,8 @@ def process_bulk_file_on_schedule(instance: Instance, filename):
         update_log(instance, f"🔴 Scheduled bulk import failed due to missing file ({filename})")
     except Exception as e:
         update_log(instance, f"🔴 Scheduled bulk import unexpectedly failed ({str(e)})")
+    finally:
+        globals.scheduler_service.finish(filename)
 
 
 # Legacy functions - now handled by SchedulerService
@@ -692,11 +716,45 @@ def setup_scheduler_on_first_load(instance: Instance):
             each_schedule["jobReference"] = job_id
             scheduled_jobs_by_file[schedule_file] = job_id
 
+            # Catch up any run that was due while the app was not running
+            catch_up_missed_schedule(instance, schedule_file, schedule_time, each_schedule.get("last_run"))
+
         # Start the scheduler
         if globals.scheduler_service.start():
             debug_me("Scheduler started.")
 
         debug_me(globals.config.schedules)
+
+
+def catch_up_missed_schedule(instance: Instance, filename, schedule_time, last_run):
+    """
+    Run a scheduled bulk import that was due while the app was not running, if it falls
+    inside the configured catch-up window. Otherwise, just log that it was skipped.
+
+    Args:
+        instance: Instance to run/log the catch-up as
+        filename: Bulk file the schedule is for
+        schedule_time: Time of day the schedule runs, as "HH:MM"
+        last_run: ISO timestamp of the last time this schedule ran, or None
+    """
+    window_minutes = globals.config.catch_up_window_minutes if globals.config else 0
+
+    due, within_window = globals.scheduler_service.get_missed_run(
+        schedule_time, last_run, datetime.now(), window_minutes
+    )
+
+    if due is None:
+        return
+
+    due_display = due.strftime("%Y-%m-%d %H:%M")
+
+    if within_window:
+        update_log(instance, f"⏰ Catching up missed scheduled run for '{filename}' (was due {due_display})")
+        debug_me(f"Catch-up run for '{filename}', due {due.isoformat()}, window {window_minutes} minutes")
+        add_file_to_schedule_thread(instance, filename)
+    else:
+        update_log(instance, f"⚠️ Scheduled run for '{filename}' was missed and is outside the catch-up window (was due {due_display})")
+        debug_me(f"Missed scheduled run for '{filename}', due {due.isoformat()}, outside catch-up window of {window_minutes} minutes")
 
 
 # Update the job references for any scheduled jobs if we reload the config file

--- a/artwork_uploader.py
+++ b/artwork_uploader.py
@@ -276,6 +276,11 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
             send_notification(instance, message)
         return
 
+    if scheduled and filename:
+        # Stamp the run only once it holds the lock: a refused run has not run,
+        # and stamping it would hide the miss from catch-up.
+        record_schedule_run(filename)
+
     # Track successful poster uploads (those with ✅ or ♻️)
     success_counter = [0]
     assets_processed = [0]
@@ -637,8 +642,12 @@ def add_file_to_schedule_thread(instance: Instance, filename):
         debug_me(f"Skipped scheduled run for '{filename}': already in progress")
         return
 
-    record_schedule_run(filename)
-    threading.Thread(target=process_bulk_file_on_schedule, args=(instance, filename,)).start()
+    try:
+        threading.Thread(target=process_bulk_file_on_schedule, args=(instance, filename,)).start()
+    except Exception as e:
+        # The guard must not leak, and an error here must not kill the scheduler thread
+        globals.scheduler_service.finish(filename)
+        update_log(instance, f"🔴 Could not start scheduled bulk import for '{filename}' ({e})")
 
 def record_schedule_run(filename):
     """Record that a scheduled run for this bulk file has just started, so a future
@@ -649,10 +658,15 @@ def record_schedule_run(filename):
     with no last_run, which disables catch-up for them."""
     if globals.config is None:
         return
-    for each_schedule in globals.config.schedules:
-        if each_schedule.get("file") == filename:
-            each_schedule["last_run"] = datetime.now().isoformat()
-    globals.config.save()
+    try:
+        for each_schedule in globals.config.schedules:
+            if each_schedule.get("file") == filename:
+                each_schedule["last_run"] = datetime.now().isoformat()
+        globals.config.save()
+    except Exception as e:
+        # A failed stamp costs one catch-up decision; letting it propagate would
+        # kill the scheduler thread, which costs every future run.
+        debug_me(f"Could not record schedule run for '{filename}': {e}")
 
 def process_bulk_file_on_schedule(instance: Instance, filename):
 
@@ -703,20 +717,21 @@ def setup_scheduler_on_first_load(instance: Instance):
                 add_file_to_schedule_thread(instance, filename)
 
             # Add to scheduler service, reusing the id already stored in
-            # config so the schedule keeps the same identity across reloads
-            globals.scheduler_service.add_schedule(
-                schedule_file,
-                schedule_callback,
-                schedule_id=schedule_id,
-                time=each_schedule.get("time"),
-                interval_value=each_schedule.get("interval_value"),
-                interval_unit=each_schedule.get("interval_unit"),
-            )
-
-            # Catch up any daily run that was due while the app was not running.
-            # Interval schedules carry no fixed due time, so get_missed_run
-            # reports nothing missed for them.
-            catch_up_missed_schedule(instance, schedule_file, each_schedule.get("time"), each_schedule.get("last_run"))
+            # config so the schedule keeps the same identity across reloads.
+            # A malformed persisted entry is skipped, not fatal: one bad line in
+            # config.json must not stop the app starting.
+            try:
+                globals.scheduler_service.add_schedule(
+                    schedule_file,
+                    schedule_callback,
+                    schedule_id=schedule_id,
+                    time=each_schedule.get("time"),
+                    interval_value=each_schedule.get("interval_value"),
+                    interval_unit=each_schedule.get("interval_unit"),
+                )
+            except ValueError as e:
+                update_log(instance, f"🔴 Skipping invalid schedule for '{schedule_file}': {e}")
+                debug_me(f"Skipping invalid schedule entry {each_schedule}: {e}")
 
 
         # Start the scheduler
@@ -724,6 +739,18 @@ def setup_scheduler_on_first_load(instance: Instance):
             debug_me("Scheduler started.")
 
         debug_me(globals.config.schedules)
+
+
+def catch_up_missed_schedules(instance: Instance):
+    """Run any daily schedule that was due while the app was not running.
+
+    Called from main only after the Plex libraries are connected: a catch-up run
+    fired before that point executes against empty libraries, fails every item,
+    and burns its one chance to be caught up."""
+    if globals.config is None:
+        return
+    for each_schedule in globals.config.schedules:
+        catch_up_missed_schedule(instance, each_schedule.get("file"), each_schedule.get("time"), each_schedule.get("last_run"))
 
 
 def catch_up_missed_schedule(instance: Instance, filename, schedule_time, last_run):
@@ -936,6 +963,10 @@ if __name__ == "__main__":
                     print(f"{e}\n")
                     print("The web UI will still start, but you won't be able to upload artwork")
                     print("until you fix the Plex connection in Settings.\n")
+
+            # Catch up missed schedules only now that the libraries are connected
+            if plex_connected and (os.getenv("WERKZEUG_RUN_MAIN") == "true" or not globals.debug):
+                catch_up_missed_schedules(cli_instance)
 
             # Create the app and web server
 

--- a/artwork_uploader.py
+++ b/artwork_uploader.py
@@ -100,8 +100,6 @@ globals.docker = os.getenv("RUNNING_IN_DOCKER") == "1"
 # ! Interactive CLI mode flag
 interactive_cli = False  # Set to False when building the executable with PyInstaller for it launches the web UI by default
 mode = InstanceMode.CLI.value
-scheduled_jobs = {}  # Legacy - kept for backwards compatibility
-scheduled_jobs_by_file = {}  # Legacy - kept for backwards compatibility
 # Services moved to core.globals for proper cross-module access
 config = None  # Initialized in main
 
@@ -644,13 +642,16 @@ def add_file_to_schedule_thread(instance: Instance, filename):
 
 def record_schedule_run(filename):
     """Record that a scheduled run for this bulk file has just started, so a future
-    restart can tell whether a run was missed."""
+    restart can tell whether a run was missed.
+
+    A run executes the whole file, so every schedule the file carries gets the
+    stamp. Stamping only the first would leave the file's other daily schedules
+    with no last_run, which disables catch-up for them."""
     if globals.config is None:
         return
     for each_schedule in globals.config.schedules:
         if each_schedule.get("file") == filename:
             each_schedule["last_run"] = datetime.now().isoformat()
-            break
     globals.config.save()
 
 def process_bulk_file_on_schedule(instance: Instance, filename):
@@ -678,10 +679,6 @@ def process_bulk_file_on_schedule(instance: Instance, filename):
         globals.scheduler_service.finish(filename)
 
 
-# Legacy functions - now handled by SchedulerService
-# Kept for backwards compatibility but no longer used internally
-
-
 #Initialises the scheduler when the script is run
 def setup_scheduler_on_first_load(instance: Instance):
     """
@@ -698,26 +695,29 @@ def setup_scheduler_on_first_load(instance: Instance):
     # If there are no scheduled jobs already...
     if not globals.scheduler_service.has_schedules():
         for each_schedule in globals.config.schedules:
+            schedule_id = each_schedule.get("id")
             schedule_file = each_schedule.get("file")
-            schedule_time = each_schedule.get("time")
 
             # Create the callback for this schedule
             def schedule_callback(filename=schedule_file):
                 add_file_to_schedule_thread(instance, filename)
 
-            # Add to scheduler service
-            job_id = globals.scheduler_service.add_schedule(
+            # Add to scheduler service, reusing the id already stored in
+            # config so the schedule keeps the same identity across reloads
+            globals.scheduler_service.add_schedule(
                 schedule_file,
-                schedule_time,
-                schedule_callback
+                schedule_callback,
+                schedule_id=schedule_id,
+                time=each_schedule.get("time"),
+                interval_value=each_schedule.get("interval_value"),
+                interval_unit=each_schedule.get("interval_unit"),
             )
 
-            # Store job reference in config and legacy dicts
-            each_schedule["jobReference"] = job_id
-            scheduled_jobs_by_file[schedule_file] = job_id
+            # Catch up any daily run that was due while the app was not running.
+            # Interval schedules carry no fixed due time, so get_missed_run
+            # reports nothing missed for them.
+            catch_up_missed_schedule(instance, schedule_file, each_schedule.get("time"), each_schedule.get("last_run"))
 
-            # Catch up any run that was due while the app was not running
-            catch_up_missed_schedule(instance, schedule_file, schedule_time, each_schedule.get("last_run"))
 
         # Start the scheduler
         if globals.scheduler_service.start():
@@ -757,14 +757,13 @@ def catch_up_missed_schedule(instance: Instance, filename, schedule_time, last_r
         debug_me(f"Missed scheduled run for '{filename}', due {due.isoformat()}, outside catch-up window of {window_minutes} minutes")
 
 
-# Update the job references for any scheduled jobs if we reload the config file
+# Kept as a hook for the "load_config" socket event. There is nothing to
+# resync here: a schedule's id is the single source of truth shared between
+# config.json and the running scheduler, and every add/edit/delete/rename
+# already keeps the two in step as they happen, so reloading config.json
+# from disk does not need to tear down and rebuild the live jobs.
 def update_scheduled_jobs():
-    if globals.config is None:
-        return
-    for each_schedule in globals.config.schedules:
-        schedule_file = each_schedule.get("file", "")
-        if schedule_file and schedule_file in scheduled_jobs_by_file:
-            each_schedule["jobReference"] = scheduled_jobs_by_file[schedule_file]
+    pass
 
 
 # * Main Initialization ---

--- a/core/config.py
+++ b/core/config.py
@@ -42,6 +42,7 @@ class Config:
         auto_manage_bulk_files: Whether to auto-organize bulk files
         reset_overlay: Whether to reset Kometa overlay labels on upload
         schedules: List of scheduled bulk import jobs
+        catch_up_window_minutes: How late a missed scheduled run can be and still run on startup, in minutes (0 disables catch-up)
         auth_enabled: Whether authentication is enabled for the web server
         auth_username: Username for web server authentication
         auth_password_hash: Hashed password for web server authentication
@@ -78,6 +79,7 @@ class Config:
         self.auto_manage_bulk_files: bool = True
         self.reset_overlay: bool = False
         self.schedules: List[Dict[str, Any]] = []
+        self.catch_up_window_minutes: int = 0
         self.auth_enabled: bool = False
         self.auth_username: str = ""
         self.auth_password_hash: str = ""
@@ -128,6 +130,7 @@ class Config:
             self.auto_manage_bulk_files = config.get("auto_manage_bulk_files", True)
             self.reset_overlay = config.get("reset_overlay", False)
             self.schedules = config.get("schedules", [])
+            self.catch_up_window_minutes = config.get("catch_up_window_minutes", 0)
             self.auth_enabled = config.get("auth_enabled", False)
             self.auth_username = config.get("auth_username", "")
             self.auth_password_hash = config.get("auth_password_hash", "")
@@ -167,6 +170,7 @@ class Config:
             "auto_manage_bulk_files": True,
             "reset_overlay": True,
             "schedules": [],
+            "catch_up_window_minutes": 0,
             "apprise_urls": [],
             "enable_webhooks": False,
             "webhook_token": "",
@@ -220,6 +224,7 @@ class Config:
             "auto_manage_bulk_files": self.auto_manage_bulk_files,
             "reset_overlay": self.reset_overlay,
             "schedules": self.schedules,
+            "catch_up_window_minutes": self.catch_up_window_minutes,
             "auth_enabled": self.auth_enabled,
             "auth_username": self.auth_username,
             "auth_password_hash": self.auth_password_hash,

--- a/core/config.py
+++ b/core/config.py
@@ -2,7 +2,7 @@
 Application configuration management.
 """
 
-import json, os
+import json, os, uuid
 from core import globals
 from typing import List, Dict, Any
 from core.constants import (
@@ -129,7 +129,7 @@ class Config:
             self.user_cache_refresh_days = config.get("user_cache_refresh_days", 7)
             self.auto_manage_bulk_files = config.get("auto_manage_bulk_files", True)
             self.reset_overlay = config.get("reset_overlay", False)
-            self.schedules = config.get("schedules", [])
+            self.schedules, schedules_migrated = self._migrate_schedules(config.get("schedules", []))
             self.catch_up_window_minutes = config.get("catch_up_window_minutes", 0)
             self.auth_enabled = config.get("auth_enabled", False)
             self.auth_username = config.get("auth_username", "")
@@ -146,6 +146,33 @@ class Config:
 
         except Exception as e:
             raise ConfigLoadError(f"Error loading configuration from '{self.path}': {e}") from e
+
+        # Persist any ids minted by the migration above, so they stay stable
+        # across reloads instead of being handed out fresh every time (which
+        # would break anything that had already matched a schedule by id).
+        if schedules_migrated:
+            self.save()
+
+    @staticmethod
+    def _migrate_schedules(schedules: List[Dict[str, Any]]) -> tuple[List[Dict[str, Any]], bool]:
+        """
+        Give every schedule an id, so schedules are addressed by their own
+        id rather than by filename.
+
+        Older config.json files stored one schedule per file as
+        {"file": ..., "time": ...} with no id. Those entries keep working
+        unchanged, they just gain an id here so they can sit alongside
+        other schedules on the same file.
+
+        Returns:
+            The schedule list, and whether any entry was missing an id
+        """
+        migrated = False
+        for entry in schedules:
+            if "id" not in entry:
+                entry["id"] = str(uuid.uuid4())
+                migrated = True
+        return schedules, migrated
 
     def create(self) -> None:
         """Create a new configuration file with default values."""

--- a/core/globals.py
+++ b/core/globals.py
@@ -1,3 +1,4 @@
+import threading
 from typing import Literal
 # Application globals
 config = None  # Config object
@@ -19,3 +20,7 @@ scrapes_running: int = 0      # How many scrapes are in flight; the flag clears 
 scrape_type: Literal['scrape', 'bulk', 'upload', 'stopped'] = 'stopped'
 main_bar: dict = {}
 bulk_bar: dict = {}
+
+# Single-flight guard for bulk imports (scheduled or manual). A second bulk import that starts
+# while one is already running is refused rather than queued - see process_bulk_import_from_ui.
+bulk_import_lock = threading.Lock()

--- a/services/scheduler_service.py
+++ b/services/scheduler_service.py
@@ -7,11 +7,20 @@ maintainability.
 
 import threading, schedule, time, uuid
 from datetime import datetime, timedelta
-from typing import Dict, Callable, Optional, Set, Tuple
+from typing import Dict, Callable, List, Optional, Set, Tuple
+
+VALID_INTERVAL_UNITS = ("hours", "days")
 
 
 class SchedulerService:
-    """Handles scheduling of bulk import jobs."""
+    """Handles scheduling of bulk import jobs.
+
+    A bulk file can carry more than one schedule, and each schedule can
+    either run daily at a fixed time or repeat every N hours/days. Every
+    schedule is tracked by its own id rather than by filename, so a file
+    can have any number of schedules and renaming a file does not require
+    tearing down and recreating its jobs.
+    """
 
     def __init__(self, check_interval: int = 1) -> None:
         """
@@ -23,8 +32,8 @@ class SchedulerService:
         self.check_interval = check_interval
         self.scheduler_thread: Optional[threading.Thread] = None
         self.scheduled_jobs: Dict[str, schedule.Job] = {}
-        self.scheduled_jobs_by_file: Dict[str, str] = {}
-        self.run_times_by_file: Dict [str, str] = {}
+        # job_id -> {"file": str, "time": str} or {"file": str, "interval_value": int, "interval_unit": str}
+        self.schedule_meta: Dict[str, Dict] = {}
         self.is_running = False
         self._running_lock = threading.Lock()
         self._running_files: Set[str] = set()
@@ -32,32 +41,54 @@ class SchedulerService:
     def add_schedule(
         self,
         filename: str,
-        schedule_time: str,
-        callback: Callable[[str], None]
+        callback: Callable[[str], None],
+        schedule_id: Optional[str] = None,
+        time: Optional[str] = None,
+        interval_value: Optional[int] = None,
+        interval_unit: Optional[str] = None,
     ) -> str:
         """
-        Add a new scheduled job.
+        Add a new scheduled job, either a daily time or a repeating interval.
 
         Args:
             filename: Name of the bulk file to process
-            schedule_time: Time to run (e.g., "14:30")
             callback: Function to call with filename when job runs
+            schedule_id: Reuse this id instead of generating one (used when
+                restoring schedules from config on load)
+            time: Time of day to run daily (e.g., "14:30"). Mutually
+                exclusive with interval_value/interval_unit.
+            interval_value: Repeat every this many hours/days. Requires
+                interval_unit.
+            interval_unit: "hours" or "days".
 
         Returns:
             Unique job ID for this schedule
+
+        Raises:
+            ValueError: If neither a time nor a valid interval is given
         """
-        # Create the scheduled job
-        job = schedule.every().day.at(schedule_time).do(
-            lambda: callback(filename)
-        )
+        job_id = schedule_id or str(uuid.uuid4())
 
-        # Create a unique job ID
-        job_id = str(uuid.uuid4())
+        # The callback reads the filename from schedule_meta at run time
+        # (rather than capturing it in the closure) so that renaming a
+        # file only needs to update the metadata, not the underlying job.
+        def run_job(job_id=job_id):
+            meta = self.schedule_meta.get(job_id)
+            if meta:
+                callback(meta["file"])
 
-        # Store job references
+        if time:
+            job = schedule.every().day.at(time).do(run_job)
+            meta = {"file": filename, "time": time}
+        elif interval_value and interval_unit in VALID_INTERVAL_UNITS:
+            interval_job = getattr(schedule.every(interval_value), interval_unit)
+            job = interval_job.do(run_job)
+            meta = {"file": filename, "interval_value": interval_value, "interval_unit": interval_unit}
+        else:
+            raise ValueError("A schedule needs either a daily time or an interval_value with a valid interval_unit")
+
         self.scheduled_jobs[job_id] = job
-        self.scheduled_jobs_by_file[filename] = job_id
-        self.run_times_by_file[filename] = schedule_time
+        self.schedule_meta[job_id] = meta
 
         return job_id
 
@@ -74,37 +105,44 @@ class SchedulerService:
         if job_id not in self.scheduled_jobs:
             return False
 
-        # Get the job
-        job = self.scheduled_jobs[job_id]
+        schedule.cancel_job(self.scheduled_jobs[job_id])
 
-        # Remove from schedule library
-        schedule.cancel_job(job)
-
-        # Remove from our tracking dicts
         del self.scheduled_jobs[job_id]
-
-        # Remove from file lookup (find which file maps to this job_id)
-        file_to_remove = None
-        for filename, jid in self.scheduled_jobs_by_file.items():
-            if jid == job_id:
-                file_to_remove = filename
-                break
-        if file_to_remove:
-            del self.scheduled_jobs_by_file[file_to_remove]
+        self.schedule_meta.pop(job_id, None)
 
         return True
 
-    def get_job_id_by_file(self, filename: str) -> Optional[str]:
+    def get_jobs_for_file(self, filename: str) -> List[str]:
         """
-        Get the job ID for a scheduled file.
+        Get every job ID scheduled against a file.
 
         Args:
             filename: Filename to look up
 
         Returns:
-            Job ID if found, None otherwise
+            List of job IDs (possibly empty)
         """
-        return self.scheduled_jobs_by_file.get(filename)
+        return [job_id for job_id, meta in self.schedule_meta.items() if meta["file"] == filename]
+
+    def rename_file(self, old_filename: str, new_filename: str) -> List[str]:
+        """
+        Point every schedule for old_filename at new_filename instead.
+
+        Because the callback reads the filename from schedule_meta at run
+        time, this is enough to keep the schedules working - the
+        underlying jobs never need to be cancelled and recreated.
+
+        Args:
+            old_filename: Filename the schedules currently reference
+            new_filename: Filename they should reference instead
+
+        Returns:
+            List of job IDs that were updated
+        """
+        job_ids = self.get_jobs_for_file(old_filename)
+        for job_id in job_ids:
+            self.schedule_meta[job_id]["file"] = new_filename
+        return job_ids
 
     def start(self) -> bool:
         """
@@ -139,7 +177,7 @@ class SchedulerService:
         """Clear all scheduled jobs."""
         schedule.clear()
         self.scheduled_jobs.clear()
-        self.scheduled_jobs_by_file.clear()
+        self.schedule_meta.clear()
 
     def get_all_job_ids(self) -> list[str]:
         """

--- a/services/scheduler_service.py
+++ b/services/scheduler_service.py
@@ -6,7 +6,8 @@ maintainability.
 """
 
 import threading, schedule, time, uuid
-from typing import Dict, Callable, Optional
+from datetime import datetime, timedelta
+from typing import Dict, Callable, Optional, Set, Tuple
 
 
 class SchedulerService:
@@ -25,6 +26,8 @@ class SchedulerService:
         self.scheduled_jobs_by_file: Dict[str, str] = {}
         self.run_times_by_file: Dict [str, str] = {}
         self.is_running = False
+        self._running_lock = threading.Lock()
+        self._running_files: Set[str] = set()
 
     def add_schedule(
         self,
@@ -155,3 +158,79 @@ class SchedulerService:
             True if there are schedules, False otherwise
         """
         return len(self.scheduled_jobs) > 0
+
+    def try_start(self, filename: str) -> bool:
+        """
+        Mark a scheduled bulk file as running, if it isn't already.
+
+        This is the overlap guard: a catch-up run and a normally scheduled run for the
+        same file must not execute at the same time.
+
+        Args:
+            filename: Bulk file the run is for
+
+        Returns:
+            True if the run was allowed to start, False if one was already in progress
+        """
+        with self._running_lock:
+            if filename in self._running_files:
+                return False
+            self._running_files.add(filename)
+            return True
+
+    def finish(self, filename: str) -> None:
+        """
+        Mark a scheduled bulk file run as finished, releasing the overlap guard.
+
+        Args:
+            filename: Bulk file the run was for
+        """
+        with self._running_lock:
+            self._running_files.discard(filename)
+
+    @staticmethod
+    def get_missed_run(
+        schedule_time: str,
+        last_run: Optional[str],
+        now: datetime,
+        window_minutes: int
+    ) -> Tuple[Optional[datetime], bool]:
+        """
+        Work out whether a daily schedule missed its most recent run.
+
+        A run is only considered missed if we have a recorded last run time that
+        predates it - a schedule with no recorded run yet (brand new, or never run
+        under a build that tracked this) is never treated as having missed anything.
+
+        Args:
+            schedule_time: Time of day the schedule runs, as "HH:MM"
+            last_run: ISO timestamp of the last time this schedule ran, or None
+            now: Current time
+            window_minutes: How late a missed run can be and still count as catchable
+
+        Returns:
+            A (due, within_window) tuple. due is None if nothing was missed.
+            within_window is True if the miss is inside the catch-up window.
+        """
+        if not last_run:
+            return None, False
+
+        try:
+            hour, minute = (int(part) for part in schedule_time.split(":"))
+            due = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
+        except (ValueError, AttributeError, TypeError):
+            return None, False
+
+        if due > now:
+            due -= timedelta(days=1)
+
+        try:
+            last_run_at = datetime.fromisoformat(last_run)
+        except (ValueError, TypeError):
+            last_run_at = None
+
+        if last_run_at is not None and last_run_at >= due:
+            return None, False
+
+        within_window = (now - due) <= timedelta(minutes=window_minutes)
+        return due, within_window

--- a/static/web_interface.css
+++ b/static/web_interface.css
@@ -195,8 +195,8 @@ h1 {
     position: absolute;
     top: 0;
     right: 55px; /* Move the tooltip 20px to the right */
-    background: #f8f9fa;
-    border: 1px solid #dee2e6;
+    background: var(--bs-body-bg);
+    border: 1px solid var(--bs-border-color);
     padding: 15px;
     border-radius: 5px;
     box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.1);
@@ -215,7 +215,7 @@ h1 {
     height: 0;
     border-left: 10px solid transparent;
     border-right: 10px solid transparent;
-    border-bottom: 10px solid #dee2e6; /* Arrow border color */
+    border-bottom: 10px solid var(--bs-border-color); /* Arrow border color */
 }
 
 /* Inner arrow (matches tooltip background) */
@@ -228,7 +228,7 @@ h1 {
     height: 0;
     border-left: 9px solid transparent;
     border-right: 9px solid transparent;
-    border-bottom: 9px solid #f8f9fa; /* Matches tooltip background */
+    border-bottom: 9px solid var(--bs-body-bg); /* Matches tooltip background */
 }
 
 /* Class to show tooltip */

--- a/static/web_interface.js
+++ b/static/web_interface.js
@@ -64,10 +64,13 @@ const scrapeUrlInput = document.getElementById("scrape_url");
 const dropArea = document.getElementById("drop-area");
 const scheduleIcon = document.getElementById("schedule_icon");
 const setTimeBtn = document.getElementById("set_time");
-const cancelTimeBtn = document.getElementById("cancel_time");
-const setContainer = document.getElementById("set_container");
-const cancelContainer = document.getElementById("cancel_container");
 const scheduleTimeInput = document.getElementById("schedule_time");
+const scheduleTypeSelect = document.getElementById("schedule_type");
+const scheduleTimeGroup = document.getElementById("schedule_time_group");
+const scheduleIntervalGroup = document.getElementById("schedule_interval_group");
+const scheduleIntervalValueInput = document.getElementById("schedule_interval_value");
+const scheduleIntervalUnitSelect = document.getElementById("schedule_interval_unit");
+const scheduleListEl = document.getElementById("schedule_list");
 const timeSelectBox = document.getElementById("time_select_box");
 const bulkFileSwitcher = document.getElementById("switch_bulk_file");
 
@@ -1846,6 +1849,14 @@ document.getElementById("rename_icon").addEventListener("click", function () {
                             // Set the currently loaded file
                             currentBulkImport = data.new_filename
 
+                            // Carry any schedules over to the new filename
+                            schedules.forEach(s => {
+                                if (s.file === data.old_filename) {
+                                    s.file = data.new_filename;
+                                }
+                            });
+                            updateSchedulerIcon();
+
                             // If the renamed file is the default, update the config
                             const bulkImportFileField = document.getElementById("bulk_import_file");
                             const selectElement = document.getElementById("switch_bulk_file");
@@ -1909,7 +1920,7 @@ document.getElementById("delete_icon").addEventListener("click", function () {
                         loadBulkFileList(); // Reload the file list if deleted
                         loadBulkFile(defaultBulkFile);
                         updateBulkSaveButtonState();
-                        socket.emit("delete_schedule", { instance_id: instanceId, "file": data.filename });
+                        getSchedulesForFile(data.filename).forEach(s => deleteSchedule(s.id));
                     }
                 }
             });
@@ -2246,106 +2257,166 @@ socket.on("upload_complete", function (data) {
 // Scheduler
 // =====================
 
-function updateOrAddSchedule(fileName, newTime) {
-    if (newTime == null) {
-        // Remove this schedule form the list of schedules
-        schedules = schedules.filter(s => s.file !== fileName);
-    } else {
-        const schedule = schedules.find(s => s.file === fileName);
-        if (schedule) {
-            // Update the existing schedule
-            schedule.time = newTime;
+    let editingScheduleId = null; // Set while the form is editing an existing schedule rather than adding a new one
+
+    function describeSchedule(s) {
+        if (s.time) {
+            return `Daily at ${s.time}`;
+        }
+        const unit = s.interval_value === 1 ? s.interval_unit.replace(/s$/, "") : s.interval_unit;
+        return `Every ${s.interval_value} ${unit}`;
+    }
+
+    function getSchedulesForFile(fileName) {
+        return schedules.filter(s => s.file === fileName);
+    }
+
+    // Show the time selector when the clock icon is clicked
+    scheduleIcon.addEventListener("click", function () {
+
+        const iconRect = scheduleIcon.getBoundingClientRect();
+
+        // Position tooltip relative to the icon
+        timeSelectBox.style.top = `${iconRect.bottom + window.scrollY + 10}px`; // Below the icon
+        timeSelectBox.style.right = `${window.innerWidth - iconRect.right - window.scrollX - 15}px`; // Align right edge
+
+        // Toggle visibility
+        timeSelectBox.classList.toggle("show-tooltip");
+
+    });
+
+    document.addEventListener("click", function (event) {
+        if (!timeSelectBox.contains(event.target) && !scheduleIcon.contains(event.target)) {
+            timeSelectBox.classList.remove("show-tooltip");
+        }
+    });
+
+    // Toggle between the "daily at a time" and "every N hours/days" inputs
+    scheduleTypeSelect.addEventListener("change", function () {
+        const isDaily = scheduleTypeSelect.value === "daily";
+        scheduleTimeGroup.classList.toggle("d-none", !isDaily);
+        scheduleIntervalGroup.classList.toggle("d-none", isDaily);
+    });
+
+    function resetScheduleForm() {
+        editingScheduleId = null;
+        setTimeBtn.textContent = "Add schedule";
+        scheduleTypeSelect.value = "daily";
+        scheduleTimeGroup.classList.remove("d-none");
+        scheduleIntervalGroup.classList.add("d-none");
+        scheduleTimeInput.value = "";
+        scheduleIntervalValueInput.value = 1;
+        scheduleIntervalUnitSelect.value = "hours";
+    }
+
+    function editSchedule(s) {
+        editingScheduleId = s.id;
+        setTimeBtn.textContent = "Update schedule";
+        if (s.time) {
+            scheduleTypeSelect.value = "daily";
+            scheduleTimeGroup.classList.remove("d-none");
+            scheduleIntervalGroup.classList.add("d-none");
+            scheduleTimeInput.value = s.time;
         } else {
-            // Add the new schedule
-            schedules.push({ file: fileName, time: newTime });
+            scheduleTypeSelect.value = "interval";
+            scheduleTimeGroup.classList.add("d-none");
+            scheduleIntervalGroup.classList.remove("d-none");
+            scheduleIntervalValueInput.value = s.interval_value;
+            scheduleIntervalUnitSelect.value = s.interval_unit;
         }
     }
-}
 
-// Show the time selector when the clock icon is clicked
-scheduleIcon.addEventListener("click", function () {
+    // Handle adding or updating a schedule
+    setTimeBtn.addEventListener("click", function () {
+        const payload = { instance_id: instanceId, file: currentBulkImport };
+        if (editingScheduleId) {
+            payload.id = editingScheduleId;
+        }
 
-    const iconRect = scheduleIcon.getBoundingClientRect();
+        if (scheduleTypeSelect.value === "daily") {
+            if (!scheduleTimeInput.value) return;
+            payload.time = scheduleTimeInput.value;
+        } else {
+            const intervalValue = parseInt(scheduleIntervalValueInput.value, 10);
+            if (!intervalValue || intervalValue < 1) return;
+            payload.interval_value = intervalValue;
+            payload.interval_unit = scheduleIntervalUnitSelect.value;
+        }
 
-    // Position tooltip relative to the icon
-    timeSelectBox.style.top = `${iconRect.bottom + window.scrollY + 10}px`; // Below the icon
-    timeSelectBox.style.right = `${window.innerWidth - iconRect.right - window.scrollX - 15}px`; // Align right edge
-
-    // Toggle visibility
-    timeSelectBox.classList.toggle("show-tooltip");
-
-});
-
-document.addEventListener("click", function (event) {
-    if (!timeSelectBox.contains(event.target) && !scheduleIcon.contains(event.target)) {
-        timeSelectBox.classList.remove("show-tooltip");
-    }
-});
-
-// Handle setting the time
-setTimeBtn.addEventListener("click", function () {
-    const selectedTime = scheduleTimeInput.value;
-    if (selectedTime) {
-        socket.emit("add_schedule",{instance_id:instanceId, file: currentBulkImport, time: selectedTime})
+        socket.emit("add_schedule", payload);
 
         // Wait for response on add schedule
         socket.once("add_schedule", (data) => {
             if (validResponse(data)) {
                 if (data.added) {
-                    updateOrAddSchedule(data.file, data.time);
+                    schedules = schedules.filter(s => s.id !== data.id);
+                    schedules.push({
+                        id: data.id,
+                        file: data.file,
+                        time: data.time,
+                        interval_value: data.interval_value,
+                        interval_unit: data.interval_unit
+                    });
                     updateSchedulerIcon();
-                    timeSelectBox.classList.remove("show-tooltip");
                 }
             }
         });
-
-    }
-});
-
-// Handle cancelling the schedule
-cancelTimeBtn.addEventListener("click", function () {
-    socket.emit("delete_schedule",{instance_id:instanceId, file: currentBulkImport})
-
-    // Wait for response
-    socket.once("delete_schedule", (data) => {
-        if (validResponse(data)) {
-            if (data.deleted) {
-                // Get the value of the default bulk file from the hidden field
-                updateOrAddSchedule(data.file, null, null)
-                updateSchedulerIcon();
-            } else {
-
-            }
-        timeSelectBox.classList.remove("show-tooltip");
-        }
     });
 
-});
-
-function updateSchedulerIcon(){
-    let details = getScheduleDetails(currentBulkImport);
-    if (details && details['time']) {
-        scheduleIcon.classList.remove("bi-clock");
-        scheduleIcon.classList.add("bi-clock-fill"); // Change to filled icon
-        setContainer.classList.remove("show"); // Hide Set button
-        cancelContainer.classList.add("show"); // Show Delete button
-        scheduleTimeInput.value = details['time'];
-        scheduleTimeInput.readOnly = true;
-        scheduleIcon.classList.add("text-success"); // Turn icon green
-    } else {
-        scheduleIcon.classList.add("bi-clock"); // Change to unfilled icon
-        scheduleIcon.classList.remove("bi-clock-fill");
-        scheduleIcon.classList.remove("text-success"); // Remove green color
-        setContainer.classList.add("show"); // Show Set button
-        cancelContainer.classList.remove("show"); // Hide Delete button
-        scheduleTimeInput.value = "";
-        scheduleTimeInput.readOnly = false;
+    // Handle removing a schedule from the list
+    function deleteSchedule(scheduleId) {
+        // Uses the ack callback (rather than a shared "once" listener) so that
+        // deleting several schedules in a row - e.g. all of a file's schedules
+        // when the file itself is deleted - matches each response to its own
+        // request instead of every listener consuming the first reply.
+        socket.emit("delete_schedule", { instance_id: instanceId, id: scheduleId }, (data) => {
+            if (data && data.deleted) {
+                schedules = schedules.filter(s => s.id !== data.id);
+                updateSchedulerIcon();
+            }
+        });
     }
-}
 
-function getScheduleDetails(fileName) {
-    return schedules.find(s => s.file === fileName);
-}
+    function renderScheduleList() {
+        scheduleListEl.innerHTML = "";
+        const fileSchedules = getSchedulesForFile(currentBulkImport);
+
+        fileSchedules.forEach(s => {
+            const item = document.createElement("li");
+            item.className = "list-group-item d-flex justify-content-between align-items-center";
+
+            const label = document.createElement("span");
+            label.textContent = describeSchedule(s);
+            label.setAttribute("role", "button");
+            label.addEventListener("click", () => editSchedule(s));
+
+            const deleteBtn = document.createElement("i");
+            deleteBtn.className = "bi bi-trash3 text-danger";
+            deleteBtn.setAttribute("role", "button");
+            deleteBtn.addEventListener("click", () => deleteSchedule(s.id));
+
+            item.appendChild(label);
+            item.appendChild(deleteBtn);
+            scheduleListEl.appendChild(item);
+        });
+    }
+
+    function updateSchedulerIcon(){
+        const fileSchedules = getSchedulesForFile(currentBulkImport);
+        renderScheduleList();
+
+        if (fileSchedules.length > 0) {
+            scheduleIcon.classList.remove("bi-clock");
+            scheduleIcon.classList.add("bi-clock-fill"); // Change to filled icon
+            scheduleIcon.classList.add("text-success"); // Turn icon green
+        } else {
+            scheduleIcon.classList.add("bi-clock"); // Change to unfilled icon
+            scheduleIcon.classList.remove("bi-clock-fill");
+            scheduleIcon.classList.remove("text-success"); // Remove green color
+        }
+
+        resetScheduleForm();
+    }
 
 
 

--- a/static/web_interface.js
+++ b/static/web_interface.js
@@ -1920,7 +1920,10 @@ document.getElementById("delete_icon").addEventListener("click", function () {
                         loadBulkFileList(); // Reload the file list if deleted
                         loadBulkFile(defaultBulkFile);
                         updateBulkSaveButtonState();
-                        getSchedulesForFile(data.filename).forEach(s => deleteSchedule(s.id));
+                        // The server removes the file's schedules authoritatively;
+                        // mirror it in the local list.
+                        schedules = schedules.filter(s => s.file !== data.filename);
+                        updateSchedulerIcon();
                     }
                 }
             });

--- a/static/web_interface.js
+++ b/static/web_interface.js
@@ -1113,6 +1113,9 @@ function getCurrentConfigForm() {
     current_form.upload_retry_attempts = parseInt(document.getElementById("upload_retry_attempts").value) || 3;
     current_form.upload_retry_backoff_seconds = parseFloat(document.getElementById("upload_retry_backoff_seconds").value) || 1;
 
+    // How late a missed scheduled run can be and still be caught up on startup
+    current_form.catch_up_window_minutes = parseInt(document.getElementById("catch_up_window_minutes").value) || 0;
+
     // Checkbox for taking an artist's newer artwork for posters we applied
     current_form.allow_artist_updates = document.getElementById("allow_artist_updates").checked;
 
@@ -1241,6 +1244,7 @@ function updateConfigUI(config) {
     document.getElementById("kometa_download_timeout").value = config.kometa_download_timeout ?? 10;
     document.getElementById("upload_retry_attempts").value = config.upload_retry_attempts ?? 3;
     document.getElementById("upload_retry_backoff_seconds").value = config.upload_retry_backoff_seconds ?? 1;
+    document.getElementById("catch_up_window_minutes").value = config.catch_up_window_minutes ?? 0;
     document.getElementById("allow_artist_updates").checked = config.allow_artist_updates;
     document.getElementById("option-add-to-bulk").checked = config.auto_manage_bulk_files;
     

--- a/templates/web_interface.html
+++ b/templates/web_interface.html
@@ -489,6 +489,21 @@
                                                 required />
                                             days</label>
                                         </div>                                        
+                                        <div class="mt-2 d-flex align-items-center">
+                                            <label for="catch_up_window_minutes" class="form-label me-2 mb-0"><i class="bi bi-calendar-x"></i>&ensp;Missed scheduled run catch-up window:
+                                            <input type="number"
+                                                class="form-control form-control-sm text-center d-inline-block me-0 input-monospace"
+                                                id="catch_up_window_minutes"
+                                                name="catch_up_window_minutes"
+                                                min="0"
+                                                max="1440"
+                                                value="0"
+                                                style="width: 60px;"
+                                                required />
+                                            <span class="text-nowrap">minutes
+                                            &nbsp;<i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="If the app was not running when a scheduled bulk import was due, run it on startup as long as it's within this many minutes of when it was due. Set to 0 to leave missed runs skipped, as before."></i></span></label>
+                                        </div>
+
                                     </div>
                                 </div>
                             </div>
@@ -527,7 +542,7 @@
                                             &nbsp;<i onclick="event.preventDefault(); event.stopPropagation();" class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="Waits this amount of seconds before first retry. Doubles every subsequent retry."></i></span></label>
                                         </div>
                                     </div>
-                                </div>
+                                </div> 
                             </div>
                             <!-- Notifications settings -->
                             <div class="row mb-3">

--- a/templates/web_interface.html
+++ b/templates/web_interface.html
@@ -675,18 +675,34 @@
                 <!-- Time Selector for scheduler -->
                 <div id="time_select_box" class="p-3 border">
                     <div id="tooltip_arrow"></div>
-                    <div class="row">
+
+                    <!-- Existing schedules for the current bulk file -->
+                    <ul id="schedule_list" class="list-group mb-2"></ul>
+
+                    <div class="row g-2 align-items-end">
                         <div class="col-auto">
-                            <label class="col-form-label text-dark">Every day at</label>
+                            <label class="col-form-label">Repeat</label>
+                            <select id="schedule_type" class="form-select">
+                                <option value="daily">Daily at</option>
+                                <option value="interval">Every</option>
+                            </select>
                         </div>
-                        <div class="col-auto">
+                        <div class="col-auto" id="schedule_time_group">
+                            <label class="col-form-label d-block invisible">Time</label>
                             <input type="time" id="schedule_time" class="form-control">
                         </div>
-                        <div class="col-auto collapse" id="set_container">
-                            <button id="set_time" class="btn btn-primary">Set</button>
+                        <div class="col-auto d-none" id="schedule_interval_group">
+                            <label class="col-form-label d-block invisible">Interval</label>
+                            <div class="input-group">
+                                <input type="number" id="schedule_interval_value" class="form-control" min="1" value="1" style="max-width: 80px;">
+                                <select id="schedule_interval_unit" class="form-select">
+                                    <option value="hours">Hours</option>
+                                    <option value="days">Days</option>
+                                </select>
+                            </div>
                         </div>
-                        <div class="col-auto collapse" id="cancel_container">
-                            <button id="cancel_time" class="btn btn-danger">Delete</button>
+                        <div class="col-auto">
+                            <button id="set_time" class="btn btn-primary">Add schedule</button>
                         </div>
                     </div>
                 </div>

--- a/tests/test_bulk_import_single_flight.py
+++ b/tests/test_bulk_import_single_flight.py
@@ -1,0 +1,229 @@
+"""
+Tests for the bulk import single-flight guard.
+
+Nothing used to stop two bulk imports running at the same time: two schedules
+landing on the same minute, or a manual run started while a scheduled one is
+still going, would both increment globals.scrapes_running and race each other
+against the same Plex library. process_bulk_import_from_ui now takes
+globals.bulk_import_lock before it does anything else and refuses (does not
+queue) a second run while the lock is held.
+"""
+
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import core.globals as globals
+from artwork_uploader import process_bulk_import_from_ui
+from models.instance import Instance
+
+
+@pytest.mark.unit
+def test_second_bulk_import_is_refused_while_one_is_running():
+    """A bulk import that starts while the lock is already held must not touch
+    scrapes_running or scrape_and_upload - it is refused outright, not queued."""
+    try:
+        globals.bulk_import_lock.acquire()
+        globals.scrapes_running = 0
+        globals.cancel_scrape = False
+
+        instance = Instance(mode="cli")
+        parsed_urls = [MagicMock()]
+
+        messages = {}
+
+        def fake_update_log(inst, message, *args, **kwargs):
+            messages["log"] = message
+
+        def fake_update_status(inst, message, *args, **kwargs):
+            messages["status"] = message
+
+        with (
+            patch("artwork_uploader.scrape_and_upload") as mock_scrape_and_upload,
+            patch("artwork_uploader.update_log", side_effect=fake_update_log),
+            patch("artwork_uploader.update_status", side_effect=fake_update_status),
+            patch("artwork_uploader.send_notification") as mock_send_notification,
+            patch("artwork_uploader.notify_web"),
+            patch("artwork_uploader.debug_me"),
+        ):
+            process_bulk_import_from_ui(instance, parsed_urls, "test_bulk.txt", scheduled=False)
+
+        mock_scrape_and_upload.assert_not_called()
+        mock_send_notification.assert_not_called()  # not scheduled, so no notification is sent
+        assert globals.scrapes_running == 0, "a refused run must never increment scrapes_running"
+
+        assert "log" in messages
+        assert "refused" in messages["log"].lower()
+        assert "already running" in messages["log"].lower()
+
+        assert "status" in messages
+        assert "refused" in messages["status"].lower()
+    finally:
+        if globals.bulk_import_lock.locked():
+            globals.bulk_import_lock.release()
+        globals.cancel_scrape = False
+        globals.scrapes_running = 0
+
+
+@pytest.mark.unit
+def test_refused_scheduled_bulk_import_sends_a_notification():
+    """A scheduled run that is refused must still tell the notification services,
+    or the collision is invisible to whoever isn't watching the web UI at the time."""
+    try:
+        globals.bulk_import_lock.acquire()
+        globals.scrapes_running = 0
+        globals.cancel_scrape = False
+
+        instance = Instance(mode="cli")
+        parsed_urls = [MagicMock()]
+
+        with (
+            patch("artwork_uploader.scrape_and_upload") as mock_scrape_and_upload,
+            patch("artwork_uploader.update_log"),
+            patch("artwork_uploader.update_status"),
+            patch("artwork_uploader.send_notification") as mock_send_notification,
+            patch("artwork_uploader.notify_web"),
+            patch("artwork_uploader.debug_me"),
+        ):
+            process_bulk_import_from_ui(instance, parsed_urls, "test_bulk.txt", scheduled=True)
+
+        mock_scrape_and_upload.assert_not_called()
+        mock_send_notification.assert_called_once()
+        assert "refused" in mock_send_notification.call_args.args[1].lower()
+    finally:
+        if globals.bulk_import_lock.locked():
+            globals.bulk_import_lock.release()
+        globals.cancel_scrape = False
+        globals.scrapes_running = 0
+
+
+@pytest.mark.unit
+def test_bulk_import_releases_the_lock_so_the_next_run_can_start():
+    """A completed bulk import must release globals.bulk_import_lock, otherwise every
+    run after the first would be refused forever."""
+    try:
+        globals.bulk_import_lock = type(globals.bulk_import_lock)()  # fresh, unlocked lock
+        globals.scrapes_running = 0
+        globals.cancel_scrape = False
+        globals.plex = MagicMock(tv_libraries=MagicMock(), movie_libraries=MagicMock())
+        globals.config = MagicMock(apprise_urls=[])
+
+        instance = Instance(mode="cli")
+        parsed_urls = [MagicMock()]
+
+        with (
+            patch("artwork_uploader.scrape_and_upload") as mock_scrape_and_upload,
+            patch("artwork_uploader.update_log"),
+            patch("artwork_uploader.update_status"),
+            patch("artwork_uploader.send_notification"),
+            patch("artwork_uploader.notify_web"),
+            patch("artwork_uploader.debug_me"),
+        ):
+            process_bulk_import_from_ui(instance, parsed_urls, "test_bulk.txt", scheduled=False)
+
+        mock_scrape_and_upload.assert_called_once()
+        assert not globals.bulk_import_lock.locked(), "the lock must be released once the run ends"
+        assert globals.scrapes_running == 0
+    finally:
+        if globals.bulk_import_lock.locked():
+            globals.bulk_import_lock.release()
+        globals.cancel_scrape = False
+        globals.scrapes_running = 0
+        globals.plex = None
+        globals.config = None
+
+
+@pytest.mark.unit
+def test_bulk_import_releases_the_lock_when_plex_is_not_configured():
+    """The Plex-incomplete early return sits inside the same try/finally as the rest of the
+    run, before scrapes_running is even incremented - a state a scheduled run can easily hit
+    if Plex is unreachable. It must still release the lock, or a single misconfigured run
+    would permanently jam every bulk import after it."""
+    try:
+        globals.bulk_import_lock = type(globals.bulk_import_lock)()  # fresh, unlocked lock
+        globals.scrapes_running = 0
+        globals.cancel_scrape = False
+        globals.plex = MagicMock(tv_libraries=None, movie_libraries=None)
+
+        instance = Instance(mode="cli")
+        parsed_urls = [MagicMock()]
+
+        with (
+            patch("artwork_uploader.scrape_and_upload") as mock_scrape_and_upload,
+            patch("artwork_uploader.update_log"),
+            patch("artwork_uploader.update_status") as mock_update_status,
+            patch("artwork_uploader.send_notification"),
+            patch("artwork_uploader.notify_web"),
+            patch("artwork_uploader.debug_me"),
+        ):
+            process_bulk_import_from_ui(instance, parsed_urls, "test_bulk.txt", scheduled=False)
+
+        mock_scrape_and_upload.assert_not_called()
+        mock_update_status.assert_called_once()
+        assert "Plex setup incomplete" in mock_update_status.call_args.args[1]
+        assert not globals.bulk_import_lock.locked(), "the lock must be released even when Plex isn't configured"
+        assert globals.scrapes_running == 0
+    finally:
+        if globals.bulk_import_lock.locked():
+            globals.bulk_import_lock.release()
+        globals.cancel_scrape = False
+        globals.scrapes_running = 0
+        globals.plex = None
+
+
+@pytest.mark.unit
+def test_lock_actually_serializes_concurrent_bulk_imports():
+    """Exercise the lock under real thread concurrency rather than a pre-armed lock. A plain
+    'check scrapes_running, then increment it' guard has a window between the check and the
+    increment where two threads can both pass the check - that is the exact bug this ticket
+    is about, and a test that only pre-locks before calling would not catch it coming back."""
+    try:
+        globals.bulk_import_lock = type(globals.bulk_import_lock)()  # fresh, unlocked lock
+        globals.scrapes_running = 0
+        globals.cancel_scrape = False
+        globals.plex = MagicMock(tv_libraries=MagicMock(), movie_libraries=MagicMock())
+        globals.config = MagicMock(apprise_urls=[])
+
+        first_entered = threading.Event()
+        release_first = threading.Event()
+        calls = []
+
+        def slow_scrape_and_upload(*args, **kwargs):
+            calls.append("scrape")
+            first_entered.set()
+            release_first.wait(timeout=5)
+            return None
+
+        with (
+            patch("artwork_uploader.scrape_and_upload", side_effect=slow_scrape_and_upload),
+            patch("artwork_uploader.update_log"),
+            patch("artwork_uploader.update_status"),
+            patch("artwork_uploader.send_notification"),
+            patch("artwork_uploader.notify_web"),
+            patch("artwork_uploader.debug_me"),
+        ):
+            first_thread = threading.Thread(
+                target=process_bulk_import_from_ui,
+                args=(Instance(mode="cli"), [MagicMock()], "first.txt"),
+            )
+            first_thread.start()
+            assert first_entered.wait(timeout=5), "first run never reached scrape_and_upload"
+
+            # The second run starts on this thread while the first is still inside its
+            # critical section on the other thread - this is the actual race the ticket
+            # describes (two schedules landing together, or a manual run overlapping a
+            # scheduled one).
+            process_bulk_import_from_ui(Instance(mode="cli"), [MagicMock()], "second.txt")
+
+            release_first.set()
+            first_thread.join(timeout=5)
+
+        assert calls == ["scrape"], "the second run must not have called scrape_and_upload while the first was in flight"
+    finally:
+        if globals.bulk_import_lock.locked():
+            globals.bulk_import_lock.release()
+        globals.cancel_scrape = False
+        globals.scrapes_running = 0
+        globals.plex = None
+        globals.config = None

--- a/tests/test_schedule_catchup.py
+++ b/tests/test_schedule_catchup.py
@@ -1,0 +1,138 @@
+"""
+Tests for the scheduled-run catch-up wiring in artwork_uploader.py.
+
+services/test_scheduler_service.py covers the pure missed-run calculation and the
+overlap-guard primitives in isolation. This file covers how artwork_uploader.py wires
+those primitives together: recording a run, skipping a run that would collide with one
+already in flight, and choosing whether a missed run is caught up or just logged.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import core.globals as globals
+from artwork_uploader import add_file_to_schedule_thread, catch_up_missed_schedule, record_schedule_run
+from models.instance import Instance
+from services.scheduler_service import SchedulerService
+
+
+pytestmark = pytest.mark.unit
+
+
+class FakeConfig:
+    """Stands in for core.config.Config: only the attributes this wiring touches."""
+
+    def __init__(self, schedules=None, catch_up_window_minutes=0):
+        self.schedules = schedules if schedules is not None else []
+        self.catch_up_window_minutes = catch_up_window_minutes
+        self.save = MagicMock()
+
+
+@pytest.fixture
+def scheduler():
+    previous_config = globals.config
+    previous_scheduler = globals.scheduler_service
+    globals.scheduler_service = SchedulerService()
+    yield globals.scheduler_service
+    globals.config = previous_config
+    globals.scheduler_service = previous_scheduler
+
+
+def test_record_schedule_run_stamps_last_run_and_saves(scheduler):
+    config = FakeConfig(schedules=[{"file": "bulk_import.txt", "time": "02:00"}])
+    globals.config = config
+
+    record_schedule_run("bulk_import.txt")
+
+    assert "last_run" in config.schedules[0]
+    assert config.schedules[0]["last_run"]  # non-empty ISO timestamp
+    config.save.assert_called_once()
+
+
+def test_record_schedule_run_is_a_no_op_for_an_unknown_file(scheduler):
+    config = FakeConfig(schedules=[{"file": "bulk_import.txt", "time": "02:00"}])
+    globals.config = config
+
+    record_schedule_run("some_other_file.txt")
+
+    assert "last_run" not in config.schedules[0]
+    config.save.assert_called_once()
+
+
+def test_add_file_to_schedule_thread_starts_the_run_and_marks_it_running(scheduler):
+    globals.config = FakeConfig(schedules=[{"file": "bulk_import.txt", "time": "02:00"}])
+    instance = Instance(mode="cli")
+
+    with patch("artwork_uploader.threading.Thread") as mock_thread:
+        add_file_to_schedule_thread(instance, "bulk_import.txt")
+
+    mock_thread.assert_called_once()
+    assert scheduler.try_start("bulk_import.txt") is False  # still marked running
+    scheduler.finish("bulk_import.txt")
+
+
+def test_add_file_to_schedule_thread_skips_when_a_run_is_already_in_progress(scheduler):
+    globals.config = FakeConfig(schedules=[{"file": "bulk_import.txt", "time": "02:00"}])
+    instance = Instance(mode="cli")
+    scheduler.try_start("bulk_import.txt")  # simulate a run already in flight
+
+    with patch("artwork_uploader.threading.Thread") as mock_thread:
+        add_file_to_schedule_thread(instance, "bulk_import.txt")
+
+    mock_thread.assert_not_called()
+    assert globals.config.schedules[0].get("last_run") is None  # no run was recorded
+
+
+def test_add_file_to_schedule_thread_is_a_no_op_without_an_instance(scheduler):
+    globals.config = FakeConfig(schedules=[{"file": "bulk_import.txt", "time": "02:00"}])
+
+    with patch("artwork_uploader.threading.Thread") as mock_thread:
+        add_file_to_schedule_thread(None, "bulk_import.txt")
+
+    mock_thread.assert_not_called()
+
+
+def test_catch_up_missed_schedule_triggers_a_run_inside_the_window(scheduler):
+    globals.config = FakeConfig(catch_up_window_minutes=1440)
+    instance = Instance(mode="cli")
+    last_run_yesterday = "2026-08-08T02:00:00"
+
+    with patch("artwork_uploader.datetime") as mock_datetime, \
+         patch("artwork_uploader.add_file_to_schedule_thread") as mock_add:
+        from datetime import datetime as real_datetime
+        mock_datetime.now.return_value = real_datetime(2026, 8, 9, 3, 0)
+        catch_up_missed_schedule(instance, "bulk_import.txt", "02:00", last_run_yesterday)
+
+    mock_add.assert_called_once_with(instance, "bulk_import.txt")
+
+
+def test_catch_up_missed_schedule_only_logs_when_outside_the_window(scheduler):
+    globals.config = FakeConfig(catch_up_window_minutes=30)
+    instance = Instance(mode="cli")
+    last_run_yesterday = "2026-08-08T02:00:00"
+
+    with patch("artwork_uploader.datetime") as mock_datetime, \
+         patch("artwork_uploader.add_file_to_schedule_thread") as mock_add, \
+         patch("artwork_uploader.update_log") as mock_log:
+        from datetime import datetime as real_datetime
+        mock_datetime.now.return_value = real_datetime(2026, 8, 9, 7, 30)
+        catch_up_missed_schedule(instance, "bulk_import.txt", "02:00", last_run_yesterday)
+
+    mock_add.assert_not_called()
+    assert mock_log.call_count == 1
+    logged_message = mock_log.call_args[0][1]
+    assert "missed" in logged_message.lower()
+    assert "02:00" in logged_message
+
+
+def test_catch_up_missed_schedule_does_nothing_for_a_never_run_schedule(scheduler):
+    globals.config = FakeConfig(catch_up_window_minutes=1440)
+    instance = Instance(mode="cli")
+
+    with patch("artwork_uploader.add_file_to_schedule_thread") as mock_add, \
+         patch("artwork_uploader.update_log") as mock_log:
+        catch_up_missed_schedule(instance, "bulk_import.txt", "02:00", None)
+
+    mock_add.assert_not_called()
+    mock_log.assert_not_called()

--- a/tests/test_schedule_catchup.py
+++ b/tests/test_schedule_catchup.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import core.globals as globals
-from artwork_uploader import add_file_to_schedule_thread, catch_up_missed_schedule, record_schedule_run
+from artwork_uploader import add_file_to_schedule_thread, catch_up_missed_schedule, record_schedule_run, setup_scheduler_on_first_load
 from models.instance import Instance
 from services.scheduler_service import SchedulerService
 
@@ -136,3 +136,23 @@ def test_catch_up_missed_schedule_does_nothing_for_a_never_run_schedule(schedule
 
     mock_add.assert_not_called()
     mock_log.assert_not_called()
+
+
+def test_setup_scheduler_skips_an_invalid_persisted_schedule(scheduler):
+    """One malformed entry in config.json must not stop the app starting or
+    block the valid schedules from registering."""
+    globals.config = FakeConfig(schedules=[
+        {"id": "bad", "file": "a.txt"},
+        {"id": "good", "file": "b.txt", "time": "02:00"},
+    ])
+    instance = Instance(mode="cli")
+
+    try:
+        with patch("artwork_uploader.update_log"), patch("artwork_uploader.debug_me"):
+            setup_scheduler_on_first_load(instance)
+
+        assert scheduler.get_jobs_for_file("b.txt") == ["good"]
+        assert scheduler.get_jobs_for_file("a.txt") == []
+    finally:
+        scheduler.stop()
+        scheduler.clear_all_schedules()

--- a/tests/test_scheduler_service.py
+++ b/tests/test_scheduler_service.py
@@ -1,0 +1,88 @@
+"""Unit tests for the scheduler service's missed-run catch-up logic and overlap guard."""
+
+import pytest
+from datetime import datetime
+
+from services.scheduler_service import SchedulerService
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_no_catch_up_when_never_run_before():
+    """A schedule with no recorded last run is never treated as having missed one."""
+    now = datetime(2026, 8, 9, 7, 30)
+    due, within_window = SchedulerService.get_missed_run("02:00", None, now, window_minutes=60)
+    assert due is None
+    assert within_window is False
+
+
+def test_missed_run_within_the_catch_up_window():
+    now = datetime(2026, 8, 9, 2, 15)
+    last_run = datetime(2026, 8, 8, 2, 0).isoformat()
+    due, within_window = SchedulerService.get_missed_run("02:00", last_run, now, window_minutes=30)
+    assert due == datetime(2026, 8, 9, 2, 0)
+    assert within_window is True
+
+
+def test_missed_run_outside_the_catch_up_window():
+    now = datetime(2026, 8, 9, 7, 30)
+    last_run = datetime(2026, 8, 8, 2, 0).isoformat()
+    due, within_window = SchedulerService.get_missed_run("02:00", last_run, now, window_minutes=60)
+    assert due == datetime(2026, 8, 9, 2, 0)
+    assert within_window is False
+
+
+def test_zero_window_never_catches_up():
+    now = datetime(2026, 8, 9, 2, 5)
+    last_run = datetime(2026, 8, 8, 2, 0).isoformat()
+    due, within_window = SchedulerService.get_missed_run("02:00", last_run, now, window_minutes=0)
+    assert due == datetime(2026, 8, 9, 2, 0)
+    assert within_window is False
+
+
+def test_already_ran_today_is_not_a_miss():
+    now = datetime(2026, 8, 9, 7, 30)
+    last_run = datetime(2026, 8, 9, 2, 0).isoformat()
+    due, within_window = SchedulerService.get_missed_run("02:00", last_run, now, window_minutes=60)
+    assert due is None
+    assert within_window is False
+
+
+def test_due_time_is_still_ahead_today_uses_yesterdays_occurrence():
+    """If it's not yet 02:00 today, the most recent due time was yesterday's run."""
+    now = datetime(2026, 8, 9, 1, 0)
+    last_run = datetime(2026, 8, 7, 2, 0).isoformat()
+    due, within_window = SchedulerService.get_missed_run("02:00", last_run, now, window_minutes=1440)
+    assert due == datetime(2026, 8, 8, 2, 0)
+    assert within_window is True
+
+
+def test_malformed_schedule_time_is_not_a_miss():
+    now = datetime(2026, 8, 9, 7, 30)
+    last_run = datetime(2026, 8, 8, 2, 0).isoformat()
+    due, within_window = SchedulerService.get_missed_run("not-a-time", last_run, now, window_minutes=60)
+    assert due is None
+    assert within_window is False
+
+
+def test_malformed_last_run_is_treated_as_missed():
+    now = datetime(2026, 8, 9, 2, 5)
+    due, within_window = SchedulerService.get_missed_run("02:00", "not-a-timestamp", now, window_minutes=60)
+    assert due == datetime(2026, 8, 9, 2, 0)
+    assert within_window is True
+
+
+def test_overlap_guard_blocks_a_second_start_for_the_same_file():
+    service = SchedulerService()
+    assert service.try_start("bulk_import.txt") is True
+    assert service.try_start("bulk_import.txt") is False
+
+    service.finish("bulk_import.txt")
+    assert service.try_start("bulk_import.txt") is True
+
+
+def test_overlap_guard_is_independent_per_file():
+    service = SchedulerService()
+    assert service.try_start("a.txt") is True
+    assert service.try_start("b.txt") is True

--- a/tests/test_scheduler_service.py
+++ b/tests/test_scheduler_service.py
@@ -1,9 +1,329 @@
-"""Unit tests for the scheduler service's missed-run catch-up logic and overlap guard."""
+"""Unit tests for services/scheduler_service.py: multi-schedule handling, the
+config.json schedule migration, missed-run catch-up logic and the overlap guard."""
 
-import pytest
+import json
 from datetime import datetime
 
+import pytest
+import schedule
+
+from core.config import Config
 from services.scheduler_service import SchedulerService
+
+
+@pytest.fixture(autouse=True)
+def clean_schedule_registry():
+    """The `schedule` library keeps a module-level job registry, so clear it around every test."""
+    schedule.clear()
+    yield
+    schedule.clear()
+
+
+@pytest.fixture
+def service():
+    return SchedulerService()
+
+
+def run_job(service, job_id):
+    """Directly invoke a scheduled job's function, without waiting for the schedule library's clock."""
+    service.scheduled_jobs[job_id].job_func()
+
+
+# ------------------------------- add_schedule -------------------------------
+
+@pytest.mark.unit
+def test_daily_schedule_runs_with_its_filename(service):
+    calls = []
+    job_id = service.add_schedule("bulk_a.txt", calls.append, time="02:00")
+
+    run_job(service, job_id)
+
+    assert calls == ["bulk_a.txt"]
+
+
+@pytest.mark.unit
+def test_interval_schedule_in_hours(service):
+    calls = []
+    job_id = service.add_schedule("bulk_a.txt", calls.append, interval_value=6, interval_unit="hours")
+
+    run_job(service, job_id)
+
+    assert calls == ["bulk_a.txt"]
+    assert service.schedule_meta[job_id] == {"file": "bulk_a.txt", "interval_value": 6, "interval_unit": "hours"}
+
+
+@pytest.mark.unit
+def test_interval_schedule_in_days(service):
+    job_id = service.add_schedule("bulk_a.txt", lambda f: None, interval_value=2, interval_unit="days")
+    assert service.schedule_meta[job_id]["interval_unit"] == "days"
+
+
+@pytest.mark.unit
+def test_add_schedule_requires_a_time_or_a_valid_interval(service):
+    with pytest.raises(ValueError):
+        service.add_schedule("bulk_a.txt", lambda f: None)
+
+    with pytest.raises(ValueError):
+        service.add_schedule("bulk_a.txt", lambda f: None, interval_value=3, interval_unit="fortnights")
+
+
+@pytest.mark.unit
+def test_a_file_can_carry_more_than_one_schedule(service):
+    """The original bug: a bulk file could only ever hold one schedule."""
+    first = service.add_schedule("bulk_a.txt", lambda f: None, time="02:00")
+    second = service.add_schedule("bulk_a.txt", lambda f: None, interval_value=6, interval_unit="hours")
+
+    assert first != second
+    assert service.get_all_job_ids() == [first, second] or set(service.get_all_job_ids()) == {first, second}
+    assert set(service.get_jobs_for_file("bulk_a.txt")) == {first, second}
+
+
+@pytest.mark.unit
+def test_add_schedule_reuses_a_given_id(service):
+    job_id = service.add_schedule("bulk_a.txt", lambda f: None, schedule_id="my-id", time="02:00")
+    assert job_id == "my-id"
+    assert "my-id" in service.scheduled_jobs
+
+
+# ------------------------------- remove_schedule -------------------------------
+
+@pytest.mark.unit
+def test_remove_schedule_only_removes_the_one_job(service):
+    keep = service.add_schedule("bulk_a.txt", lambda f: None, time="02:00")
+    remove = service.add_schedule("bulk_a.txt", lambda f: None, time="12:30")
+
+    assert service.remove_schedule(remove) is True
+
+    assert keep in service.scheduled_jobs
+    assert remove not in service.scheduled_jobs
+    assert service.get_jobs_for_file("bulk_a.txt") == [keep]
+
+
+@pytest.mark.unit
+def test_remove_schedule_returns_false_when_not_found(service):
+    assert service.remove_schedule("does-not-exist") is False
+
+
+# ------------------------------- rename_file -------------------------------
+
+@pytest.mark.unit
+def test_rename_file_moves_every_schedule_for_that_file(service):
+    calls = []
+    a = service.add_schedule("old.txt", calls.append, time="02:00")
+    b = service.add_schedule("old.txt", calls.append, interval_value=6, interval_unit="hours")
+    other = service.add_schedule("unrelated.txt", calls.append, time="09:00")
+
+    renamed_ids = service.rename_file("old.txt", "new.txt")
+
+    assert set(renamed_ids) == {a, b}
+    assert service.schedule_meta[a]["file"] == "new.txt"
+    assert service.schedule_meta[b]["file"] == "new.txt"
+    assert service.schedule_meta[other]["file"] == "unrelated.txt"
+
+
+@pytest.mark.unit
+def test_rename_file_does_not_recreate_the_underlying_job(service):
+    """Renaming should only touch metadata - the schedule library job stays the same object."""
+    job_id = service.add_schedule("old.txt", lambda f: None, time="02:00")
+    job_before = service.scheduled_jobs[job_id]
+
+    service.rename_file("old.txt", "new.txt")
+
+    assert service.scheduled_jobs[job_id] is job_before
+
+
+@pytest.mark.unit
+def test_renamed_schedule_calls_back_with_the_new_filename(service):
+    calls = []
+    job_id = service.add_schedule("old.txt", calls.append, time="02:00")
+
+    service.rename_file("old.txt", "new.txt")
+    run_job(service, job_id)
+
+    assert calls == ["new.txt"]
+
+
+# ------------------------------- housekeeping -------------------------------
+
+@pytest.mark.unit
+def test_has_schedules(service):
+    assert service.has_schedules() is False
+    service.add_schedule("bulk_a.txt", lambda f: None, time="02:00")
+    assert service.has_schedules() is True
+
+
+@pytest.mark.unit
+def test_clear_all_schedules(service):
+    service.add_schedule("bulk_a.txt", lambda f: None, time="02:00")
+    service.add_schedule("bulk_b.txt", lambda f: None, interval_value=1, interval_unit="days")
+
+    service.clear_all_schedules()
+
+    assert service.get_all_job_ids() == []
+    assert service.schedule_meta == {}
+    assert len(schedule.jobs) == 0
+
+
+# ------------------------------- config.json migration -------------------------------
+
+@pytest.mark.unit
+def test_legacy_schedule_entries_are_migrated_with_an_id(tmp_path):
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({
+        "schedules": [
+            {"file": "bulk_a.txt", "time": "02:00"},
+            {"file": "bulk_b.txt", "time": "12:30"},
+        ]
+    }))
+
+    config = Config(str(config_path))
+    config.load()
+
+    assert len(config.schedules) == 2
+    ids = [s["id"] for s in config.schedules]
+    assert all(ids)
+    assert len(set(ids)) == 2
+    assert config.schedules[0]["file"] == "bulk_a.txt"
+    assert config.schedules[0]["time"] == "02:00"
+
+
+@pytest.mark.unit
+def test_migration_keeps_an_existing_id_stable(tmp_path):
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({
+        "schedules": [{"id": "already-has-one", "file": "bulk_a.txt", "time": "02:00"}],
+    }))
+
+    config = Config(str(config_path))
+    config.load()
+
+    assert config.schedules[0]["id"] == "already-has-one"
+
+
+@pytest.mark.unit
+def test_migrated_ids_are_written_back_to_disk_and_stay_stable(tmp_path):
+    """A minted id that only lives in memory is useless: every socket handler
+    calls config.load() again before matching by id, so if the id were not
+    persisted, a fresh (different) one would be minted on the next load and
+    nothing would ever match again."""
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({
+        "schedules": [{"file": "bulk_a.txt", "time": "02:00"}],
+    }))
+
+    first = Config(str(config_path))
+    first.load()
+    first_id = first.schedules[0]["id"]
+
+    on_disk = json.loads(config_path.read_text())
+    assert on_disk["schedules"][0]["id"] == first_id
+
+    second = Config(str(config_path))
+    second.load()
+    assert second.schedules[0]["id"] == first_id
+
+
+@pytest.mark.unit
+def test_deleting_a_migrated_schedule_stays_deleted_after_reload(tmp_path):
+    """Regression test for web_routes.delete_task_from_scheduler: it loads
+    config again and then filters by id, which only works if the id survives
+    that reload unchanged."""
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({
+        "schedules": [{"file": "bulk_a.txt", "time": "02:00"}],
+    }))
+
+    config = Config(str(config_path))
+    config.load()
+    schedule_id = config.schedules[0]["id"]
+
+    config.load()
+    config.schedules = [s for s in config.schedules if s.get("id") != schedule_id]
+    config.save()
+
+    reloaded = Config(str(config_path))
+    reloaded.load()
+    assert reloaded.schedules == []
+
+
+@pytest.mark.unit
+def test_editing_a_migrated_schedule_updates_in_place_after_reload(tmp_path):
+    """Regression test for web_routes.update_or_add_schedule: matching an
+    existing entry by id has to actually find it, or an edit turns into a
+    second schedule alongside the original."""
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({
+        "schedules": [{"file": "bulk_a.txt", "time": "02:00"}],
+    }))
+
+    config = Config(str(config_path))
+    config.load()
+    schedule_id = config.schedules[0]["id"]
+
+    config.load()
+    matched = False
+    for each_schedule in config.schedules:
+        if each_schedule.get("id") == schedule_id:
+            each_schedule["time"] = "12:30"
+            matched = True
+    if not matched:
+        config.schedules.append({"id": schedule_id, "file": "bulk_a.txt", "time": "12:30"})
+    config.save()
+
+    reloaded = Config(str(config_path))
+    reloaded.load()
+    assert len(reloaded.schedules) == 1
+    assert reloaded.schedules[0]["time"] == "12:30"
+
+
+@pytest.mark.unit
+def test_renaming_a_migrated_schedules_file_survives_reload(tmp_path):
+    """Regression test for web_routes.rename_bulk_file: the ids handed back
+    by SchedulerService.rename_file only match config entries whose id is
+    still the same one the scheduler was built from."""
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({
+        "schedules": [{"file": "old.txt", "time": "02:00"}],
+    }))
+
+    config = Config(str(config_path))
+    config.load()
+    schedule_id = config.schedules[0]["id"]
+
+    config.load()
+    for each_schedule in config.schedules:
+        if each_schedule.get("id") == schedule_id:
+            each_schedule["file"] = "new.txt"
+    config.save()
+
+    reloaded = Config(str(config_path))
+    reloaded.load()
+    assert reloaded.schedules[0]["file"] == "new.txt"
+
+
+@pytest.mark.unit
+def test_multiple_schedules_for_one_file_survive_a_save_and_reload(tmp_path):
+    config_path = tmp_path / "config.json"
+    config = Config(str(config_path))
+    config.create()
+    config.load()
+
+    config.schedules = [
+        {"id": "a", "file": "bulk_a.txt", "time": "02:00"},
+        {"id": "b", "file": "bulk_a.txt", "interval_value": 6, "interval_unit": "hours"},
+    ]
+    config.save()
+
+    reloaded = Config(str(config_path))
+    reloaded.load()
+
+    assert len(reloaded.schedules) == 2
+    assert {s["id"] for s in reloaded.schedules} == {"a", "b"}
+    by_id = {s["id"]: s for s in reloaded.schedules}
+    assert by_id["a"]["file"] == "bulk_a.txt"
+    assert by_id["a"]["time"] == "02:00"
+    assert by_id["b"]["interval_value"] == 6
+    assert by_id["b"]["interval_unit"] == "hours"
 
 
 pytestmark = pytest.mark.unit

--- a/web_routes.py
+++ b/web_routes.py
@@ -369,7 +369,10 @@ def setup_socket_handlers(
         instance = Instance(data.get("instance_id"), "web")
         old_name = data.get("old_filename")
         new_name = data.get("new_filename")
-        rename_bulk_import_file(instance, old_name, new_name)
+        if not rename_bulk_import_file(instance, old_name, new_name):
+            # The file on disk still has its old name; repointing the schedules
+            # would leave every one of them targeting a file that does not exist.
+            return
 
         renamed_ids = globals.scheduler_service.rename_file(old_name, new_name)
         if renamed_ids:
@@ -381,9 +384,23 @@ def setup_socket_handlers(
 
     @globals.web_socket.on("delete_bulk_file")
     def delete_bulk_file(data):
-        """Delete a bulk import file."""
+        """Delete a bulk import file, and every schedule that points at it."""
         instance = Instance(data.get("instance_id"), "web")
-        delete_bulk_import_file(instance, data.get("filename"))
+        filename = data.get("filename")
+        if not delete_bulk_import_file(instance, filename):
+            return
+
+        # The server owns this cleanup: a client's in-memory schedule list can be
+        # stale, and an orphaned schedule fires forever against a missing file.
+        for job_id in globals.scheduler_service.get_jobs_for_file(filename):
+            globals.scheduler_service.remove_schedule(job_id)
+        config.load()
+        remaining = [s for s in config.schedules if s.get("file") != filename]
+        if len(remaining) != len(config.schedules):
+            removed = len(config.schedules) - len(remaining)
+            config.schedules = remaining
+            config.save()
+            update_log(instance, f"🗑️ Removed {removed} schedule(s) for '{filename}'")
 
     @globals.web_socket.on("create_bulk_file")
     def create_bulk_file(data):
@@ -658,6 +675,14 @@ def setup_socket_handlers(
                 schedule_time = data.get("time")
                 interval_value = data.get("interval_value")
                 interval_unit = data.get("interval_unit")
+
+                # Validate the shape before anything is persisted or removed: a bad
+                # payload written to config.json would raise on every startup.
+                from services.scheduler_service import VALID_INTERVAL_UNITS
+                if not schedule_time and not (interval_value and interval_unit in VALID_INTERVAL_UNITS):
+                    update_log(instance, f"🔴 Rejected invalid schedule for '{schedule_file}': needs a daily time or a valid interval")
+                    notify_web(instance, "add_schedule", {"added": False, "file": schedule_file})
+                    return {"added": False, "file": schedule_file}
 
                 # Editing an existing schedule replaces its job under the same id
                 if schedule_id:

--- a/web_routes.py
+++ b/web_routes.py
@@ -10,7 +10,7 @@ The routes are organized into:
 - Helper functions for file uploads and processing
 """
 
-import os, logging, flask.cli, sys, re, base64, hmac, tempfile, zipfile, subprocess, threading
+import os, logging, flask.cli, sys, re, base64, hmac, tempfile, zipfile, subprocess, threading, uuid
 from pathlib import Path
 from packaging import version
 from plexapi.server import PlexServer
@@ -365,15 +365,19 @@ def setup_socket_handlers(
 
     @globals.web_socket.on("rename_bulk_file")
     def rename_bulk_file(data):
-        """Rename a bulk import file."""
+        """Rename a bulk import file, taking any of its schedules along with it."""
         instance = Instance(data.get("instance_id"), "web")
         old_name = data.get("old_filename")
         new_name = data.get("new_filename")
-        time = globals.scheduler_service.run_times_by_file.get(old_name)
         rename_bulk_import_file(instance, old_name, new_name)
-        if time:
-            delete_task_from_scheduler({"instance_id": instance.id, "file": old_name})
-            add_tasks_to_scheduler({"instance_id": instance.id, "file": new_name, "time": time})
+
+        renamed_ids = globals.scheduler_service.rename_file(old_name, new_name)
+        if renamed_ids:
+            config.load()
+            for each_schedule in config.schedules:
+                if each_schedule.get("id") in renamed_ids:
+                    each_schedule["file"] = new_name
+            config.save()
 
     @globals.web_socket.on("delete_bulk_file")
     def delete_bulk_file(data):
@@ -607,49 +611,63 @@ def setup_socket_handlers(
 
     @globals.web_socket.on("delete_schedule")
     def delete_task_from_scheduler(data):
-        """Delete a scheduled task."""
+        """Delete a scheduled task, addressed by its own id.
+
+        Returns an ack value as well as broadcasting, so a caller that fires
+        several of these in a row (e.g. deleting a file with more than one
+        schedule) can match each response to its own request instead of all
+        of them racing to consume the same "delete_schedule" event.
+        """
         if data.get("instance_id"):
             instance = Instance(data.get("instance_id"), "web")
-            schedule_file = data.get("file")
+            schedule_id = data.get("id")
 
-            if schedule_file:
-                # Get job ID from scheduler service
-                job_id = globals.scheduler_service.get_job_id_by_file(schedule_file)
+            if schedule_id:
+                # Remove from scheduler service
+                removed = globals.scheduler_service.remove_schedule(schedule_id)
 
-                if job_id:
-                    # Remove from scheduler service
-                    globals.scheduler_service.remove_schedule(job_id)
-
+                if removed:
                     # Make sure it's also removed from the config file
                     config.load()
                     config.schedules = [
                         each_schedule
                         for each_schedule in config.schedules
-                        if each_schedule["file"] != schedule_file
+                        if each_schedule.get("id") != schedule_id
                     ]
                     config.save()
 
                     # And update the front-end
-                    notify_web(instance, "delete_schedule", { "file": schedule_file, "job_reference": job_id, "deleted": True })
-                    update_log(instance, f"🗑️ Deleted scheduled task for '{schedule_file}'")
-                    debug_me(f"Deleted scheduled task for '{schedule_file}' with job ID '{job_id}'")
+                    notify_web(instance, "delete_schedule", { "id": schedule_id, "deleted": True })
+                    update_log(instance, f"🗑️ Deleted scheduled task '{schedule_id}'")
+                    debug_me(f"Deleted scheduled task with job ID '{schedule_id}'")
+                    return {"id": schedule_id, "deleted": True}
                 else:
-                    debug_me(f"Couldn't find a scheduled job for '{schedule_file}'")
-                    notify_web(instance, "delete_schedule", {"deleted": False, "job_id": job_id})
+                    debug_me(f"Couldn't find a scheduled job with ID '{schedule_id}'")
+                    notify_web(instance, "delete_schedule", {"deleted": False, "id": schedule_id})
+                    return {"id": schedule_id, "deleted": False}
 
     @globals.web_socket.on("add_schedule")
     def add_tasks_to_scheduler(data):
-        """Add a new scheduled task."""
+        """Add a new scheduled task, or update an existing one if an id is given."""
         try:
             # Schedule bulk import task
             if data.get("instance_id"):
                 instance = Instance(data.get("instance_id"), "web")
+                schedule_id = data.get("id")
                 schedule_file = data.get("file")
                 schedule_time = data.get("time")
+                interval_value = data.get("interval_value")
+                interval_unit = data.get("interval_unit")
+
+                # Editing an existing schedule replaces its job under the same id
+                if schedule_id:
+                    globals.scheduler_service.remove_schedule(schedule_id)
 
                 # Make sure the schedule is saved as part of the config
                 config.load()
-                update_or_add_schedule(schedule_file, schedule_time)
+                schedule_id = update_or_add_schedule(
+                    schedule_id, schedule_file, schedule_time, interval_value, interval_unit
+                )
                 config.save()
 
                 try:
@@ -657,16 +675,27 @@ def setup_socket_handlers(
                     def schedule_callback(filename=schedule_file):
                         add_file_to_schedule_thread(instance, filename)
 
-                    # Add to scheduler service
-                    job_id = globals.scheduler_service.add_schedule(
+                    # Add to scheduler service, keeping the id from config
+                    globals.scheduler_service.add_schedule(
                         schedule_file,
-                        schedule_time,
-                        schedule_callback
+                        schedule_callback,
+                        schedule_id=schedule_id,
+                        time=schedule_time,
+                        interval_value=interval_value,
+                        interval_unit=interval_unit,
                     )
 
-                    notify_web(instance, "add_schedule", { "added": True, "file": schedule_file, "time": schedule_time, "jobReference": job_id })
-                    update_log(instance, f"⏰ Added scheduled task '{schedule_file}' every day at {schedule_time}")
-                    debug_me(f"Added scheduled task '{schedule_file}' every day at {schedule_time} with job ID '{job_id}'")
+                    description = f"every day at {schedule_time}" if schedule_time else f"every {interval_value} {interval_unit}"
+                    notify_web(instance, "add_schedule", {
+                        "added": True,
+                        "id": schedule_id,
+                        "file": schedule_file,
+                        "time": schedule_time,
+                        "interval_value": interval_value,
+                        "interval_unit": interval_unit,
+                    })
+                    update_log(instance, f"⏰ Scheduled task '{schedule_file}' {description}")
+                    debug_me(f"Scheduled task '{schedule_file}' {description} with job ID '{schedule_id}'")
                 except Exception as e:
                     update_log(instance, f"🔴 Failed to add scheduled task '{schedule_file}'")
                     debug_me(f"Error adding schedule: {e}")
@@ -679,16 +708,28 @@ def setup_socket_handlers(
             debug_me(f"Error in scheduler setup: {e}")
             raise
 
-    def update_or_add_schedule(file_name, new_time):
-        """Helper function to update or add a schedule in config."""
+    def update_or_add_schedule(schedule_id, file_name, schedule_time, interval_value, interval_unit):
+        """Helper function to update or add a schedule in config. Returns the schedule's id."""
+        entry = {"file": file_name}
+        if schedule_time:
+            entry["time"] = schedule_time
+        else:
+            entry["interval_value"] = interval_value
+            entry["interval_unit"] = interval_unit
+
         for each_schedule in config.schedules:
-            if each_schedule["file"] == file_name:
-                # Update existing schedule
-                each_schedule["time"] = new_time
-                return
+            if each_schedule.get("id") == schedule_id:
+                # Update existing schedule in place, clearing out fields from the old type
+                each_schedule.pop("time", None)
+                each_schedule.pop("interval_value", None)
+                each_schedule.pop("interval_unit", None)
+                each_schedule.update(entry)
+                return schedule_id
 
         # Add new schedule if not found
-        config.schedules.append({"file": file_name, "time": new_time})
+        new_id = schedule_id or str(uuid.uuid4())
+        config.schedules.append({"id": new_id, **entry})
+        return new_id
 
     @globals.web_socket.on("detect_docker")
     def docker_detection(data):


### PR DESCRIPTION
Three related scheduling changes, split into four commits that review independently.

Multiple schedules: a schedule now carries its own id rather than being keyed by filename. One bulk file can hold any number of schedules, each daily at a time or repeating every N hours or days. The schedule picker lists a file's schedules for editing and removal. Legacy single schedule config entries migrate with a stable id on first load. Renaming a file repoints its schedules, and deleting a file removes them server side.

Catch-up: each scheduled run stamps a last_run timestamp. On startup, a daily schedule whose due time passed while the app was down runs late, if it falls within a configurable window. The default (catch_up_window_minutes 0) keeps today's behaviour. Catch-up waits until the Plex libraries are connected, so a caught up run cannot fire against empty libraries.

Single flight: two bulk imports racing the same library breaks the artwork ID label and locked field logic, which assume a single writer. A process wide lock refuses the second run with a clear status line rather than queueing it.

The last commit hardens the seams. Schedule payloads validate before persisting, so a bad entry cannot crash every startup. A malformed entry already in config.json gets skipped with a log line. A config save failure inside the scheduler thread logs rather than kills the thread. A refused run keeps its old last_run, so it stays catchable.

Note: this touches some of the same regions as my notification routing and run history PRs. They are independent, and I am happy to rebase whichever lands last.
