### PR TITLE
Record bulk imports run from the command line in the run history

### DIFF
--- a/artwork_uploader.py
+++ b/artwork_uploader.py
@@ -114,43 +114,87 @@ def parse_bulk_file_from_cli(instance: Instance, file_path):
     Load and parse the URLs from a bulk import file, then scrape them with any options set for that URL.
     """
 
+    display_filename = os.path.basename(file_path)
+
+    # A bulk import started from the command line is a run like any other, so it keeps the same
+    # counters as one started from the Bulk Import tab and gets the same record in the history.
+    # The outcome starts as failed: every path out of here is recorded, including one that
+    # raises, and only a run that finished gets to say otherwise.
+    started_at = datetime.now(timezone.utc).isoformat()
+    outcome = RunOutcome.FAILED.value
+    success_counter = [0]
+    assets_processed = [0]
+    cached_counter = [0]
+    locked_counter = [0]
+    failed_counter = [0]  # Uploads that failed after exhausting their retries
+    errors = 0
+
     # Open the file and read the contents
     try:
         with open(file_path, 'r', encoding='utf-8') as file:
             urls = file.readlines()
     except FileNotFoundError:
         print("File not found. Please enter a valid file path.")
+        now = datetime.now(timezone.utc).isoformat()
+        RunHistory().add_run(
+            RunType.BULK.value, display_filename, started_at, now,
+            RunTrigger.CLI.value, RunOutcome.FAILED.value
+        )
+        return
 
     start_time = time.time()
-    update_log(instance, f"🎬 Bulk process started for '{os.path.basename(file_path)}'")
+    update_log(instance, f"🎬 Bulk process started for '{display_filename}'")
 
-    # Loop through the file, process the URL and options, then scrape according to the URL
-    for n, line in enumerate(urls, 1):
+    try:
 
-        # Skip comments
-        if is_not_comment(line):
+        # Loop through the file, process the URL and options, then scrape according to the URL
+        for n, line in enumerate(urls, 1):
 
-            # Parse the line to extract the URL and options
-            try:
-                parsed_url = parse_url_and_options(line)
-            except InvalidUrl as e:
-                update_log(instance, f"❌ Invalid URL found in bulk import file '{os.path.basename(file_path)}', line {n}: '{str(e)}'")
-                continue
-            except InvalidFlag as e:
-                update_log(instance, f"❌ One or more invalid flags found in bulk import file '{os.path.basename(file_path)}', line {n}: {str(e)}")
-                continue
+            # Skip comments
+            if is_not_comment(line):
 
-            try:
-                success_counter = [0]
-                scrape_and_upload(instance, parsed_url.url, parsed_url.options, False, success_counter)
-            except ScraperException as e:
-                debug_me(f"ScraperException: Error processing {parsed_url.url}: {str(e)}")
-            except Exception as e:
-                debug_me(f"Unknown Exception: Error processing {parsed_url.url}: {str(e)}")
+                # Parse the line to extract the URL and options
+                try:
+                    parsed_url = parse_url_and_options(line)
+                except InvalidUrl as e:
+                    update_log(instance, f"❌ Invalid URL found in bulk import file '{display_filename}', line {n}: '{str(e)}'")
+                    errors += 1
+                    continue
+                except InvalidFlag as e:
+                    update_log(instance, f"❌ One or more invalid flags found in bulk import file '{display_filename}', line {n}: {str(e)}")
+                    errors += 1
+                    continue
 
-    end_time = time.time()
-    elapsed = elapsed_time(end_time - start_time)
-    update_log(instance, f"🏁 Bulk process completed in {elapsed} for '{os.path.basename(file_path)}'")
+                try:
+                    scrape_and_upload(instance, parsed_url.url, parsed_url.options, False, success_counter, assets_processed, cached_counter=cached_counter, locked_counter=locked_counter, failed_counter=failed_counter)
+                except ScraperException as e:
+                    debug_me(f"ScraperException: Error processing {parsed_url.url}: {str(e)}")
+                    errors += 1
+                except Exception as e:
+                    debug_me(f"Unknown Exception: Error processing {parsed_url.url}: {str(e)}")
+                    errors += 1
+
+        end_time = time.time()
+        elapsed = elapsed_time(end_time - start_time)
+        update_log(instance, f"🏁 Bulk process completed in {elapsed} for '{display_filename}'")
+
+        # A line that failed to scrape at all (errors) and an item that failed to upload after
+        # exhausting its retries (failed_counter) both count as errors in the run summary. An
+        # item that succeeded on a retry never reaches failed_counter, so it isn't one.
+        if errors + failed_counter[0]:
+            outcome = RunOutcome.PARTIAL.value
+        elif assets_processed[0]:
+            outcome = RunOutcome.SUCCESS.value
+        else:
+            outcome = RunOutcome.SKIPPED.value
+
+    finally:
+        RunHistory().add_run(
+            RunType.BULK.value, display_filename, started_at, datetime.now(timezone.utc).isoformat(),
+            RunTrigger.CLI.value, outcome,
+            assets_processed[0], success_counter[0], cached_counter[0], locked_counter[0],
+            errors + failed_counter[0]
+        )
 
 # ---------------------- GUI FUNCTIONS ----------------------
 

--- a/core/enums.py
+++ b/core/enums.py
@@ -103,6 +103,7 @@ class RunTrigger(str, Enum):
     """Type of trigger that triggered a run"""
     MANUAL = "manual"
     SCHEDULED = "scheduled"
+    CLI = "cli"
     RADARR = "radarr"
     SONARR = "sonarr"
 

--- a/services/run_history.py
+++ b/services/run_history.py
@@ -58,15 +58,26 @@ class RunHistory:
             return []
 
     def _save(self, runs: List[Dict[str, Any]]) -> None:
+        # Written to a temporary file and moved into place, so a reader never sees a partly
+        # written one. The write lock above only holds within a single process, and a bulk
+        # import run from the command line is a second process alongside the web interface,
+        # so a read landing mid-write is possible: it would come back empty and the next
+        # save would keep only its own record. os.replace is atomic on POSIX and Windows.
+        temp_path = f"{self.path}.tmp"
         try:
             directory = os.path.dirname(self.path)
             if directory:
                 os.makedirs(directory, exist_ok=True)
-            with open(self.path, "w", encoding="utf-8") as history_file:
+            with open(temp_path, "w", encoding="utf-8") as history_file:
                 json.dump(runs, history_file, indent=4)
+            os.replace(temp_path, self.path)
         except OSError as e:
             from utils.notifications import debug_me
             debug_me(f"Run history could not be saved to '{self.path}': {e}")
+            try:
+                os.remove(temp_path)
+            except OSError:
+                pass  # nothing to tidy up, or the same problem that stopped the write
 
     def _prune(self, runs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         if self.max_age_days:

--- a/static/web_interface.js
+++ b/static/web_interface.js
@@ -1665,6 +1665,7 @@ const RUN_HISTORY_TYPE_LABELS = {
 const RUN_HISTORY_TRIGGER_LABELS = {
     manual: "Manual",
     scheduled: "Scheduled",
+    cli: "Command line",
     radarr: "Radarr",
     sonarr: "Sonarr"
 };

--- a/tests/test_run_counters.py
+++ b/tests/test_run_counters.py
@@ -1,9 +1,16 @@
 """Unit tests for the run-summary counters."""
 
+import dataclasses
+from unittest.mock import MagicMock, patch
+
 import pytest
 
+import core.globals as globals
+from artwork_uploader import parse_bulk_file_from_cli, process_bulk_import_from_ui
 from models.callbacks import ProcessingCallbacks
+from models.instance import Instance
 from services.artwork_processor import ArtworkProcessor
+from services.run_history import RunHistory
 
 
 @pytest.mark.parametrize("result, expected", [
@@ -80,3 +87,71 @@ def test_failed_uploads_are_counted_and_do_not_count_as_success():
 
     assert success[0] == 1
     assert failed[0] == 1
+
+
+# Every counter on ProcessingCallbacks is a keyword argument that defaults to None, and each
+# of the increment methods checks for its list before touching it. Leaving one out of a call
+# to scrape_and_upload therefore raises nothing and logs nothing: the number simply stays at
+# zero. That has already happened once per counter. assets_processed, cached_counter,
+# locked_counter and failed_counter were each added to the bulk import from the Bulk Import
+# tab and none of them reached the command line path, which was still passing only a
+# success_counter years later. These two check that both paths fill in every counter the
+# class declares, so the next one added cannot go quiet in one of them.
+
+def _counter_field_names():
+    """Read the counters off the class rather than listing them here, so one added later
+    is covered without anybody remembering to update this test."""
+    return [field.name for field in dataclasses.fields(ProcessingCallbacks)
+            if not field.name.startswith("on_")]
+
+
+def _callbacks_built_by(start_the_run, tmp_path):
+    """Run one of the bulk paths with the processor stubbed out, and give back the
+    ProcessingCallbacks it handed to it."""
+    with (
+        patch("artwork_uploader.ArtworkProcessor") as processor_class,
+        patch("artwork_uploader.RunHistory", lambda: RunHistory(str(tmp_path / "run_history.json"))),
+        patch("artwork_uploader.notify_web"),
+        patch("artwork_uploader.update_log"),
+        patch("artwork_uploader.update_status"),
+        patch("artwork_uploader.debug_me"),
+    ):
+        processor_class.return_value.scrape_and_process.return_value = ("A Title", "An Author")
+        start_the_run()
+
+    assert processor_class.call_count == 1, "the path under test never reached the processor"
+    return processor_class.call_args.args[1]
+
+
+@pytest.fixture
+def plex_configured():
+    globals.plex = MagicMock(tv_libraries=MagicMock(), movie_libraries=MagicMock())
+    globals.config = MagicMock(apprise_urls=[])
+    try:
+        yield
+    finally:
+        globals.plex = None
+        globals.config = None
+        globals.cancel_scrape = False
+        globals.scrapes_running = 0
+
+
+@pytest.mark.unit
+def test_the_command_line_bulk_path_passes_every_counter(tmp_path, plex_configured):
+    bulk_file = tmp_path / "nightly.txt"
+    bulk_file.write_text("https://mediux.pro/sets/12345\n", encoding="utf-8")
+
+    callbacks = _callbacks_built_by(
+        lambda: parse_bulk_file_from_cli(Instance(mode="cli"), str(bulk_file)), tmp_path
+    )
+
+    assert [name for name in _counter_field_names() if getattr(callbacks, name) is None] == []
+
+
+@pytest.mark.unit
+def test_the_bulk_import_tab_path_passes_every_counter(tmp_path, plex_configured):
+    callbacks = _callbacks_built_by(
+        lambda: process_bulk_import_from_ui(Instance(mode="cli"), [MagicMock()], "nightly.txt"), tmp_path
+    )
+
+    assert [name for name in _counter_field_names() if getattr(callbacks, name) is None] == []

--- a/tests/test_run_history.py
+++ b/tests/test_run_history.py
@@ -1,8 +1,10 @@
 """Unit tests for the persistent run history (services/run_history.py)."""
 
 import json
+import os
 import threading
 from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
 
 import pytest
 
@@ -237,3 +239,29 @@ def test_concurrent_runs_finishing_together_do_not_lose_a_record(tmp_path):
         thread.join()
 
     assert len(RunHistory(path).get_runs()) == 20
+
+
+@pytest.mark.unit
+def test_saving_leaves_no_temporary_file_behind(tmp_path):
+    path = tmp_path / "run_history.json"
+    RunHistory(str(path)).add_run(RUN_TYPE_BULK, "file.txt", _iso(), _iso(), TRIGGER_MANUAL, OUTCOME_SUCCESS)
+
+    assert path.is_file()
+    assert not os.path.exists(f"{path}.tmp")
+
+
+@pytest.mark.unit
+def test_a_failed_write_leaves_the_existing_history_intact(tmp_path):
+    """The history is written to a temporary file and moved into place, so a write that
+    dies part way cannot take the records already on disk with it."""
+    path = tmp_path / "run_history.json"
+    history = RunHistory(str(path))
+    history.add_run(RUN_TYPE_BULK, "first.txt", _iso(), _iso(), TRIGGER_MANUAL, OUTCOME_SUCCESS)
+
+    with patch("services.run_history.json.dump", side_effect=OSError("no space left on device")):
+        history.add_run(RUN_TYPE_BULK, "second.txt", _iso(), _iso(), TRIGGER_MANUAL, OUTCOME_SUCCESS)
+
+    runs = history.get_runs()
+    assert len(runs) == 1
+    assert runs[0]["label"] == "first.txt"
+    assert not os.path.exists(f"{path}.tmp")

--- a/tests/test_run_history_cli.py
+++ b/tests/test_run_history_cli.py
@@ -1,0 +1,186 @@
+"""
+Covers the run history record parse_bulk_file_from_cli writes.
+
+A bulk import run from the command line reaches none of the recording sites the web
+interface uses, so it needs its own coverage: a clean run, a run whose lines error, a
+run where the file has nothing worth doing, a missing file, and a run that dies on an
+unexpected exception part way through.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from artwork_uploader import parse_bulk_file_from_cli
+from models.instance import Instance
+from services.run_history import RunHistory
+from core.enums import RunOutcome, RunTrigger, RunType
+
+OUTCOME_SUCCESS = RunOutcome.SUCCESS.value
+OUTCOME_PARTIAL = RunOutcome.PARTIAL.value
+OUTCOME_FAILED = RunOutcome.FAILED.value
+OUTCOME_SKIPPED = RunOutcome.SKIPPED.value
+
+URL = "https://mediux.pro/sets/12345"
+
+
+@pytest.fixture
+def history(tmp_path, monkeypatch):
+    real_history = RunHistory(str(tmp_path / "run_history.json"))
+    monkeypatch.setattr("artwork_uploader.RunHistory", lambda: real_history)
+    return real_history
+
+
+@pytest.fixture
+def bulk_file(tmp_path):
+    def write(contents, name="nightly.txt"):
+        path = tmp_path / name
+        path.write_text(contents, encoding="utf-8")
+        return str(path)
+    return write
+
+
+def _quiet():
+    """The CLI writes its progress to stdout, which the tests don't need to see."""
+    return (
+        patch("artwork_uploader.update_log"),
+        patch("artwork_uploader.debug_me"),
+    )
+
+
+@pytest.mark.unit
+def test_successful_run_is_recorded_with_its_counters(history, bulk_file):
+    def fake_scrape(instance, url, options, bulk, success_counter, assets_processed,
+                    cached_counter=None, locked_counter=None, failed_counter=None):
+        assets_processed[0] += 1
+        success_counter[0] += 1
+        cached_counter[0] += 1
+
+    quiet_log, quiet_debug = _quiet()
+    with patch("artwork_uploader.scrape_and_upload", side_effect=fake_scrape), quiet_log, quiet_debug:
+        parse_bulk_file_from_cli(Instance(mode="cli"), bulk_file(f"{URL}\n{URL}\n"))
+
+    runs = history.get_runs()
+    assert len(runs) == 1
+    assert runs[0]["run_type"] == RunType.BULK.value
+    assert runs[0]["trigger"] == RunTrigger.CLI.value
+    assert runs[0]["outcome"] == OUTCOME_SUCCESS
+    assert runs[0]["assets_processed"] == 2
+    assert runs[0]["success_count"] == 2
+    assert runs[0]["cached_count"] == 2
+    assert runs[0]["error_count"] == 0
+
+
+@pytest.mark.unit
+def test_the_label_is_the_file_name_not_the_whole_path(history, bulk_file):
+    """The history table shows the label as it is, so a full container path would be unreadable."""
+    quiet_log, quiet_debug = _quiet()
+    with patch("artwork_uploader.scrape_and_upload"), quiet_log, quiet_debug:
+        parse_bulk_file_from_cli(Instance(mode="cli"), bulk_file(f"{URL}\n", name="weekly.txt"))
+
+    assert history.get_runs()[0]["label"] == "weekly.txt"
+
+
+@pytest.mark.unit
+def test_counters_survive_the_whole_file(history, bulk_file):
+    """Every line adds to the same counters, rather than each line starting from zero."""
+    def fake_scrape(instance, url, options, bulk, success_counter, assets_processed,
+                    cached_counter=None, locked_counter=None, failed_counter=None):
+        assets_processed[0] += 2
+        success_counter[0] += 1
+        locked_counter[0] += 1
+
+    quiet_log, quiet_debug = _quiet()
+    with patch("artwork_uploader.scrape_and_upload", side_effect=fake_scrape), quiet_log, quiet_debug:
+        parse_bulk_file_from_cli(Instance(mode="cli"), bulk_file(f"{URL}\n{URL}\n{URL}\n"))
+
+    runs = history.get_runs()
+    assert runs[0]["assets_processed"] == 6
+    assert runs[0]["success_count"] == 3
+    assert runs[0]["locked_count"] == 3
+
+
+@pytest.mark.unit
+def test_a_line_that_fails_to_scrape_is_recorded_as_partial(history, bulk_file):
+    from core.exceptions import ScraperException
+
+    quiet_log, quiet_debug = _quiet()
+    with patch("artwork_uploader.scrape_and_upload", side_effect=ScraperException("bad set")), quiet_log, quiet_debug:
+        parse_bulk_file_from_cli(Instance(mode="cli"), bulk_file(f"{URL}\n"))
+
+    runs = history.get_runs()
+    assert runs[0]["outcome"] == OUTCOME_PARTIAL
+    assert runs[0]["error_count"] == 1
+
+
+@pytest.mark.unit
+def test_an_upload_that_exhausted_its_retries_counts_as_an_error(history, bulk_file):
+    """The line itself scraped fine, so only failed_counter says anything went wrong."""
+    def fake_scrape(instance, url, options, bulk, success_counter, assets_processed,
+                    cached_counter=None, locked_counter=None, failed_counter=None):
+        assets_processed[0] += 1
+        failed_counter[0] += 1
+
+    quiet_log, quiet_debug = _quiet()
+    with patch("artwork_uploader.scrape_and_upload", side_effect=fake_scrape), quiet_log, quiet_debug:
+        parse_bulk_file_from_cli(Instance(mode="cli"), bulk_file(f"{URL}\n"))
+
+    runs = history.get_runs()
+    assert runs[0]["outcome"] == OUTCOME_PARTIAL
+    assert runs[0]["error_count"] == 1
+
+
+@pytest.mark.unit
+def test_an_unusable_line_is_recorded_as_an_error_without_scraping(history, bulk_file):
+    quiet_log, quiet_debug = _quiet()
+    with patch("artwork_uploader.scrape_and_upload") as mock_scrape, quiet_log, quiet_debug:
+        parse_bulk_file_from_cli(Instance(mode="cli"), bulk_file("not a url at all\n"))
+
+    mock_scrape.assert_not_called()
+    runs = history.get_runs()
+    assert runs[0]["outcome"] == OUTCOME_PARTIAL
+    assert runs[0]["error_count"] == 1
+
+
+@pytest.mark.unit
+def test_a_file_with_nothing_to_do_is_recorded_as_skipped(history, bulk_file):
+    quiet_log, quiet_debug = _quiet()
+    with patch("artwork_uploader.scrape_and_upload") as mock_scrape, quiet_log, quiet_debug:
+        parse_bulk_file_from_cli(Instance(mode="cli"), bulk_file("# parked for now\n// and this one\n\n"))
+
+    mock_scrape.assert_not_called()
+    runs = history.get_runs()
+    assert runs[0]["outcome"] == OUTCOME_SKIPPED
+    assert runs[0]["assets_processed"] == 0
+    assert runs[0]["error_count"] == 0
+
+
+@pytest.mark.unit
+def test_a_missing_file_is_recorded_as_failed(history, tmp_path):
+    quiet_log, quiet_debug = _quiet()
+    with patch("artwork_uploader.scrape_and_upload") as mock_scrape, quiet_log, quiet_debug:
+        parse_bulk_file_from_cli(Instance(mode="cli"), str(tmp_path / "gone.txt"))
+
+    mock_scrape.assert_not_called()
+    runs = history.get_runs()
+    assert len(runs) == 1
+    assert runs[0]["outcome"] == OUTCOME_FAILED
+    assert runs[0]["label"] == "gone.txt"
+
+
+@pytest.mark.unit
+def test_an_unexpected_exception_mid_run_is_still_recorded(history, bulk_file):
+    """The run is recorded on the way out, so a crash leaves a record rather than a silence."""
+    quiet_log, quiet_debug = _quiet()
+    with (
+        patch("artwork_uploader.scrape_and_upload"),
+        patch("artwork_uploader.elapsed_time", side_effect=RuntimeError("boom")),
+        quiet_log,
+        quiet_debug,
+    ):
+        with pytest.raises(RuntimeError):
+            parse_bulk_file_from_cli(Instance(mode="cli"), bulk_file(f"{URL}\n"))
+
+    runs = history.get_runs()
+    assert len(runs) == 1
+    assert runs[0]["outcome"] == OUTCOME_FAILED


