### PR TITLE
Make config.json.example parse again

### DIFF
--- a/config/config.json.example
+++ b/config/config.json.example
@@ -45,7 +45,7 @@
     "_save_to_kometa_help": "Saves artwork to Kometa asset directory instead of applying it to Plex directly",
 
     "stage_assets": false,
-    "_stage_assets": "Saves artwork for seasons and episodes not yet in Plex (except season specials)"
+    "_stage_assets": "Saves artwork for seasons and episodes not yet in Plex (except season specials)",
 
     "track_artwork_ids": true,
     "_track_artwork_ids_help": "Use Plex labels to track uploaded artwork and prevent duplicate uploads",
@@ -60,8 +60,8 @@
     "_schedules_help": "Scheduled bulk import jobs. Configure through the web UI",
 
     "apprise_urls": [],
-    "_apprise_urls_help": "List of notification channels, each {\"url\": <Apprise URL>, \"events\": [<event names>]}. Configure through the web UI"
-}
+    "_apprise_urls_help": "List of notification channels, each {\"url\": <Apprise URL>, \"events\": [<event names>]}. Configure through the web UI",
+
     "plex_connect_timeout": 10,
     "_plex_connect_timeout_help": "Seconds to wait when connecting to the Plex server (also applies to uploads)",
 

--- a/tests/test_config_example.py
+++ b/tests/test_config_example.py
@@ -1,0 +1,37 @@
+"""The shipped example config has to be usable as a starting config.json.
+
+Nothing reads config.json.example at runtime, so a syntax error in it stays invisible
+until somebody copies it to config.json to set the tool up, and then it fails at the
+first load with a message about the file they just copied rather than the file they
+copied it from. It was unparseable for a long stretch, so it is checked here.
+"""
+
+import json
+import os
+import shutil
+
+import pytest
+
+from core.config import Config
+
+EXAMPLE = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                       "config", "config.json.example")
+
+
+@pytest.mark.unit
+def test_the_example_config_is_valid_json():
+    with open(EXAMPLE, encoding="utf-8") as example:
+        json.load(example)
+
+
+@pytest.mark.unit
+def test_the_example_config_loads_as_a_config(tmp_path):
+    """Copied into place as config.json, it has to survive a load rather than raising."""
+    config_path = tmp_path / "config.json"
+    shutil.copyfile(EXAMPLE, config_path)
+
+    config = Config(str(config_path))
+    config.load()
+
+    assert config.apprise_urls == []
+    assert config.schedules == []


### PR DESCRIPTION
`config/config.json.example` is not valid JSON, so copying it to `config.json` to set the tool up produces a config that fails to load on the first run. The error names `config.json`, the file you just created, rather than the example you copied it from, which makes it a confusing first five minutes for a new user.

```
$ python -c "import json; json.load(open('config/config.json.example'))"
json.decoder.JSONDecodeError: Expecting ',' delimiter: line 50 column 5 (char 2011)
```

Two separate breaks, one old and one new.

**A missing comma**, after the `stage_assets` help line. This is the one the parser reports first, and it goes back a long way: v0.8.7, v0.9.0, v0.9.19, v0.9.20 and v0.9.21 all fail on the same line and character offset.

```json
"stage_assets": false,
"_stage_assets": "Saves artwork for seasons and episodes not yet in Plex (except season specials)"
                                                                                                  ^ no comma
"track_artwork_ids": true,
```

**A brace closing the object early**, left behind when `apprise_urls` became a list of notification channels. Everything after it, the timeouts and the upload retry settings, sat outside the object:

```json
"_apprise_urls_help": "List of notification channels, ..."
}
"plex_connect_timeout": 10,
```

Fixing only the comma just moves the error along to `Extra data: line 65`, so both need doing. The blank line between the two sections is put back so the spacing matches the rest of the file.

### Why it went unnoticed

Nothing reads the example at runtime. `Config` writes its own defaults when `config.json` is absent, so the example is documentation, only ever consumed by a person copying it. It can rot indefinitely without anything complaining, and it has.

So there are two small tests: the example parses, and `Config` can load a copy of it. Against the file as it stands on `main` both fail, the first with the `JSONDecodeError` above and the second with `ConfigLoadError`. With the fix, 206 passed, run with pytest against the tree in the published image.

No production code touched.
