### PR TITLE
Made some minor adjustments to PR #89

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ If you enable ```skip_locked_artwork```, a scheduled user or bulk scrape will on
 
 If you also enable ```allow_artist_updates```, a scheduled scrape may additionally replace artwork it applied earlier when the same artist has posted a newer version of it. It still never touches artwork you set by hand (anything without one of this tool's artwork-ID labels) or artwork from a different artist, and it only ever moves forward to a newer upload, so runs settle on each artist's latest rather than flip-flopping. It needs both ```skip_locked_artwork``` and ```track_artwork_ids``` on. Because this writes over artwork the tool previously chose, take a note of your current posters before the first run if you want to be able to revert.
 
-With ```local_library_matching``` enabled (the default), a user-catalog scrape skips everything that isn't in your libraries without any web requests, so full-catalog runs take minutes rather than hours.
+With ```local_library_matching``` enabled, a user-catalog scrape skips everything that isn't in your libraries without any web requests, so full-catalog runs take minutes rather than hours.
 
 Additionally, you can configure one or more push notification services so you get a notification every time a scheduled bulk import job completes. Notifications are provided by Apprise. Configure the list of notification services by providing a comma-separated list of Apprise notification URLs through the web UI or via the ```apprise_urls``` variable in the ```config.json```file. Check [the Apprise service list](https://appriseit.com/services/) for details on the supported services and how to set them up and generate a notification URL for your favorite services.
 
@@ -292,6 +292,18 @@ This is optional - if you don't do this, a new config.json will be created when 
 
 ```"webhook_apply_delay"```
 - Seconds to wait after an import before applying artwork (default ```30```).  The *arr apps fire the webhook the moment they import a file, usually before Plex has scanned it, so this gives Plex a head start; if the item still is not in Plex the apply retries for a few minutes before giving up.
+
+```"plex_connect_timeout"```
+- Timeout for connecting to or uploading artwork to Plex. Defaults to `10` seconds.
+
+```"kometa_download_timeout"```
+- Timeout for downloading assets from ThePosterDB or MediUX. Defaults to `10` seconds.
+
+```"upload_retry_attemts"```
+- Total number of times to attempt an operation, including the original attempt. Only transient errors (timeouts or server errors) are retried. Defaults to `3`.
+
+```"upload_retry_backoff_seconds"```
+- Cool-down period before first retry of an operation. Doubles every subsequent retry. Defaults to `1` second.
 
 ### Filter options
 Both mediux_filters and tpdb_filters specify which artwork types to upload by including the flags below.  Specify one or more in an array ["show_cover, "title_card"]. TPDb does not provide title cards, backgrounds or square art so these filters are not available in the web UI.

--- a/core/config.py
+++ b/core/config.py
@@ -7,7 +7,6 @@ from core import globals
 from typing import List, Dict, Any
 from core.constants import (
     DEFAULT_PLEX_CONNECT_TIMEOUT,
-    DEFAULT_PLEX_TEST_CONNECTION_TIMEOUT,
     DEFAULT_KOMETA_DOWNLOAD_TIMEOUT,
     DEFAULT_UPLOAD_RETRY_ATTEMPTS,
     DEFAULT_UPLOAD_RETRY_BACKOFF_SECONDS,
@@ -51,9 +50,8 @@ class Config:
         webhook_token: Shared secret required on webhook requests
         webhook_tpdb_users: ThePosterDB users to apply cached artwork from on import, in priority order
         webhook_apply_delay: Seconds to wait after an import before applying artwork (lets Plex scan first)
-        plex_connect_timeout: Seconds to wait when connecting to the Plex server (also applies to uploads)
-        plex_test_connection_timeout: Seconds to wait when testing a Plex connection from the web settings
-        kometa_download_timeout: Seconds to wait when downloading artwork to save to the Kometa asset directory
+        plex_connect_timeout: Timeout for connecting to the Plex server (also applies to uploads)
+        kometa_download_timeout: Timeout for downloading artwork to save to the Kometa asset directory
         upload_retry_attempts: Total attempts (including the first) made for a transient upload failure
         upload_retry_backoff_seconds: Seconds to wait before the first retry, doubling after each attempt
     """
@@ -73,7 +71,7 @@ class Config:
         self.stage_assets: bool = False
         self.track_artwork_ids: bool = True
         self.skip_locked_artwork: bool = False
-        self.local_library_matching: bool = True
+        self.local_library_matching: bool = False
         self.allow_artist_updates: bool = False
         self.cache_user_scrapes: bool = False
         self.user_cache_refresh_days: int = 7
@@ -89,7 +87,6 @@ class Config:
         self.webhook_tpdb_users: List[str] = []
         self.webhook_apply_delay: int = 30
         self.plex_connect_timeout: int = DEFAULT_PLEX_CONNECT_TIMEOUT
-        self.plex_test_connection_timeout: int = DEFAULT_PLEX_TEST_CONNECTION_TIMEOUT
         self.kometa_download_timeout: int = DEFAULT_KOMETA_DOWNLOAD_TIMEOUT
         self.upload_retry_attempts: int = DEFAULT_UPLOAD_RETRY_ATTEMPTS
         self.upload_retry_backoff_seconds: float = DEFAULT_UPLOAD_RETRY_BACKOFF_SECONDS
@@ -124,7 +121,7 @@ class Config:
             self.bulk_txt = config.get("bulk_txt", "bulk_import.txt")
             self.track_artwork_ids = config.get("track_artwork_ids", True)
             self.skip_locked_artwork = config.get("skip_locked_artwork", False)
-            self.local_library_matching = config.get("local_library_matching", True)
+            self.local_library_matching = config.get("local_library_matching", False)
             self.allow_artist_updates = config.get("allow_artist_updates", False)
             self.cache_user_scrapes = config.get("cache_user_scrapes", False)
             self.user_cache_refresh_days = config.get("user_cache_refresh_days", 7)
@@ -140,7 +137,6 @@ class Config:
             self.webhook_tpdb_users = config.get("webhook_tpdb_users", [])
             self.webhook_apply_delay = config.get("webhook_apply_delay", 30)
             self.plex_connect_timeout = config.get("plex_connect_timeout", DEFAULT_PLEX_CONNECT_TIMEOUT)
-            self.plex_test_connection_timeout = config.get("plex_test_connection_timeout", DEFAULT_PLEX_TEST_CONNECTION_TIMEOUT)
             self.kometa_download_timeout = config.get("kometa_download_timeout", DEFAULT_KOMETA_DOWNLOAD_TIMEOUT)
             self.upload_retry_attempts = config.get("upload_retry_attempts", DEFAULT_UPLOAD_RETRY_ATTEMPTS)
             self.upload_retry_backoff_seconds = config.get("upload_retry_backoff_seconds", DEFAULT_UPLOAD_RETRY_BACKOFF_SECONDS)
@@ -164,7 +160,7 @@ class Config:
             "stage_assets": False,
             "track_artwork_ids": True,
             "skip_locked_artwork": False,
-            "local_library_matching": True,
+            "local_library_matching": False,
             "allow_artist_updates": False,
             "cache_user_scrapes": False,
             "user_cache_refresh_days": 7,
@@ -177,7 +173,6 @@ class Config:
             "webhook_tpdb_users": [],
             "webhook_apply_delay": 30,
             "plex_connect_timeout": DEFAULT_PLEX_CONNECT_TIMEOUT,
-            "plex_test_connection_timeout": DEFAULT_PLEX_TEST_CONNECTION_TIMEOUT,
             "kometa_download_timeout": DEFAULT_KOMETA_DOWNLOAD_TIMEOUT,
             "upload_retry_attempts": DEFAULT_UPLOAD_RETRY_ATTEMPTS,
             "upload_retry_backoff_seconds": DEFAULT_UPLOAD_RETRY_BACKOFF_SECONDS
@@ -234,7 +229,6 @@ class Config:
             "webhook_tpdb_users": self.webhook_tpdb_users,
             "webhook_apply_delay": self.webhook_apply_delay,
             "plex_connect_timeout": self.plex_connect_timeout,
-            "plex_test_connection_timeout": self.plex_test_connection_timeout,
             "kometa_download_timeout": self.kometa_download_timeout,
             "upload_retry_attempts": self.upload_retry_attempts,
             "upload_retry_backoff_seconds": self.upload_retry_backoff_seconds

--- a/core/constants.py
+++ b/core/constants.py
@@ -147,8 +147,7 @@ UPLOAD_CHUNK_TIMEOUT = 10 # seconds
 
 # Network timeouts (seconds)
 DEFAULT_PLEX_CONNECT_TIMEOUT = 10  # PlexConnector.connect()
-DEFAULT_PLEX_TEST_CONNECTION_TIMEOUT = 5  # "Test connection" in the web settings
-DEFAULT_KOMETA_DOWNLOAD_TIMEOUT = 5  # Downloading artwork to save to the Kometa asset directory
+DEFAULT_KOMETA_DOWNLOAD_TIMEOUT = 10  # Downloading artwork to save to the Kometa asset directory
 
 # Upload retry behaviour: a transient failure (timeout, connection error, 5xx) is retried this many
 # times in total, waiting backoff seconds and doubling that wait after each attempt. A 401 or 404

--- a/static/web_interface.css
+++ b/static/web_interface.css
@@ -244,10 +244,8 @@ h1 {
 }
 
 /* Remove Bootstrap's validation checkmark icon on small numeric inputs */
-.was-validated #user_cache_refresh_days.form-control:valid,
-.was-validated #user_cache_refresh_days.form-control:invalid,
-.was-validated #webhook_apply_delay.form-control:valid,
-.was-validated #webhook_apply_delay.form-control:invalid {
+.was-validated .d-inline-block.form-control:valid,
+.was-validated .d-inline-block.form-control:invalid {
     background-image: none !important;
     padding-right: 0.5rem !important; /* Prevents text clipping */
 }
@@ -907,4 +905,27 @@ Theme Switcher Dropdown Icons (Fix dark mode SVG fills)
 #status,
 #status_container { /* Replace with your banner's actual class or ID */
     z-index: 1060 !important; /* Higher than Bootstrap modal (1055) and backdrop (1050) */
+}
+
+/* ==========================================================================
+   Code Snippet Styling Inside Tooltips
+   ========================================================================== */
+
+.tooltip-inner code {
+    color: #D789B2;
+    background-color: rgba(14, 39, 47, 1); /* Match the background of the alertbox */
+    padding: 0.15em 0.35em;
+    border-radius: 0.25rem;
+}
+
+[data-bs-theme="dark"] .tooltip-inner code {
+    color: #C54282;
+    background-color: rgba(214, 243, 251, 1); /* Match the background of the alertbox in light mode*/
+    padding: 0.15em 0.35em;
+    border-radius: 0.25rem;
+}
+
+/* Optional: Slightly increase tooltip width for longer instructions */
+.wide-tooltip .tooltip-inner {
+    max-width: 320px !important;
 }

--- a/static/web_interface.js
+++ b/static/web_interface.js
@@ -1109,10 +1109,9 @@ function getCurrentConfigForm() {
 
     // Timeouts and retries
     current_form.plex_connect_timeout = parseInt(document.getElementById("plex_connect_timeout").value) || 10;
-    current_form.plex_test_connection_timeout = parseInt(document.getElementById("plex_test_connection_timeout").value) || 5;
-    current_form.kometa_download_timeout = parseInt(document.getElementById("kometa_download_timeout").value) || 5;
+    current_form.kometa_download_timeout = parseInt(document.getElementById("kometa_download_timeout").value) || 10;
     current_form.upload_retry_attempts = parseInt(document.getElementById("upload_retry_attempts").value) || 3;
-    current_form.upload_retry_backoff_seconds = parseFloat(document.getElementById("upload_retry_backoff_seconds").value) || 0;
+    current_form.upload_retry_backoff_seconds = parseFloat(document.getElementById("upload_retry_backoff_seconds").value) || 1;
 
     // Checkbox for taking an artist's newer artwork for posters we applied
     current_form.allow_artist_updates = document.getElementById("allow_artist_updates").checked;
@@ -1137,7 +1136,7 @@ function getCurrentConfigForm() {
     current_form.enable_webhooks = document.getElementById("enable_webhooks").checked;
     current_form.webhook_token = document.getElementById("webhook_token").value.trim();
     current_form.webhook_tpdb_users = tpdbUserPicker ? tpdbUserPicker.getValue() : [];
-    current_form.webhook_apply_delay = parseInt(document.getElementById("webhook_apply_delay").value, 10) || 0;
+    current_form.webhook_apply_delay = parseInt(document.getElementById("webhook_apply_delay").value, 10) || 30;
 
     return current_form
 }
@@ -1239,8 +1238,7 @@ function updateConfigUI(config) {
     document.getElementById("cache_user_scrapes").checked = config.cache_user_scrapes;
     document.getElementById("user_cache_refresh_days").value = config.user_cache_refresh_days ?? 7;
     document.getElementById("plex_connect_timeout").value = config.plex_connect_timeout ?? 10;
-    document.getElementById("plex_test_connection_timeout").value = config.plex_test_connection_timeout ?? 5;
-    document.getElementById("kometa_download_timeout").value = config.kometa_download_timeout ?? 5;
+    document.getElementById("kometa_download_timeout").value = config.kometa_download_timeout ?? 10;
     document.getElementById("upload_retry_attempts").value = config.upload_retry_attempts ?? 3;
     document.getElementById("upload_retry_backoff_seconds").value = config.upload_retry_backoff_seconds ?? 1;
     document.getElementById("allow_artist_updates").checked = config.allow_artist_updates;
@@ -2439,9 +2437,15 @@ function toggleKometaSettings() {
     const kometaSettings = document.getElementById("kometa_settings");
     const kometaBase = document.getElementById("kometa_base");
     const dockerWarning = document.getElementById("docker_warning");
+    const kometaTimeout = document.getElementById("kometa_timeout_container");
+    const uploadTimeoutLabel = document.getElementById("plex_timeout_label");
+    const uploadRetryLabel = document.getElementById("upload_retry_label");
 
     if (saveToKometa) {
         kometaSettings.style.display = "block";
+        kometaTimeout.classList.remove("d-none");
+        uploadTimeoutLabel.innerHTML='<i class="bi bi-plugin"></i>&ensp;Plex connect timeout:';
+        uploadRetryLabel.textContent="download";
         if (docker) {
             if (dockerWarning) {
                 dockerWarning.classList.remove("d-none");
@@ -2462,6 +2466,9 @@ function toggleKometaSettings() {
             dockerWarning.classList.add("d-none");
         }
         kometaSettings.style.display = "none";
+        kometaTimeout.classList.add("d-none");
+        uploadTimeoutLabel.innerHTML='<i class="bi bi-cloud-upload"></i>&ensp;Plex connect/upload timeout:';
+        uploadRetryLabel.textContent="upload";
         if (kometaBase) {
             kometaBase.required = false;
             // Clear invalid styling when hiding

--- a/templates/web_interface.html
+++ b/templates/web_interface.html
@@ -161,8 +161,8 @@
                                     </div>
                                 </div>
                                 <div class="mb-3">
-                                    <label for="plex_token" class="form-label"><i class="bi bi-key"></i>&ensp;Authentication token</label>
-                                    &nbsp;<i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-html="true" data-bs-title="Check the <a href='https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/' target='_blank'>Plex support docs</a> for instructions on how to obtain your token"></i>
+                                    <label for="plex_token" class="form-label"><i class="bi bi-key"></i>&ensp;Authentication <span class="text-nowrap">token
+                                    &nbsp;<i onclick="event.preventDefault(); event.stopPropagation();" class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-html="true" data-bs-title="Check the <a href='https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/' target='_blank'>Plex support docs</a> for instructions on how to obtain your token"></i></span></label>
                                     <div class="position-relative">
                                         <input type="password" id="plex_token" name="plex_token" class="form-control input-monospace pe-5 has-inline-btn" required pattern="[A-Za-z0-9_\-]{20,40}"
                                             title="Plex token should be a 20+ character string with letters, digits, dashes or underscores."
@@ -181,7 +181,7 @@
                                     <select id="tv_library" name="tv_library" multiple placeholder="Click to add..."></select>
                                 </div>
 
-                                <div class="mb-3">
+                                <div class="mb-0">
                                     <label for="movie_library" class="form-label"><i class="bi bi-film"></i>&ensp;Movie libraries</label>
                                     <select id="movie_library" name="movie_library" multiple placeholder="Click to add..."></select>
                                 </div>
@@ -189,21 +189,21 @@
                             <!-- Kometa settings -->
                             <div class="p-3 border mt-3 rounded-4 shadow-sm">
                                 <h5 class="mb-3"><i class="bi bi-download"></i>&ensp;Kometa settings</h5>
-                                <div class="form-check form-switch mb-3">
+                                <div class="form-check form-switch">
                                     <input class="form-check-input" type="checkbox" value="--kometa" id="save_to_kometa"/>
                                     <label for="save_to_kometa" class="form-check-label">Save artwork to Kometa asset directory</label>
                                 </div>
-                                <div class="form-check form-switch mb-3" style="display: none;">
+                                <div class="form-check form-switch mt-2" style="display: none;">
                                     <input class="form-check-input" type="checkbox" value="reset_overlay" id="reset_overlay"/>
                                     <label for="reset_overlay" class="form-check-label">Reset the Overlay tag for Kometa if artwork updated</label>
                                 </div>                                
                                 <div id="kometa_settings" style="display: none;">
-                                    <div class="form-check form-switch mb-3">
+                                    <div class="form-check form-switch mt-2">
                                         <input class="form-check-input" type="checkbox" value="stage_assets" id="stage_assets"/>
-                                        <label for="stage_assets" class="form-check-label">Stage assets</label>&nbsp;
-                                        <i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="Saves assets for seasons and episodes not yet in Plex (excluding specials)"></i>
+                                        <label for="stage_assets" class="form-check-label">Stage <span class="text-nowrap">assets
+                                        &nbsp;<i onclick="event.preventDefault(); event.stopPropagation();" class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="Saves assets for seasons and episodes not yet in Plex (excluding specials)"></i></span></label>
                                     </div>
-                                    <div class="mb-3">
+                                    <div class="mt-3">
                                         <label for="kometa_base" class="form-label"><i class="bi bi-folder"></i>&ensp;Kometa Asset Directory</label>
                                         <div class="position-relative">
                                             <input type="text" 
@@ -226,9 +226,9 @@
                                             Please provide your Kometa asset directory
                                         </div>
                                     </div>
-                                    <div class="mb-3">
-                                        <label for="temp_dir" class="form-label"><i class="bi bi-clock-history"></i>&ensp;Temp Directory</label>&nbsp;
-                                        <i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="Temp directory for Kometa operations (optional)"></i>
+                                    <div class="mt-3">
+                                        <label for="temp_dir" class="form-label"><i class="bi bi-clock-history"></i>&ensp;Temp <span class="text-nowrap">Directory
+                                        &nbsp;<i onclick="event.preventDefault(); event.stopPropagation();" class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="Temp directory for Kometa operations (optional)"></i></span></label>
                                         <div class="position-relative">
                                             <input type="text" 
                                                 id="temp_dir" 
@@ -258,21 +258,21 @@
                             <!-- Authentication settings -->
                             <div class="p-3 border mt-3 rounded-4 shadow-sm">
                                 <h5 class="mb-3"><i class="bi bi-shield-check"></i>&ensp;Authentication settings</h5>
-                                <div class="form-check form-switch mb-3">
+                                <div class="form-check form-switch mb-0">
                                     <input class="form-check-input" type="checkbox" id="auth_enabled"/>
                                     <label for="auth_enabled" class="form-check-label">Enable password protection</label>
                                 </div>
-                                <div id="auth_settings" style="display: none;">
+                                <div id="auth_settings" class="mt-3 mb-0" style="display: none;">
                                     <div class="mb-3">
                                         <label for="auth_username" class="form-label"><i class="bi bi-person"></i>&ensp;Username</label>
                                         <input type="text" id="auth_username" name="auth_username" class="form-control" placeholder="username">
                                     </div>
-                                    <div class="mb-3">
+                                    <div class="mb-0>
                                         <label for="auth_password" class="form-label"><i class="bi bi-lock"></i>&ensp;Password</label>
                                         <input type="password" id="auth_password" name="auth_password" class="form-control" placeholder="Enter new password">
                                         <small class="form-text text-muted">Leave blank to keep existing password</small>
                                     </div>
-                                    <div class="alert alert-info" role="alert">
+                                    <div class="alert alert-info mt-3 mb-0" role="alert">
                                         <i class="bi bi-info-circle"></i> You will need to log in with these credentials after saving. Sessions last 7 days with "Remember me" enabled.
                                     </div>
                                 </div>
@@ -280,15 +280,21 @@
                             <!-- Webhook settings -->
                             <div class="p-3 border mt-3 rounded-4 shadow-sm">
                                 <h5 class="mb-3"><i class="bi bi-broadcast-pin"></i>&ensp;Webhook settings</h5>
-                                <div class="form-check form-switch mb-3">
+                                <div class="form-check form-switch mb-0">
                                     <input class="form-check-input" type="checkbox" id="enable_webhooks"/>
-                                    <label for="enable_webhooks" class="form-check-label">Enable Sonarr/Radarr webhook</label>
-                                    <i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="Allows TPDb artwork from cached user pages to be applied to items 
-                                    or downloaded to the Kometa asset directory immediately after they are imported in Sonarr or Radarr"></i>
+                                    <label for="enable_webhooks" class="form-check-label">Enable Sonarr/Radarr <span class="text-nowrap">webhook
+                                    &nbsp;<i onclick="event.preventDefault(); event.stopPropagation();" class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="Allows TPDb artwork from cached user pages to be applied to items 
+                                    or downloaded to the Kometa asset directory immediately after they are imported in Sonarr or Radarr"></i></span></label>
                                 </div>
                                 <div id="webhook_settings" style="display: none;">
-                                    <div class="mb-3">
-                                        <label for="webhook_token" class="form-label"><i class="bi bi-key"></i>&ensp;Webhook token</label>
+                                    <div class="mb-3 mt-3">
+                                        <label for="webhook_token" class="form-label"><i class="bi bi-key"></i>&ensp;Webhook <span class="text-nowrap">token</span>
+                                        &nbsp;<i onclick="event.preventDefault(); event.stopPropagation();" class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-custom-class="wide-tooltip"
+                                        data-bs-title="In Sonarr/Radarr go to Settings &rarr; Connect &rarr; <i class='bi bi-plus-square'></i> &rarr; Webhook. Set the URL to 
+                                        <code>/webhook/sonarr</code> or <code>/webhook/radarr</code> on this server, method POST, and tick only the 'On File Import' 
+                                        trigger. Send this token either as the connection's Password, or as a header: click the <span class='text-nowrap'><strong>Advanced</strong> 
+                                        (<i class='bi bi-gear-fill'></i>)</span> button on the webhook connection and add a Header with Key <span class='text-nowrap'>
+                                        <code>X-Webhook-Token</code></span> and Value set to this token."></i></span></label></span></label>
                                         <div class="position-relative">
                                             <input type="password" id="webhook_token" name="webhook_token" class="form-control input-monospace has-two-inline-btns" placeholder="Enter token or click to generate"
                                             spellcheck="false" autocomplete="off" autocorrect="off" autocapitalize="off" required
@@ -306,24 +312,17 @@
                                             Please generate a webhook token
                                         </div>
                                     </div>
-                                    <div class="alert alert-info alert-dismissible fade show" role="alert">
-                                        <i class="bi bi-info-circle"></i>&ensp;In Sonarr/Radarr go to Settings &rarr; Connect &rarr; + &rarr; Webhook. Set the URL to 
-                                        <code>/webhook/sonarr</code> or <code>/webhook/radarr</code> on this server, method POST, and tick only the "On File Import" 
-                                        trigger. Send this token either as the connection's Password, or as a header: click the <strong>Advanced</strong> (cog) button 
-                                        on the webhook connection and add a Header with Key <code>X-Webhook-Token</code> and Value set to this token.
-                                        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-                                    </div>
                                     <div class="mb-3">
-                                        <label for="webhook_tpdb_users" class="form-label"><i class="bi bi-people"></i>&ensp;ThePosterDB users</label>
-                                        <i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="List of TPDb users, searched in this order (first 
-                                        match wins). Requires 'Cache ThePosterDB user pages' enabled, and a scrape of these users needs to have run at least once,
-                                        so their artwork is cacehd and ca be looked up.)"></i>
+                                        <label for="webhook_tpdb_users" class="form-label"><i class="bi bi-people"></i>&ensp;ThePosterDB <span class="text-nowrap">users
+                                        &nbsp;<i onclick="event.preventDefault(); event.stopPropagation();" class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-custom-class="wide-tooltip"
+                                        data-bs-title="List of TPDb users, searched in this order (first match wins). Requires <strong>Cache ThePosterDB user pages</strong> enabled, and a scrape 
+                                        of these users needs to have run at least once, so their artwork is cacehd and ca be looked up.)"></i></span></label>
                                         <select id="webhook_tpdb_users" name="webhook_tpdb_users" multiple placeholder="Enter usernames"></select>
                                     </div>
-                                    <div class="mb-3">
-                                        <label for="webhook_apply_delay" class="form-label me-2 mb-0"><i class="bi bi-clock""></i>&ensp;Delay</label>
+                                    <div class="mb-0">
+                                        <label for="webhook_apply_delay" class="form-label me-2 mb-0"><i class="bi bi-clock""></i>&ensp;Delay
                                         <input type="number" 
-                                            class="form-control form-control-sm text-center d-inline-block me-2 input-monospace" 
+                                            class="form-control form-control-sm text-center d-inline-block me-0 input-monospace" 
                                             id="webhook_apply_delay" 
                                             name="webhook_apply_delay"
                                             min="0" 
@@ -331,9 +330,9 @@
                                             value="30"
                                             style="width: 60px;" 
                                             required />
-                                        <span class="text-body">seconds before applying</span>
-                                        <i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="How long to wait after an import before applying artwork, 
-                                        giving Plex time to scan the new item. If it is still not ready, the apply retries for a few minutes."></i>
+                                        seconds before <span class="text-nowrap">applying
+                                        &nbsp;<i onclick="event.preventDefault(); event.stopPropagation();" class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="How long to wait after an import before applying artwork, 
+                                        giving Plex time to scan the new item. If it is still not ready, the apply retries for a few minutes."></i></span></label>
                                     </div>
                                 </div>
                             </div>
@@ -440,44 +439,45 @@
                                 <div class="col">
                                     <div class="p-3 border rounded-4 shadow-sm">
                                         <h5 class="mb-3"><i class="bi bi-sliders"></i>&ensp;Additional settings</h5>
-                                        <div class="form-check form-switch mb-3">
+                                        <div class="form-check form-switch mb-0">
                                             <input class="form-check-input" type="checkbox" value="auto_manage" id="auto_manage_bulk_files"/>
                                             <label for="auto_manage_bulk_files" class="form-check-label">Sort and label bulk files automatically</label>
                                         </div>
-                                        <div class="form-check form-switch mb-3" style="display: none;">
+                                        <div class="form-check form-switch mt-2" style="display: none;">
                                             <input class="form-check-input" type="checkbox" value="--force" id="track_artwork_ids"/>
-                                            <label for="track_artwork_ids" class="form-check-label">Track artwork ID in Plex labels</label>
-                                            <i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="(Recommended) Tracks artwork IDs through Plex labels, avoiding having to download assets that have already been downloaded and set"></i>
+                                            <label for="track_artwork_ids" class="form-check-label">Track artwork ID in Plex <span class="text-nowrap">labels
+                                            &nbsp;<i onclick="event.preventDefault(); event.stopPropagation();" class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="(Recommended) Tracks artwork IDs through Plex labels, avoiding having to download assets that have already been downloaded and set"></i></span></label>
                                         </div>
-                                        <div class="form-check form-switch mb-3">
+                                        <div class="form-check form-switch mt-2">
                                             <input class="form-check-input" type="checkbox" value="skip_locked_artwork" id="skip_locked_artwork"/>
-                                            <label for="skip_locked_artwork" class="form-check-label">Skip locked artwork</label>
-                                            <i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="Skips artwork that is locked in Plex, so scheduled runs only update default artwork"></i>
+                                            <label for="skip_locked_artwork" class="form-check-label">Skip locked <span class="text-nowrap">artwork
+                                            &nbsp;<i onclick="event.preventDefault(); event.stopPropagation();" class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="Skips artwork that is locked in Plex, so scheduled runs only update default artwork"></i></span></label>
                                         </div>
-                                        <div class="form-check form-switch mb-3">
+                                        <div class="form-check form-switch mt-2">
                                             <input class="form-check-input" type="checkbox" value="allow_artist_updates" id="allow_artist_updates"/>
-                                            <label for="allow_artist_updates" class="form-check-label">Allow artist updates</label>
-                                            <i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="ThePosterDB only: Lets a run replace artwork it applied earlier when the same artist has posted a newer
+                                            <label for="allow_artist_updates" class="form-check-label">Allow artist <span class="text-nowrap">updates
+                                            &nbsp;<i onclick="event.preventDefault(); event.stopPropagation();" class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="ThePosterDB only: Lets a run replace artwork it applied earlier when the same artist has posted a newer
                                             version of it. Artwork you set by hand and artwork from a different artist are left alone, and it only ever moves forward to a newer upload. Needs
-                                            skip locked artwork and track artwork IDs enabled. (NOTE: Does not apply to uploaded ZIP files.)"></i>
+                                            skip locked artwork and track artwork IDs enabled. (NOTE: Does not apply to uploaded ZIP files.)"></i></span></label>
                                         </div>
-                                        <div class="form-check form-switch mb-3">
+                                        <div class="form-check form-switch mt-2">
                                             <input class="form-check-input" type="checkbox" value="local_library_matching" id="local_library_matching"/>
-                                            <label for="local_library_matching" class="form-check-label">Local library matching</label>
-                                            <i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="ThePosterDB only: Tries to match artwork by title against local libraries for faster 
+                                            <label for="local_library_matching" class="form-check-label">Local library <span class="text-nowrap">matching
+                                            &nbsp;<i onclick="event.preventDefault(); event.stopPropagation();" class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-custom-class="wide-tooltip"
+                                            data-bs-title="ThePosterDB only: Tries to match artwork by title against local libraries for faster 
                                             scrapes of very large user pages. Skips fetching individual poster pages from TPDb to get the TMDB ID of each item for the most accurate
-                                            matching so it is much faster but it can reduce match accuracy."></i>
+                                            matching so it is much faster but it can reduce match accuracy."></i></span></label>
                                         </div>
-                                        <div class="form-check form-switch mb-3">
+                                        <div class="form-check form-switch mt-2">
                                             <input class="form-check-input" type="checkbox" value="cache_user_scrapes" id="cache_user_scrapes"/>
-                                            <label for="cache_user_scrapes" class="form-check-label">Cache ThePosterDB user pages</label>
-                                            <i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="ThePosterDB only: Keeps a persistent cache in a SQLite database of TPDb user 
-                                            page scrapes so that periodic scrapes of large user portfolios are much faster"></i>
+                                            <label for="cache_user_scrapes" class="form-check-label">Cache ThePosterDB user <span class="text-nowrap">pages
+                                            &nbsp;<i onclick="event.preventDefault(); event.stopPropagation();" class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="ThePosterDB only: Keeps a persistent cache in a SQLite database of TPDb user 
+                                            page scrapes so that periodic scrapes of large user portfolios are much faster"></i></span></label>
                                         </div>
-                                        <div id="cache_expiry_container" class="mt-2 mb-3 d-flex align-items-center" style="display: d-none;">
-                                            <label for="user_cache_refresh_days" class="form-label me-2 mb-0"><i class="bi bi-recycle""></i>&ensp; Refresh user cache every</label>
+                                        <div id="cache_expiry_container" class="mt-2 d-flex align-items-center" style="display: d-none;">
+                                            <label for="user_cache_refresh_days" class="form-label me-2 mb-0"><i class="bi bi-recycle""></i>&ensp; Refresh user cache every
                                             <input type="number" 
-                                                class="form-control form-control-sm text-center d-inline-block me-2 input-monospace" 
+                                                class="form-control form-control-sm text-center d-inline-block me-0 input-monospace" 
                                                 id="user_cache_refresh_days" 
                                                 name="user_cache_refresh_days"
                                                 min="1" 
@@ -485,7 +485,7 @@
                                                 value="30" 
                                                 style="width: 60px;" 
                                                 required />
-                                            <span class="text-body">days</span>
+                                            days</label>
                                         </div>                                        
                                     </div>
                                 </div>
@@ -496,35 +496,33 @@
                                     <div class="p-3 border rounded-4 shadow-sm">
                                         <h5 class="mb-3"><i class="bi bi-stopwatch"></i>&ensp;Timeouts and retries</h5>
                                         <div class="mt-2 d-flex align-items-center">
-                                            <label for="plex_connect_timeout" class="form-label me-2 mb-0">Wait for a Plex connection or upload for</label>
-                                            <input type="number" class="form-control form-control-sm text-center d-inline-block me-2 input-monospace"
+                                            <label for="plex_connect_timeout" class="form-label me-2 mb-0"><span id="plex_timeout_label">
+                                            <i class="bi bi-cloud-upload"></i>&ensp;Plex connect/upload timeout:</span>
+                                            <input type="number" class="form-control form-control-sm text-center d-inline-block me-0 input-monospace"
                                                 id="plex_connect_timeout" name="plex_connect_timeout" min="1" max="300" value="10" style="width: 60px;" required />
-                                            <span class="text-body">seconds</span>
+                                            seconds</label>
+                                        </div>
+                                        <div class="mt-2 d-flex align-items-center d-none" id="kometa_timeout_container">
+                                            <label for="kometa_download_timeout" class="form-label me-2 mb-0">
+                                            <i class="bi bi-cloud-download"></i>&ensp;Kometa download timeout:
+                                            <input type="number" class="form-control form-control-sm text-center d-inline-block me-0 input-monospace"
+                                                id="kometa_download_timeout" name="kometa_download_timeout" min="1" max="300" value="10" style="width: 60px;" required />
+                                            seconds</label>
                                         </div>
                                         <div class="mt-2 d-flex align-items-center">
-                                            <label for="plex_test_connection_timeout" class="form-label me-2 mb-0">Wait for a settings connection test for</label>
-                                            <input type="number" class="form-control form-control-sm text-center d-inline-block me-2 input-monospace"
-                                                id="plex_test_connection_timeout" name="plex_test_connection_timeout" min="1" max="60" value="5" style="width: 60px;" required />
-                                            <span class="text-body">seconds</span>
+                                            <label for="upload_retry_attempts" class="form-label me-2 mb-0">
+                                            <i class="bi bi-arrow-counterclockwise"></i>&ensp;Max <span id="upload_retry_label">upload</span> attempts:
+                                            <span class="text-nowrap"><input type="number" class="form-control form-control-sm text-center d-inline-block me-0 input-monospace"
+                                                id="upload_retry_attempts" name="upload_retry_attempts" min="1" max="10" value="2" style="width: 60px;" required />
+                                            <i onclick="event.preventDefault(); event.stopPropagation();" class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="Including the original attempt. Only transient failures are retried: a timeout or a server error."></i></span></label>
                                         </div>
                                         <div class="mt-2 d-flex align-items-center">
-                                            <label for="kometa_download_timeout" class="form-label me-2 mb-0">Wait for a Kometa artwork download for</label>
-                                            <input type="number" class="form-control form-control-sm text-center d-inline-block me-2 input-monospace"
-                                                id="kometa_download_timeout" name="kometa_download_timeout" min="1" max="300" value="5" style="width: 60px;" required />
-                                            <span class="text-body">seconds</span>
-                                        </div>
-                                        <div class="mt-2 d-flex align-items-center">
-                                            <label for="upload_retry_attempts" class="form-label me-2 mb-0">Attempt a failed upload</label>
-                                            <input type="number" class="form-control form-control-sm text-center d-inline-block me-2 input-monospace"
-                                                id="upload_retry_attempts" name="upload_retry_attempts" min="1" max="10" value="3" style="width: 60px;" required />
-                                            <span class="text-body">times in total</span>
-                                            <i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="Only transient failures are retried: a timeout or a server error. The count includes the first attempt."></i>
-                                        </div>
-                                        <div class="mt-2 mb-3 d-flex align-items-center">
-                                            <label for="upload_retry_backoff_seconds" class="form-label me-2 mb-0">Wait before the first retry for</label>
-                                            <input type="number" class="form-control form-control-sm text-center d-inline-block me-2 input-monospace"
+                                            <label for="upload_retry_backoff_seconds" class="form-label me-2 mb-0">
+                                                <i class="bi bi-fire"></i>&ensp;Cool-down period:
+                                                <input type="number" class="form-control form-control-sm text-center d-inline-block me-0 input-monospace"
                                                 id="upload_retry_backoff_seconds" name="upload_retry_backoff_seconds" min="0" max="60" step="0.5" value="1" style="width: 60px;" required />
-                                            <span class="text-body">seconds, doubling each retry</span>
+                                            <span class="text-nowrap">seconds
+                                            &nbsp;<i onclick="event.preventDefault(); event.stopPropagation();" class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="Waits this amount of seconds before first retry. Doubles every subsequent retry."></i></span></label>
                                         </div>
                                     </div>
                                 </div>
@@ -535,11 +533,10 @@
                                     <div class="p-3 border rounded-4 shadow-sm">
                                         <h5 class="mb-3"><i class="bi bi-app-indicator"></i>&ensp;Notifications settings</h5>
                                         <div id="notifications_settings" style="display: block;">
-                                            <div class="mb-3">
+                                            <div>
                                                 <label class="form-label">
-                                                    <i class="bi bi-link-45deg"></i>&ensp;Apprise URLs to notify
-                                                </label>
-                                                &nbsp;<i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-html="true" data-bs-title='Enter Apprise URLs. See <a href="https://appriseit.com/services/" target="_blank" rel="noopener noreferrer">the Apprise services list</a> for details.'></i>
+                                                    <i class="bi bi-link-45deg"></i>&ensp;Apprise URLs to <span class="text-nowrap">notify
+                                                &nbsp;<i onclick="event.preventDefault(); event.stopPropagation();" class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-html="true" data-bs-title='Enter Apprise URLs. See <a href="https://appriseit.com/services/" target="_blank" rel="noopener noreferrer">the Apprise services list</a> for details.'></i></span></label>
                                                 
                                                 <!-- Dynamic URL Rows Container -->
                                                 <div id="apprise_urls_container" class="d-flex flex-column gap-2"></div>
@@ -739,16 +736,17 @@
                 </div>                    
             </div>
 
-
             <!-- Scraper Tab -->
             <div class="tab-pane fade" id="scraper" role="tabpanel" aria-labelledby="scraper-tab" tabindex="0">
                 <form id="scraperForm" class="needs-validation" novalidate>
                     <div class="row">
                         <div class="col mb-3">
                             <div class="p-3 border rounded-4 shadow-sm">
-                                <label for="scrape_url" class="form-label"><i class="bi bi-link-45deg"></i>&ensp;URL to scrape</label>
+                                <label for="scrape_url" class="form-label h5"><i class="bi bi-link-45deg"></i>&ensp;URL to scrape</label>
                                 <input type="text" id="scrape_url" name="scrape_url" class="form-control"
                                     value="" required
+                                    spellcheck="false" autocomplete="off" autocorrect="off" autocapitalize="off" 
+                                    data-1p-ignore data-bwignoredata-lpignore="true" data-dashlane-ignore="true"
                                     placeholder="theposterdb.com (poster/set/user) or mediux.pro (sets/boxsets) URL"
                                     pattern="https://(theposterdb\.com/(poster/\d+|set/\d+|user/[A-Za-z0-9]+)|mediux\.pro/(sets|boxsets)/\d+)"
                                     title="Please enter a valid URL (e.g., https://theposterdb.com/set/12345 or https://mediux.pro/sets/12345 or https://mediux.pro/boxsets/1153)">
@@ -757,14 +755,14 @@
                         </div>
                         <div class="mb-3 col-md-4 col-lg-3">
                             <div class="p-3 border rounded-4 shadow-sm">
-                                <label for="scrape_url" class="form-label"><i class="bi bi-calendar3"></i>&ensp;Plex year</label>
-                                &nbsp;<i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="Use this if the year in Plex is different to that on MediUX or TPDb"></i>
+                                <label for="year" class="form-label h5"><i class="bi bi-calendar3"></i>&ensp;Plex <span class="text-nowrap h5">year
+                                &nbsp;<i onclick="event.preventDefault(); event.stopPropagation();" class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="Use this if the year in Plex is different to that on MediUX or TPDb"></i></span></label>
                                 <input type="text" id="year" name="year" class="form-control"
                                     value=""
                                     placeholder="e.g. 1978 or 2023"
                                     pattern="^(19|20)\d{2}$"
                                     title="Use this if the year in Plex is different to that on MediUX or TPDb">
-                                <div class="invalid-feedback">Please use a valid year (1900-2099).</div>    
+                                <div class="invalid-feedback">Please use a valid year (1900-2099).</div>
                             </div>
                         </div>
                     </div>
@@ -772,33 +770,33 @@
                         <div class="col">
                             <div class="p-3 border rounded-4 shadow-sm">
                                 <h5 class="mb-3"><i class="bi bi-sliders"></i>&ensp;Options</h5>
-                                <div class="form-check form-switch mb-2">
+                                <div class="form-check form-switch mb-0">
                                     <input class="form-check-input" type="checkbox" value="--force" id="option-force"/>
                                     <label for="option-force" class="form-check-label">Force upload the artwork, even if it
                                         already exists</label>
                                 </div>
-                                <div class="form-check form-switch mb-2">
+                                <div class="form-check form-switch mt-2">
                                     <input class="form-check-input" type="checkbox" value="--skip-locked" id="option-skip-locked"/>
                                     <label for="option-skip-locked" class="form-check-label">Skip locked artwork</label>
                                     <i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="Skips artwork that is locked in Plex, so scheduled runs only update default artwork"></i>
                                 </div>
-                                <div class="form-check form-switch mb-2">
+                                <div class="form-check form-switch mt-2">
                                     <input class="form-check-input" type="checkbox" value="--allow-artist-updates" id="option-allow-artist-updates"/>
                                     <label for="option-allow-artist-updates" class="form-check-label">Allow artist updates</label>
                                     <i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="Replaces artwork an earlier run applied when the same artist has posted a newer version, leaving hand-set artwork alone. Needs skip locked artwork"></i>
                                 </div>
-                                <div class="form-check form-switch mb-2">
+                                <div class="form-check form-switch mt-2">
                                     <input class="form-check-input" type="checkbox" value="--stage" id="option-stage"/>
-                                    <label for="option-stage" class="form-check-label">Stage assests&ensp;</label>
-                                        <i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="Saves assets for seasons and episodes not yet in Plex (excluding specials)"></i>
+                                    <label for="option-stage" class="form-check-label">Stage <span class="text-nowrap">assets
+                                        &nbsp;<i onclick="event.preventDefault(); event.stopPropagation();" class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="Saves assets for seasons and episodes not yet in Plex (excluding specials)"></i></span></label>
                                 </div>
-                                <div class="form-check form-switch mb-2" style="display: none;">
+                                <div class="form-check form-switch mt-2" style="display: none;">
                                     <input class="form-check-input" type="checkbox" value="--temp"
                                         id="option-temp"/>
                                     <label for="option-temp" class="form-check-label">Use temporary directory for downloaded 
                                         assets</label>
                                 </div>
-                                <div class="form-check form-switch mb-2">
+                                <div class="form-check form-switch mt-2">
                                     <input class="form-check-input" type="checkbox" value="--add-to-bulk"
                                         id="option-add-to-bulk"/>
                                     <label for="option-add-to-bulk" class="form-check-label">Automatically add this URL to
@@ -807,7 +805,7 @@
                             </div>
                         </div>
                         <div class="col theposterdb collapse">
-                            <div class="p-3 border rounded-3 shadow-sm">
+                            <div class="p-3 border rounded-4 shadow-sm">
                                 <h5 class="mb-3"><i class="bi bi-sliders"></i>&ensp;The Poster DB options</h5>
                                 <div class="form-check form-switch">
                                     <input class="form-check-input" type="checkbox" value="--add-sets"
@@ -815,7 +813,7 @@
                                     <label for="option-add-sets" class="form-check-label">Add additional sets from the same
                                         page</label>
                                 </div>
-                                <div class="form-check form-switch">
+                                <div class="form-check form-switch mt-2">
                                     <input class="form-check-input" type="checkbox" value="--add-posters"
                                         id="option-add-posters"/>
                                     <label for="option-add-posters" class="form-check-label">Add the additional posters
@@ -828,65 +826,51 @@
                         <div class="col">
                             <div class="p-3 border rounded-4 shadow-sm">
                                 <h5 class="mb-3"><i class="bi bi-card-image"></i>&ensp;Artwork to include</h5>
-                                <div id="scraper-filters-inherit" class="collapse show row mb-1">
-                                    <div class="col-6 col-md-4 col-lg-3">
-                                        <div class="form-check form-switch mb-2">
-                                            <input class="form-check-input" type="checkbox" checked value="inherit" name="filter" id="scraper-filters-global"/>
-                                            <label for="scraper-filters-global" class="form-check-label">As set by global filters</label>
-                                        </div>
-                                    </div>
+                                <div class="form-check form-switch mb-2">
+                                    <input class="form-check-input" type="checkbox" checked value="inherit" name="filter" id="scraper-filters-global"/>
+                                    <label for="scraper-filters-global" class="form-check-label">As set by global filters</label>
                                 </div>
                                 <div id="scraper-filters" class="collapse">
-                                    <div class="row mb-1">
-                                        <div class="col-12 mb-2"><strong>TV shows</strong></div>
-                                        <div class="col-6 col-md-4 col-lg-3">
-                                            <div class="form-check form-switch mb-2">
-                                                <input class="form-check-input" type="checkbox" checked value="show_cover" name="filter" id="filter-show_cover"/>
-                                                <label for="filter-show_cover" class="form-check-label">Show cover</label>
-                                            </div>
+                                    <!-- TV Shows -->
+                                    <div class="mb-2"><strong>TV Shows</strong></div>
+                                    <div class="d-flex flex-wrap align-items-center gap-y-2 mb-3">
+                                        <div class="form-check form-switch filter-toggle-item m-0">
+                                            <input class="form-check-input" type="checkbox" checked value="show_cover" id="filter-show_cover"/>
+                                            <label for="filter-show_cover" class="form-check-label text-nowrap">Show cover</label>
                                         </div>
-                                        <div class="col-6 col-md-4 col-lg-3">
-                                            <div class="form-check form-switch mb-2">
-                                                <input class="form-check-input" type="checkbox" checked value="season_cover" name="filter" id="filter-season_cover"/>
-                                                <label for="filter-season_cover" class="form-check-label">Season covers</label>
-                                            </div>
+                                        <div class="form-check form-switch filter-toggle-item m-0">
+                                            <input class="form-check-input" type="checkbox" checked value="season_cover" id="filter-season_cover"/>
+                                            <label for="filter-season_cover" class="form-check-label text-nowrap">Season covers</label>
                                         </div>
-                                        <div class="col-6 col-md-4 col-lg-3">
-                                            <div class="form-check form-switch mb-2" id="tpdb-card" style="display: block;">
-                                                <input class="form-check-input" type="checkbox" checked value="title_card" name="filter" id="filter-title_card"/>
-                                                <label for="filter-title_card" class="form-check-label">Title cards</label>
-                                            </div>
+                                        <div class="form-check form-switch filter-toggle-item m-0">
+                                            <input class="form-check-input" type="checkbox" checked value="title_card" id="filter-title_card"/>
+                                            <label for="filter-title_card" class="form-check-label text-nowrap">Title cards</label>
+                                        </div>
+                                    </div>                                
+
+                                    <!-- Movies -->
+                                    <div class="mb-2"><strong>Movies</strong></div>
+                                    <div class="d-flex flex-wrap align-items-center gap-y-2 mb-3">
+                                        <div class="form-check form-switch filter-toggle-item m-0">
+                                            <input class="form-check-input" type="checkbox" checked value="movie_poster" id="filter-movie_poster"/>
+                                            <label for="filter-movie_poster" class="form-check-label text-nowrap">Movie poster</label>
                                         </div>
                                     </div>
-                                    <div class="row">
-                                        <div class="col-12 mb-2"><strong>Movies</strong></div>
-                                        <div class="col-6 col-md-4 col-lg-3">
-                                            <div class="form-check form-switch mb-2">
-                                                <input class="form-check-input" type="checkbox" checked value="movie_poster"
-                                                    id="filter-movie_poster"/>
-                                                <label for="filter-movie_poster" class="form-check-label">Movie poster</label>
-                                            </div>
+
+                                    <!-- General -->
+                                    <div class="mb-2"><strong>General</strong></div>
+                                    <div class="d-flex flex-wrap align-items-center gap-y-2">
+                                        <div class="form-check form-switch filter-toggle-item m-0">
+                                            <input class="form-check-input" type="checkbox" checked value="background" id="filter-background"/>
+                                            <label for="filter-background" class="form-check-label text-nowrap">Background</label>
                                         </div>
-                                        <div class="col-12 mb-2"><strong>General</strong></div>
-                                        <div class="col-6 col-md-8 col-lg-3">
-                                            <div class="form-check form-switch mb-2">
-                                                <input class="form-check-input" type="checkbox" checked
-                                                    value="collection_poster" id="filter-collection_poster"/>
-                                                <label for="filter-collection_poster" class="form-check-label">Collection
-                                                    poster</label>
-                                            </div>
+                                        <div class="form-check form-switch filter-toggle-item m-0">
+                                            <input class="form-check-input" type="checkbox" checked value="square_art" id="filter-square_art"/>
+                                            <label for="filter-square_art" class="form-check-label text-nowrap">Square art</label>
                                         </div>
-                                        <div class="col-6 col-md-4 col-lg-3">
-                                            <div class="form-check form-switch mb-2" id="tpdb-background" style="display: block;">
-                                                <input class="form-check-input" type="checkbox" checked value="background" name="filter" id="filter-background"/>
-                                                <label for="filter-background" class="form-check-label">Background</label>
-                                            </div>
-                                        </div>
-                                        <div class="col-6 col-md-4 col-lg-3">
-                                            <div class="form-check form-switch mb-2" id="tpdb-square" style="display: block;">
-                                                <input class="form-check-input" type="checkbox" checked value="square_art" name="filter" id="filter-square_art"/>
-                                                <label for="filter-square_art" class="form-check-label">Square art</label>
-                                            </div>
+                                        <div class="form-check form-switch filter-toggle-item m-0">
+                                            <input class="form-check-input" type="checkbox" checked value="collection_poster" id="filter-collection_poster"/>
+                                            <label for="filter-collection_poster" class="form-check-label text-nowrap">Collection poster</label>
                                         </div>
                                     </div>
                                 </div>
@@ -944,12 +928,10 @@
 
             <!-- Uploader Tab -->
             <div class="tab-pane fade" id="uploader" role="tabpanel" aria-labelledby="uploader-tab" tabindex="0">
-                <div class="row mb-3 shadow-sm rounded-4" id="drop-area">
-                    <div class="col">
-                        <p><i class="bi bi-1-square"></i>&ensp;Check any options or customize filters.</p>
-                        <p><i class="bi bi-2-square"></i>&ensp;Drop a ZIP file from ThePosterDB.com or MediUX.pro here - or click to select one.</p>
-                        <p><i class="bi bi-3-square"></i>&ensp;The app will try to determine whether the artwork is for a TV show or a movie / collection or if it contains a mix of assets.</p>
-                    </div>
+                <div class="row mb-0 shadow-sm rounded-4" id="drop-area">
+                    <p><i class="bi bi-1-square"></i>&ensp;Check any options or customize filters.</p>
+                    <p><i class="bi bi-2-square"></i>&ensp;Drop a ZIP file from ThePosterDB.com or MediUX.pro here - or click to select one.</p>
+                    <p><i class="bi bi-3-square"></i>&ensp;The app will try to determine whether the artwork is for a TV show or a movie / collection or if it contains a mix of assets.</p>
                 </div>
                 <div id="progress-container" class="row mt-3 mb-3" style="display:none">
                     <div class="col">
@@ -963,7 +945,7 @@
                     <div class="row">
                         <div class="col mb-3">
                             <div class="p-3 border mt-3 rounded-4 shadow-sm">
-                                <label for="plex_title" class="form-label"><i class="bi bi-textarea-t"></i>&ensp;Plex title</label>
+                                <label for="plex_title" class="form-label h5"><i class="bi bi-textarea-t"></i>&ensp;Plex title</label>
                                 <input type="text" id="plex_title" name="plex_title" class="form-control"
                                     value=""
                                     placeholder="(if different to file title)"
@@ -972,8 +954,8 @@
                         </div>
                         <div class="mb-3 col-md-4 col-lg-3">
                             <div class="p-3 border mt-3 rounded-4 shadow-sm">
-                                    <label for="plex_year" class="form-label"><i class="bi bi-calendar3"></i>&ensp;Plex year</label>
-                                    &nbsp;<i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="Use this if the year in Plex is different to that on MediUX or TPDb"></i>
+                                    <label for="plex_year" class="form-label h5"><i class="bi bi-calendar3"></i>&ensp;Plex <span class="text-nowrap h5">year
+                                    &nbsp;<i onclick="event.preventDefault(); event.stopPropagation();" class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="Use this if the year in Plex is different to that on MediUX or TPDb"></i></span></label>
                                     <input type="text" id="plex_year" name="plex_year" class="form-control"
                                         value=""
                                         placeholder="e.g. 1978 or 2023"
@@ -988,22 +970,22 @@
                     <div class="col">
                         <div class="p-3 border rounded-4 shadow-sm">
                             <h5 class="mb-3"><i class="bi bi-sliders"></i>&ensp;Options</h5>
-                            <div class="form-check form-switch mb-2">
+                            <div class="form-check form-switch mb-0">
                                 <input class="form-check-input" type="checkbox" value="force" id="upload-option-force"/>
                                 <label for="upload-option-force" class="form-check-label">Force upload the artwork, even if it
                                     already exists</label>
                             </div>
-                                <div class="form-check form-switch mb-2">
+                                <div class="form-check form-switch mt-2">
                                     <input class="form-check-input" type="checkbox" value="skip-locked" id="upload-option-skip-locked"/>
                                     <label for="upload-option-skip-locked" class="form-check-label">Skip locked artwork</label>
                                     <i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="Skips artwork that is locked in Plex, so scheduled runs only update default artwork"></i>
                                 </div>                            
-                            <div class="form-check form-switch mb-2">
+                            <div class="form-check form-switch mt-2">
                                 <input class="form-check-input" type="checkbox" value="stage" id="upload-option-stage"/>
-                                    <label for="upload-option-stage" class="form-check-label">Stage assests&ensp;</label>
-                                        <i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="Saves assets for seasons and episodes not yet in Plex (excluding specials)"></i>
+                                    <label for="upload-option-stage" class="form-check-label">Stage <span class="text-nowrap">assets
+                                    &nbsp;<i onclick="event.preventDefault(); event.stopPropagation();" class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="Saves assets for seasons and episodes not yet in Plex (excluding specials)"></i></span></label>
                             </div>
-                            <div class="form-check form-switch mb-2" style="display: none;">
+                            <div class="form-check form-switch mt-2 mb-0" style="display: none;">
                                 <input class="form-check-input" type="checkbox" value="temp"
                                     id="upload-option-temp"/>
                                 <label for="upload-option-temp" class="form-check-label">Use temporary directory for downloaded 
@@ -1016,62 +998,51 @@
                     <div class="col">
                         <div class="p-3 border rounded-4 shadow-sm">
                             <h5 class="mb-3"><i class="bi bi-card-image"></i>&ensp;Artwork to include</h5>
-                            <div id="upload-filters-inherit" class="collapse show row mb-1">
-                                <div class="col-6 col-md-4 col-lg-3">
-                                    <div class="form-check form-switch mb-2">
-                                        <input class="form-check-input" type="checkbox" checked value="inherit" name="filter" id="upload-filters-global"/>
-                                        <label for="upload-filters-global" class="form-check-label">As set by global filters</label>
-                                    </div>
-                                </div>
+                            <div class="form-check form-switch mb-0">
+                                <input class="form-check-input" type="checkbox" checked value="inherit" name="filter" id="upload-filters-global"/>
+                                <label for="upload-filters-global" class="form-check-label">As set by global filters</label>
                             </div>
                             <div id="upload-filters" class="collapse">
-                                <div class="row mb-1">
-                                    <div class="col-12 mb-2"><strong>TV shows</strong></div>
-                                    <div class="col-6 col-md-4 col-lg-3">
-                                        <div class="form-check form-switch mb-2">
-                                            <input class="form-check-input" type="checkbox" checked value="show_cover" name="filter" id="upload-filter-show_cover"/>
-                                            <label for="upload-filter-show_cover" class="form-check-label">Show cover</label>
-                                        </div>
+                                <!-- TV Shows -->
+                                <div class="mt-2 mb-2"><strong>TV Shows</strong></div>
+                                <div class="d-flex flex-wrap align-items-center gap-y-2 mb-3">
+                                    <div class="form-check form-switch filter-toggle-item m-0">
+                                        <input class="form-check-input" type="checkbox" checked value="show_cover" id="upload-filter-show_cover"/>
+                                        <label for="upload-filter-show_cover" class="form-check-label text-nowrap">Show cover</label>
                                     </div>
-                                    <div class="col-6 col-md-4 col-lg-3">
-                                        <div class="form-check form-switch mb-2">
-                                            <input class="form-check-input" type="checkbox" checked value="season_cover" name="filter" id="upload-filter-season_cover"/>
-                                            <label for="upload-filter-season_cover" class="form-check-label">Season covers</label>
-                                        </div>
+                                    <div class="form-check form-switch filter-toggle-item m-0">
+                                        <input class="form-check-input" type="checkbox" checked value="season_cover" id="upload-filter-season_cover"/>
+                                        <label for="upload-filter-season_cover" class="form-check-label text-nowrap">Season covers</label>
                                     </div>
-                                    <div class="col-6 col-md-4 col-lg-3">
-                                        <div class="form-check form-switch mb-2">
-                                            <input class="form-check-input" type="checkbox" checked value="title_card" name="filter" id="upload-filter-title_card"/>
-                                            <label for="upload-filter-title_card" class="form-check-label">Title cards</label>
-                                        </div>
+                                    <div class="form-check form-switch filter-toggle-item m-0">
+                                        <input class="form-check-input" type="checkbox" checked value="title_card" id="upload-filter-title_card"/>
+                                        <label for="upload-filter-title_card" class="form-check-label text-nowrap">Title cards</label>
+                                    </div>
+                                </div>                                
+
+                                <!-- Movies -->
+                                <div class="mb-2"><strong>Movies</strong></div>
+                                <div class="d-flex flex-wrap align-items-center gap-y-2 mb-3">
+                                    <div class="form-check form-switch filter-toggle-item m-0">
+                                        <input class="form-check-input" type="checkbox" checked value="movie_poster" id="upload-filter-movie_poster"/>
+                                        <label for="upload-filter-movie_poster" class="form-check-label text-nowrap">Movie poster</label>
                                     </div>
                                 </div>
-                                <div class="row">
-                                    <div class="col-12 mb-2"><strong>Movies</strong></div>
-                                    <div class="col-6 col-md-4 col-lg-3">
-                                        <div class="form-check form-switch mb-2">
-                                            <input class="form-check-input" type="checkbox" checked value="movie_poster" id="upload-filter-movie_poster"/>
-                                            <label for="upload-filter-movie_poster" class="form-check-label">Movie poster</label>
-                                        </div>
+
+                                <!-- General -->
+                                <div class="mb-2"><strong>General</strong></div>
+                                <div class="d-flex flex-wrap align-items-center gap-y-2 mb-0">
+                                    <div class="form-check form-switch filter-toggle-item m-0">
+                                        <input class="form-check-input" type="checkbox" checked value="background" id="upload-filter-background"/>
+                                        <label for="upload-filter-background" class="form-check-label text-nowrap">Background</label>
                                     </div>
-                                    <div class="col-12 mb-2"><strong>General</strong></div>
-                                    <div class="col-6 col-md-8 col-lg-3">
-                                        <div class="form-check form-switch mb-2">
-                                            <input class="form-check-input" type="checkbox" checked value="collection_poster" id="upload-filter-collection_poster"/>
-                                            <label for="upload-filter-collection_poster" class="form-check-label">Collection poster</label>
-                                        </div>
+                                    <div class="form-check form-switch filter-toggle-item m-0">
+                                        <input class="form-check-input" type="checkbox" checked value="square_art" id="upload-filter-square_art"/>
+                                        <label for="upload-filter-square_art" class="form-check-label text-nowrap">Square art</label>
                                     </div>
-                                    <div class="col-6 col-md-4 col-lg-3">
-                                        <div class="form-check form-switch mb-2">
-                                            <input class="form-check-input" type="checkbox" checked value="background" name="filter" id="upload-filter-background"/>
-                                            <label for="upload-filter-background" class="form-check-label">Background</label>
-                                        </div>
-                                    </div>
-                                    <div class="col-6 col-md-4 col-lg-3">
-                                        <div class="form-check form-switch mb-2">
-                                            <input class="form-check-input" type="checkbox" checked value="square_art" name="filter" id="upload-filter-square_art"/>
-                                            <label for="upload-filter-square_art" class="form-check-label">Square art</label>
-                                        </div>
+                                    <div class="form-check form-switch filter-toggle-item m-0">
+                                        <input class="form-check-input" type="checkbox" checked value="collection_poster" id="upload-filter-collection_poster"/>
+                                        <label for="upload-filter-collection_poster" class="form-check-label text-nowrap">Collection poster</label>
                                     </div>
                                 </div>
                             </div>
@@ -1176,7 +1147,7 @@
                                     this tool provides an easy-to-use interface to streamline the process.</p>
                                 <p><i class="bi bi-github"></i>&ensp;Find the source code and report any issues on <a href="https://github.com/mscodemonkey/artwork-uploader-plex" target="_blank">GitHub</a></p>
                                 <p><i class="bi bi-arrow-through-heart"></i>&ensp;Like what you see? Give us a star on our GitHub page!</p>
-                                <div class="form-check form-switch mb-3">
+                                <div class="form-check form-switch">
                                     <input class="form-check-input" type="checkbox" id="debug-mode"/>
                                     <label for="debug-mode" class="form-check-label">Enable debug mode</label>&nbsp;
                                     <i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-title="If you need to report an issue, enable debug mode, reproduce the issue and check the logs."></i>

--- a/web_routes.py
+++ b/web_routes.py
@@ -438,7 +438,7 @@ def setup_socket_handlers(
         token = data.get("token", "")
 
         try:
-            plex_server = PlexServer(url, token, timeout=globals.config.plex_test_connection_timeout)
+            plex_server = PlexServer(url, token, timeout=globals.config.plex_connect_timeout)
             debug_me(f"Successfully connected to Plex server at '{url}'")
         except Exception as e:
             debug_me(f"Failed to connect to Plex server at '{url}'")


### PR DESCRIPTION
- Removed plex_test_connection_timeout since the "Test Connection to Plex" button was removed in the UI and it was only used when fetching libraries so it didn't make sense to have a separate timeout just for that, overcomplicating the UI. Now the fetch libraries operation uses the regular plex_connect_timeout timeout
- Made the default timeout for Kometa downloads 10 seconds, like the upload timeout
- Available timeouts presented in the card depend on the operating mode (upload to Plex / save to Kometa)
- Rationalized the labels for the different timeouts in the UI for brevity and better readability in mobile screens
- Made a number of UI tweak across the board for enhanced consistency (not specific to PR #89)