### PR TITLE
Give the scrape_and_upload double its failed_counter argument

### DIFF
--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -348,7 +348,7 @@ def test_mid_run_crash_after_processing_is_not_reported_as_failed_to_start():
 
         call_count = {"n": 0}
 
-        def flaky_scrape_and_upload(inst, url, options, bulk, success_counter, assets_processed, cached_counter=None, locked_counter=None):
+        def flaky_scrape_and_upload(inst, url, options, bulk, success_counter, assets_processed, cached_counter=None, locked_counter=None, failed_counter=None):
             call_count["n"] += 1
             if call_count["n"] == 1:
                 assets_processed[0] += 1


### PR DESCRIPTION
You beat me to most of this one. When I opened it, `main` failed six tests and this PR covered all six. 1c8beec has since fixed the two real problems behind five of them, the missing `add_run` and the double notification, so I have dropped those and rebased on v1.0.0. What is left is the sixth.

`test_mid_run_crash_after_processing_is_not_reported_as_failed_to_start` stands in for `scrape_and_upload` with a function that was never given the `failed_counter` argument the real one takes:

```python
def flaky_scrape_and_upload(inst, url, options, bulk, success_counter, assets_processed, cached_counter=None, locked_counter=None):
```

So the first call raises `TypeError` before the `PlexConnectorException` the test is arranging. Nothing gets processed, `assets_processed[0]` stays at 0, and the run reports `run_failed_to_start`, which is the exact thing the test exists to rule out. The other doubles picked this argument up in v0.9.21; this one was written without it.

One argument added, no production code touched.

Before: 1 failed, 203 passed. After: 204 passed, run with pytest against the tree in the published image.