### PR DESCRIPTION
The run history records a run in five places: a scrape from the main tab, a bulk import from the Bulk Import tab, a scheduled one, a ZIP upload, and a webhook import. The sixth way to start a run, `artwork_uploader.py bulk <file>`, records nothing, because `parse_bulk_file_from_cli` is its own path and reaches none of them.

That leaves out the case the history is arguably most useful for. Anyone driving the tool from cron, a systemd timer or Task Scheduler has a Run History tab that stays permanently empty, and nothing to look at the next morning once the container logs have rotated, which is the situation the module docstring describes.

### What it does

Mirrors what `process_bulk_import_from_ui` already does rather than routing the CLI through it. Going through the UI function would pull in `notify_web`, the progress bars and `globals.scrapes_running`, and change what a wrapper script sees on stdout, which seemed like too much to risk for a change that only needs to record something. So: the same five counters, the same outcome rules, and one `add_run` in a `finally` so a run that raises still leaves a record.

Two things had to be fixed to get there, both inside that function:

- The counters were never wired up. Only `success_counter` was passed, and it was rebuilt from `[0]` inside the loop on every line, so nothing was ever tallied across a file. `assets_processed`, `cached_counter`, `locked_counter` and `failed_counter` were all left as `None`, so `record_result` counted into nothing.
- A missing bulk file printed "File not found. Please enter a valid file path." and then carried straight on to `for n, line in enumerate(urls, 1)` with `urls` unbound, raising `UnboundLocalError`. It now records the run as failed and returns.

Command line runs record a new `cli` trigger so they can be told apart from something a person started in the browser, with a matching label in the history table. The table already fell back to the raw value for an unknown trigger, so that part is only cosmetic.

### Second commit: writing the history through a temporary file

Worth a separate look, because this change is what makes it matter. `_write_locks` is a threading lock, so it only serializes writers inside one process, and a CLI bulk import is a second process running alongside the web interface. A read landing in the middle of a write now becomes possible, and since `_load` treats an unreadable file as no history at all, that read comes back empty and the save after it keeps only its own record, quietly dropping the rest.

Writing to a temporary file and moving it into place with `os.replace` means a reader sees either the previous history or the new one. It also stops a crash or a full disk from truncating what was already recorded. Happy to drop this commit if you would rather take it separately.

### Not included

The CLI still exits 0 whatever happened, so a wrapper cannot tell a clean run from a failed one by exit status alone. An opt-in `--fail-on-error` would fix that without changing the default for anybody, and the outcome this change already works out is most of the job. Left out deliberately to keep this to recording, but happy to send it as a follow-up if you would find it useful.

### Verified

`tests/test_run_history_cli.py`, 9 tests covering each outcome the path can reach, following the pattern in `test_run_history_recording.py`, plus 2 in `test_run_history.py` for the temporary file write. 215 passed, none failing, run with pytest against the tree in the published image.

Also run against the published image with a real config, same tree and same bulk file either side, since the CLI's output is what wrapper scripts parse:

```
main                                    with this change
🎬 Bulk process started                 🎬 Bulk process started
🔍 Mr. & Mrs. Smith (2024) • …          🔍 Mr. & Mrs. Smith (2024) • …
❌ Scraper error: No poster data …      ❌ Scraper error: No poster data …
🏁 Bulk process completed in 3s         🏁 Bulk process completed in 2s
exit 0                                  exit 0
-> no run_history.json at all           -> bulk / nightly.txt / cli / partial
                                           processed=3 errors=1
```

Byte identical on stdout, same exit code. The four outcomes as recorded on a real run:

```
onehit.txt           cli  success  processed=1  updated=1  errors=0
nightly.txt          cli  partial  processed=3  updated=0  errors=1
parked.txt           cli  skipped  processed=0  updated=0  errors=0
does-not-exist.txt   cli  failed   processed=0  updated=0  errors=0
```

### One aside

The `add_run` in `process_bulk_import_from_ui` passes `errors` as its `error_count`, while the outcome and the summary line both use `total_errors`. A UI run whose only errors are uploads that exhausted their retries is therefore stored as `partial` with `error_count: 0`. This change counts both for the CLI, which is the only place the two deliberately differ. Say the word and I will make them match, either way round.

### Keeping the two bulk paths in step

Mirroring the Bulk Import tab path rather than sharing it leaves the obvious question: what stops the two drifting apart. It is a fair worry, because they already have. Every counter is a keyword argument defaulting to `None`, and each increment method checks for its list before touching it, so leaving one out raises nothing and logs nothing. The number just stays at zero.

That has happened once per counter, and none were noticed:

| Counter | Added to the Bulk Import tab path in | Reached the command line path |
| --- | --- | --- |
| `assets_processed` | 63f88dd, add notification service | no |
| `cached_counter` | 972b877, end a cached crawl at the last upload | no |
| `locked_counter` | fadd7ed, show how many assets were locked | no |
| `failed_counter` | 80d517a, retry transient upload failures | no |

So the last commit adds two tests in `test_run_counters.py` that run each path with the processor stubbed out and check the `ProcessingCallbacks` it built against the counters the class declares. The expected list is read from the dataclass rather than written out, so a counter added later is covered without anybody remembering the test exists. Left out of one path, that path fails and names it. Left out of both, both fail. I checked both cases by breaking it on purpose:

```
# failed_counter removed from the command line call
AssertionError: assert ['failed_counter'] == []
FAILED test_the_command_line_bulk_path_passes_every_counter

# a sixth counter added to ProcessingCallbacks, wired to neither path
AssertionError: assert ['retried_counter'] == []
FAILED test_the_command_line_bulk_path_passes_every_counter
FAILED test_the_bulk_import_tab_path_passes_every_counter
```

It guards your path as much as mine, and it is test only.

What it does not cover is the outcome rules, which are also written out twice now. If the meaning of an outcome changes on one side, both suites keep passing while the two quietly disagree. The tidy answer is a small object holding the five counters, built once and handed to `scrape_and_upload`, with the outcome worked out on it: one place to add a counter, one place to decide what an outcome means, and both paths keep their own logging and their own trigger. That felt like refactoring your code inside a change whose job is to fill a gap, so I have left it out, but I am happy to put it up as a follow-up if you like the shape of it.

217 passed with the guard included.