### PR TITLE
Work out the run outcome in one place instead of four

### DIFF
--- a/artwork_uploader.py
+++ b/artwork_uploader.py
@@ -1,4 +1,5 @@
 import uuid, os, re, threading, sys, time
+from dataclasses import replace
 from datetime import datetime, timezone
 from core import globals
 
@@ -122,11 +123,7 @@ def parse_bulk_file_from_cli(instance: Instance, file_path):
     # raises, and only a run that finished gets to say otherwise.
     started_at = datetime.now(timezone.utc).isoformat()
     outcome = RunOutcome.FAILED.value
-    success_counter = [0]
-    assets_processed = [0]
-    cached_counter = [0]
-    locked_counter = [0]
-    failed_counter = [0]  # Uploads that failed after exhausting their retries
+    tally = ProcessingCallbacks()
     errors = 0
 
     # Open the file and read the contents
@@ -166,7 +163,7 @@ def parse_bulk_file_from_cli(instance: Instance, file_path):
                     continue
 
                 try:
-                    scrape_and_upload(instance, parsed_url.url, parsed_url.options, False, success_counter, assets_processed, cached_counter=cached_counter, locked_counter=locked_counter, failed_counter=failed_counter)
+                    scrape_and_upload(instance, parsed_url.url, parsed_url.options, False, tally)
                 except ScraperException as e:
                     debug_me(f"ScraperException: Error processing {parsed_url.url}: {str(e)}")
                     errors += 1
@@ -178,22 +175,17 @@ def parse_bulk_file_from_cli(instance: Instance, file_path):
         elapsed = elapsed_time(end_time - start_time)
         update_log(instance, f"🏁 Bulk process completed in {elapsed} for '{display_filename}'")
 
-        # A line that failed to scrape at all (errors) and an item that failed to upload after
-        # exhausting its retries (failed_counter) both count as errors in the run summary. An
-        # item that succeeded on a retry never reaches failed_counter, so it isn't one.
-        if errors + failed_counter[0]:
-            outcome = RunOutcome.PARTIAL.value
-        elif assets_processed[0]:
-            outcome = RunOutcome.SUCCESS.value
-        else:
-            outcome = RunOutcome.SKIPPED.value
+        # A line that failed to scrape at all is an error the uploader never saw, so it is
+        # handed to the tally rather than counted twice. There is no Stop button behind a
+        # command line run, so it can never end up stopped.
+        outcome = tally.outcome(extra_errors=errors)
 
     finally:
         RunHistory().add_run(
             RunType.BULK.value, display_filename, started_at, datetime.now(timezone.utc).isoformat(),
             RunTrigger.CLI.value, outcome,
-            assets_processed[0], success_counter[0], cached_counter[0], locked_counter[0],
-            errors + failed_counter[0]
+            tally.assets_processed[0], tally.success_counter[0], tally.cached_counter[0],
+            tally.locked_counter[0], tally.errors(errors)
         )
 
 # ---------------------- GUI FUNCTIONS ----------------------
@@ -234,11 +226,7 @@ def process_scrape_url_from_web(instance: Instance, url: str) -> None:
     started_at = datetime.now(timezone.utc).isoformat()
     label = url
     outcome = RunOutcome.FAILED.value
-    success_counter = [0]
-    assets_processed = [0]
-    cached_counter = [0]
-    locked_counter = [0]
-    failed_counter = [0]
+    tally = ProcessingCallbacks()
 
     try:
         # Check if the Plex TV and movie libraries are configured
@@ -255,20 +243,10 @@ def process_scrape_url_from_web(instance: Instance, url: str) -> None:
         label = parsed_line.url
         update_status(instance, f"Scraping URL '{parsed_line.url}'", color=StatusColor.INFO.value, sticky=True, spinner=True)
 
-        title, author = scrape_and_upload(
-            instance, parsed_line.url, parsed_line.options, False, success_counter, assets_processed,
-            cached_counter=cached_counter, locked_counter=locked_counter, failed_counter=failed_counter
-        )
+        title, author = scrape_and_upload(instance, parsed_line.url, parsed_line.options, False, tally)
 
         # Read the cancel flag here, not in the finally below - that's where it gets cleared
-        if globals.cancel_scrape:
-            outcome = RunOutcome.STOPPED.value
-        elif failed_counter[0]:
-            outcome = RunOutcome.PARTIAL.value
-        elif assets_processed[0]:
-            outcome = RunOutcome.SUCCESS.value
-        else:
-            outcome = RunOutcome.SKIPPED.value
+        outcome = tally.outcome(stopped=globals.cancel_scrape)
 
         # Update the web ui bulk list with this URL and artwork (only if it's not already in the bulk list)
         if instance.mode == "web" and parsed_line.options.add_to_bulk and title:
@@ -284,7 +262,8 @@ def process_scrape_url_from_web(instance: Instance, url: str) -> None:
         RunHistory().add_run(
             RunType.SCRAPE.value, label, started_at, datetime.now(timezone.utc).isoformat(),
             RunTrigger.MANUAL.value, outcome,
-            assets_processed[0], success_counter[0], cached_counter[0], locked_counter[0], failed_counter[0]
+            tally.assets_processed[0], tally.success_counter[0], tally.cached_counter[0],
+            tally.locked_counter[0], tally.errors()
         )
         globals.scrapes_running -= 1
         if globals.scrapes_running <= 0:
@@ -370,11 +349,7 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
         record_schedule_run(filename)
 
     # Track successful poster uploads (those with ✅ or ♻️)
-    success_counter = [0]
-    assets_processed = [0]
-    cached_counter = [0]
-    locked_counter = [0]
-    failed_counter = [0]  # Uploads that failed after exhausting their retries
+    tally = ProcessingCallbacks()
     errors = 0
     started_at = datetime.now(timezone.utc).isoformat()
     trigger = RunTrigger.SCHEDULED.value if scheduled else RunTrigger.MANUAL.value
@@ -416,7 +391,7 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
                 break
 
             try:
-                scrape_and_upload(instance, parsed_line.url, parsed_line.options, True, success_counter, assets_processed, cached_counter=cached_counter, locked_counter=locked_counter, failed_counter=failed_counter)
+                scrape_and_upload(instance, parsed_line.url, parsed_line.options, True, tally)
                 #time.sleep(1)
             except ScraperException as e:
                 update_log(instance, f"❌ Error processing line: '{parsed_line.url}'")
@@ -436,25 +411,24 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
         end_time = time.time()
         elapsed = elapsed_time(end_time - start_time)
 
-        # A line that failed to scrape at all (errors) and an item that failed to upload after
-        # exhausting its retries (failed_counter) both count as errors in the run summary. An
-        # item that succeeded on a retry never reaches failed_counter, so it isn't one.
-        total_errors = errors + failed_counter[0]
+        # A line that failed to scrape at all is an error the uploader never saw, so it is
+        # handed to the tally rather than counted twice.
+        total_errors = tally.errors(errors)
+        outcome = tally.outcome(stopped=globals.cancel_scrape, extra_errors=errors)
 
         if globals.cancel_scrape:
             message = (
                 "🛑 "
                 + ("Scheduled b" if scheduled else "B")
                 + f"ulk import of '{display_filename}' stopped by user • "
-                + f"{assets_processed[0]} asset(s) processed • "
-                + (f"{cached_counter[0]} new in cache • " if cached_counter[0] else "")
-                + f"{success_counter[0]} asset(s) updated"
-                + (f" • {locked_counter[0]} asset(s) locked (skipped)" if locked_counter[0] else "")
-                + (f" • {failed_counter[0]} asset(s) failed" if failed_counter[0] else "")
+                + f"{tally.assets_processed[0]} asset(s) processed • "
+                + (f"{tally.cached_counter[0]} new in cache • " if tally.cached_counter[0] else "")
+                + f"{tally.success_counter[0]} asset(s) updated"
+                + (f" • {tally.locked_counter[0]} asset(s) locked (skipped)" if tally.locked_counter[0] else "")
+                + (f" • {tally.failed_counter[0]} asset(s) failed" if tally.failed_counter[0] else "")
             )
             update_status(instance, message[2:], color=StatusColor.WARNING.value, sticky=False, spinner=False)
             notify_web(instance, "progress_bar", {"percent": 100, "bar_type": "bulk"})
-            outcome = RunOutcome.STOPPED.value
             if notify_enabled:
                 send_notification(instance, message, event=NotificationEvent.RUN_CANCELLED.value)
         else:
@@ -463,14 +437,13 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
                 + ("Scheduled b" if scheduled else "B")
                 + f"ulk import of '{display_filename}' completed "
                 + (f"successfully in {elapsed} • " if total_errors == 0 else f"with {total_errors} error(s) in {elapsed}, check logs for details • ")
-                + f"{assets_processed[0]} asset(s) processed • "
-                + (f"{cached_counter[0]} new in cache • " if cached_counter[0] else "")
-                + f"{success_counter[0]} asset(s) updated"
-                + (f" • {locked_counter[0]} asset(s) locked (skipped)" if locked_counter[0] else "")
-                + (f" • {failed_counter[0]} asset(s) failed" if failed_counter[0] else "")
+                + f"{tally.assets_processed[0]} asset(s) processed • "
+                + (f"{tally.cached_counter[0]} new in cache • " if tally.cached_counter[0] else "")
+                + f"{tally.success_counter[0]} asset(s) updated"
+                + (f" • {tally.locked_counter[0]} asset(s) locked (skipped)" if tally.locked_counter[0] else "")
+                + (f" • {tally.failed_counter[0]} asset(s) failed" if tally.failed_counter[0] else "")
             )
             update_status(instance, message[2:], color=StatusColor.SUCCESS.value if total_errors == 0 else StatusColor.WARNING.value, sticky=False, spinner=False)
-            outcome = RunOutcome.SUCCESS.value if total_errors == 0 else RunOutcome.PARTIAL.value
             if notify_enabled:
                 event = NotificationEvent.RUN_COMPLETED.value if total_errors == 0 else NotificationEvent.RUN_COMPLETED_WITH_ERRORS.value
                 debug_me(f"Sending '{event}' notifications to {len(globals.config.apprise_urls)} configured notification channel(s).")
@@ -478,7 +451,8 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
         RunHistory().add_run(
             RunType.BULK.value, filename if filename else "bulk_import.txt",
             started_at, datetime.now(timezone.utc).isoformat(), trigger, outcome,
-            assets_processed[0], success_counter[0], cached_counter[0], locked_counter[0], total_errors
+            tally.assets_processed[0], tally.success_counter[0], tally.cached_counter[0],
+            tally.locked_counter[0], total_errors
         )
         update_log(instance, message)
 
@@ -488,16 +462,16 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
         RunHistory().add_run(
             RunType.BULK.value, filename if filename else "bulk_import.txt",
             started_at, datetime.now(timezone.utc).isoformat(), trigger, RunOutcome.FAILED.value,
-            assets_processed[0], success_counter[0], cached_counter[0], locked_counter[0],
-            errors + failed_counter[0]
+            tally.assets_processed[0], tally.success_counter[0], tally.cached_counter[0],
+            tally.locked_counter[0], tally.errors(errors)
         )
         if notify_enabled:
             # scrape_and_upload only shields the loop from ScraperException - a PlexConnectorException
             # or anything else raised mid-run lands here after real work has already happened, so it must
             # not be reported as "failed to start". assets_processed only moves once an item has actually
             # been processed, so it tells the two cases apart.
-            if assets_processed[0] > 0:
-                send_notification(instance, f"⚠️ Bulk import of '{display_filename}' stopped unexpectedly after {assets_processed[0]} asset(s) processed • {bulk_import_exception}", event=NotificationEvent.RUN_COMPLETED_WITH_ERRORS.value)
+            if tally.assets_processed[0] > 0:
+                send_notification(instance, f"⚠️ Bulk import of '{display_filename}' stopped unexpectedly after {tally.assets_processed[0]} asset(s) processed • {bulk_import_exception}", event=NotificationEvent.RUN_COMPLETED_WITH_ERRORS.value)
             else:
                 send_notification(instance, f"🔴 Bulk import of '{display_filename}' failed to start • {bulk_import_exception}", event=NotificationEvent.RUN_FAILED_TO_START.value)
 
@@ -511,12 +485,15 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
         globals.bulk_import_lock.release()
 
 # Scraped the URL then uploads what it's scraped to Plex or download to Kometa asset directory
-def scrape_and_upload(instance: Instance, url, options, bulk=False, success_counter=None, assets_processed=None, cached_counter=None, locked_counter=None, failed_counter=None):
+def scrape_and_upload(instance: Instance, url, options, bulk=False, tally: ProcessingCallbacks = None):
     """
     Scrape artwork from a URL and upload to Plex.
 
     This is now a thin wrapper around ArtworkProcessor that handles
     UI updates via callbacks.
+
+    The caller owns the tally, so one run's counters survive across every URL in it.
+    A caller that wants no counting can leave it out and get a throwaway one.
     """
     # Create callbacks for UI updates
     def status_callback(message: str, color: str, spinner: bool, sticky: bool):
@@ -543,16 +520,14 @@ def scrape_and_upload(instance: Instance, url, options, bulk=False, success_coun
             globals.bulk_bar["speed"] = bar_speed
             
 
-    callbacks = ProcessingCallbacks(
+    # replace() copies the tally's fields onto a new object, so the counter lists are
+    # shared with the caller's tally and every URL in a run adds to the same numbers.
+    callbacks = replace(
+        tally if tally is not None else ProcessingCallbacks(),
         on_status_update=status_callback,
         on_log_update=log_callback,
         on_debug=debug_callback,
-        on_progress_update=progress_callback,
-        success_counter=success_counter,
-        assets_processed=assets_processed,
-        cached_counter=cached_counter,
-        locked_counter=locked_counter,
-        failed_counter=failed_counter
+        on_progress_update=progress_callback
     )
 
     # Use the service to do the actual work
@@ -603,20 +578,11 @@ def process_uploaded_artwork(instance: Instance, file_list, skipped, zip_title, 
     def debug_callback(message: str, context: str = None):
         debug_me(message, context)
 
-    success_counter = [0]
-    assets_processed = [0]
-    locked_counter = [0]
-    failed_counter = [0]
-
     callbacks = ProcessingCallbacks(
         on_status_update=status_callback,
         on_log_update=log_callback,
         on_progress_update=progress_callback,
-        on_debug=debug_callback,
-        success_counter=success_counter,
-        assets_processed=assets_processed,
-        locked_counter=locked_counter,
-        failed_counter=failed_counter
+        on_debug=debug_callback
     )
 
     # Use the service to do the actual work
@@ -637,19 +603,13 @@ def process_uploaded_artwork(instance: Instance, file_list, skipped, zip_title, 
     outcome = RunOutcome.FAILED.value
     try:
         processor.process_uploaded_files(file_list, skipped, zip_title, zip_author, zip_source, opts, override_title=plex_title)
-        if globals.cancel_scrape:
-            outcome = RunOutcome.STOPPED.value
-        elif failed_counter[0]:
-            outcome = RunOutcome.PARTIAL.value
-        elif assets_processed[0]:
-            outcome = RunOutcome.SUCCESS.value
-        else:
-            outcome = RunOutcome.SKIPPED.value
+        outcome = callbacks.outcome(stopped=globals.cancel_scrape)
     finally:
         RunHistory().add_run(
             RunType.UPLOAD.value, label, started_at, datetime.now(timezone.utc).isoformat(),
             RunTrigger.MANUAL.value, outcome,
-            assets_processed[0], success_counter[0], 0, locked_counter[0], failed_counter[0]
+            callbacks.assets_processed[0], callbacks.success_counter[0], 0,
+            callbacks.locked_counter[0], callbacks.errors()
         )
 
 
@@ -1082,9 +1042,9 @@ if __name__ == "__main__":
             cli_options.add_posters = False
             cli_options.add_sets = False
             try:
-                success_counter = [0]
-                scrape_and_upload(cli_instance, cli_command, cli_options, False, success_counter)
-                debug_me(f"Finished scraping TPDb user URL from CLI with {success_counter[0]} asset(s) updated", "__main__")
+                tally = ProcessingCallbacks()
+                scrape_and_upload(cli_instance, cli_command, cli_options, False, tally)
+                debug_me(f"Finished scraping TPDb user URL from CLI with {tally.success_counter[0]} asset(s) updated", "__main__")
             except Exception as e:
                 debug_me(f"Error scraping TPDb user URL from CLI: {str(e)}", "__main__")
                 update_status(cli_instance, str(e), color=StatusColor.DANGER.value)
@@ -1092,9 +1052,9 @@ if __name__ == "__main__":
         # User passed in a poster or set URL, so let's process that
         else:
             try:
-                success_counter = [0]
-                scrape_and_upload(cli_instance, cli_command, cli_options, False, success_counter)
-                debug_me(f"Finished scraping URL from CLI with {success_counter[0]} asset(s) updated", "__main__")
+                tally = ProcessingCallbacks()
+                scrape_and_upload(cli_instance, cli_command, cli_options, False, tally)
+                debug_me(f"Finished scraping URL from CLI with {tally.success_counter[0]} asset(s) updated", "__main__")
             except Exception as e:
                 debug_me(f"Error scraping URL from CLI: {str(e)}", "__main__")
                 update_status(cli_instance, str(e),color=StatusColor.DANGER.value)

--- a/artwork_uploader.py
+++ b/artwork_uploader.py
@@ -472,13 +472,13 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
             update_status(instance, message[2:], color=StatusColor.SUCCESS.value if total_errors == 0 else StatusColor.WARNING.value, sticky=False, spinner=False)
             outcome = RunOutcome.SUCCESS.value if total_errors == 0 else RunOutcome.PARTIAL.value
             if notify_enabled:
-                event = NotificationEvent.RUN_COMPLETED.value if errors == 0 else NotificationEvent.RUN_COMPLETED_WITH_ERRORS.value
+                event = NotificationEvent.RUN_COMPLETED.value if total_errors == 0 else NotificationEvent.RUN_COMPLETED_WITH_ERRORS.value
                 debug_me(f"Sending '{event}' notifications to {len(globals.config.apprise_urls)} configured notification channel(s).")
                 send_notification(instance, message, event=event)
         RunHistory().add_run(
             RunType.BULK.value, filename if filename else "bulk_import.txt",
             started_at, datetime.now(timezone.utc).isoformat(), trigger, outcome,
-            assets_processed[0], success_counter[0], cached_counter[0], locked_counter[0], errors
+            assets_processed[0], success_counter[0], cached_counter[0], locked_counter[0], total_errors
         )
         update_log(instance, message)
 
@@ -488,7 +488,8 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
         RunHistory().add_run(
             RunType.BULK.value, filename if filename else "bulk_import.txt",
             started_at, datetime.now(timezone.utc).isoformat(), trigger, RunOutcome.FAILED.value,
-            assets_processed[0], success_counter[0], cached_counter[0], locked_counter[0], errors
+            assets_processed[0], success_counter[0], cached_counter[0], locked_counter[0],
+            errors + failed_counter[0]
         )
         if notify_enabled:
             # scrape_and_upload only shields the loop from ScraperException - a PlexConnectorException

--- a/models/callbacks.py
+++ b/models/callbacks.py
@@ -1,23 +1,28 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional, Callable
+
+from core.enums import RunOutcome
 
 @dataclass
 class ProcessingCallbacks:
     """
-    Callbacks for UI updates during artwork processing.
+    Callbacks for UI updates during artwork processing, and the tally of what the run did.
 
     All callbacks are optional and called with appropriate arguments
     when processing events occur.
+
+    The counters are always present, so a caller that forgets one still gets a working
+    counter rather than a number that stays at zero.
     """
     on_status_update: Optional[Callable[[str, str, bool, bool], None]] = None  # (message, color, spinner, sticky)
     on_log_update: Optional[Callable[[str], None]] = None  # (message)
     on_progress_update: Optional[Callable[[int, int, str, str, str], None]] = None  # (current, total, title, bar type, bar speed) - for progress bars
     on_debug: Optional[Callable[[str, Optional[str]], None]] = None  # (message, context) - for debug messages
-    success_counter: Optional[list] = None  # Mutable list to track successful uploads (contains count as single element)
-    assets_processed: Optional[list] = None  # Mutable list to track total assets processed (contains count as single element)
-    cached_counter: Optional[list] = None  # Mutable list to track assets newly added to the user cache (contains count as single element)
-    locked_counter: Optional[list] = None  # Mutable list to track artwork skipped because the Plex field was locked (contains count as single element)
-    failed_counter: Optional[list] = None  # Mutable list to track uploads that failed after exhausting their retries (contains count as single element)
+    success_counter: list = field(default_factory=lambda: [0])  # Mutable list to track successful uploads (contains count as single element)
+    assets_processed: list = field(default_factory=lambda: [0])  # Mutable list to track total assets processed (contains count as single element)
+    cached_counter: list = field(default_factory=lambda: [0])  # Mutable list to track assets newly added to the user cache (contains count as single element)
+    locked_counter: list = field(default_factory=lambda: [0])  # Mutable list to track artwork skipped because the Plex field was locked (contains count as single element)
+    failed_counter: list = field(default_factory=lambda: [0])  # Mutable list to track uploads that failed after exhausting their retries (contains count as single element)
 
     def status(self, message: str, color: str = "info", spinner: bool = False, sticky: bool = False):
         if self.on_status_update:
@@ -71,3 +76,37 @@ class ProcessingCallbacks:
             self.failed(1)
             return "failed"
         return None
+
+    def errors(self, extra: int = 0) -> int:
+        """Every failure the run summary counts.
+
+        An upload that exhausted its retries, plus anything the caller counted itself.
+        An item that succeeded on a retry never reaches failed_counter, so it is not one.
+
+        Args:
+            extra: Failures counted outside the uploader, such as a bulk import line
+                that could not be scraped at all.
+        """
+        return (self.failed_counter[0] if self.failed_counter else 0) + extra
+
+    def outcome(self, stopped: bool = False, extra_errors: int = 0) -> str:
+        """Say how a run ended, from the counters it collected.
+
+        Written down here because the paths that record a run each decided this for
+        themselves, and they had already drifted: a bulk import from the Bulk Import
+        tab had no skipped branch, so a file that processed nothing was stored as a
+        success while the same file from the scrape tab, a ZIP or the command line was
+        stored as skipped.
+
+        Args:
+            stopped: True if the user pressed Stop. Only the paths with a Stop button
+                pass this, so a run started from the command line never reports stopped.
+            extra_errors: Passed on to errors().
+        """
+        if stopped:
+            return RunOutcome.STOPPED.value
+        if self.errors(extra_errors):
+            return RunOutcome.PARTIAL.value
+        if self.assets_processed and self.assets_processed[0]:
+            return RunOutcome.SUCCESS.value
+        return RunOutcome.SKIPPED.value

--- a/services/webhook_service.py
+++ b/services/webhook_service.py
@@ -128,9 +128,7 @@ class WebhookService:
         # One history record covers the whole event, retries included, so the run starts
         # counting from the moment it was accepted and the tally survives every attempt.
         started_at = datetime.now(timezone.utc).isoformat()
-        tally = ProcessingCallbacks(
-            success_counter=[0], assets_processed=[0], locked_counter=[0], failed_counter=[0]
-        )
+        tally = ProcessingCallbacks()
         # Wait a configurable delay before the first attempt: the *arr apps fire the webhook the
         # moment they import a file, usually before Plex has scanned it in, so give Plex a head
         # start. If it is still not ready by then, the retry ladder takes over.

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -348,10 +348,10 @@ def test_mid_run_crash_after_processing_is_not_reported_as_failed_to_start():
 
         call_count = {"n": 0}
 
-        def flaky_scrape_and_upload(inst, url, options, bulk, success_counter, assets_processed, cached_counter=None, locked_counter=None, failed_counter=None):
+        def flaky_scrape_and_upload(inst, url, options, bulk, tally=None):
             call_count["n"] += 1
             if call_count["n"] == 1:
-                assets_processed[0] += 1
+                tally.assets(1)
                 return
             raise PlexConnectorException("Plex connection dropped")
 
@@ -425,10 +425,9 @@ def test_an_upload_that_exhausted_its_retries_sends_completed_with_errors():
         def fake_send_notification(inst, message, event=None):
             events_sent.append(event)
 
-        def fake_scrape(instance, url, options, bulk, success_counter, assets_processed,
-                        cached_counter=None, locked_counter=None, failed_counter=None):
-            assets_processed[0] += 1
-            failed_counter[0] += 1
+        def fake_scrape(instance, url, options, bulk, tally=None):
+            tally.assets(1)
+            tally.failed(1)
 
         with (
             patch("artwork_uploader.scrape_and_upload", side_effect=fake_scrape),

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -407,3 +407,42 @@ def test_mid_run_crash_before_any_processing_is_reported_as_failed_to_start():
         globals.config = None
         globals.scrapes_running = 0
         globals.cancel_scrape = False
+
+
+@pytest.mark.unit
+def test_an_upload_that_exhausted_its_retries_sends_completed_with_errors():
+    """The summary line for such a run already reads "completed with 1 error(s)", but the
+    event picked on the scrape errors alone, so a channel subscribed to failures heard
+    nothing and a channel subscribed to clean runs got the warning."""
+    try:
+        globals.plex = MagicMock(tv_libraries=["TV Shows"], movie_libraries=["Movies"])
+        globals.config = MagicMock(apprise_urls=[])
+        globals.scrapes_running = 0
+        globals.cancel_scrape = False
+
+        events_sent = []
+
+        def fake_send_notification(inst, message, event=None):
+            events_sent.append(event)
+
+        def fake_scrape(instance, url, options, bulk, success_counter, assets_processed,
+                        cached_counter=None, locked_counter=None, failed_counter=None):
+            assets_processed[0] += 1
+            failed_counter[0] += 1
+
+        with (
+            patch("artwork_uploader.scrape_and_upload", side_effect=fake_scrape),
+            patch("artwork_uploader.send_notification", side_effect=fake_send_notification),
+            patch("artwork_uploader.update_log"),
+            patch("artwork_uploader.update_status"),
+            patch("artwork_uploader.notify_web"),
+            patch("artwork_uploader.debug_me"),
+        ):
+            process_bulk_import_from_ui(Instance(mode="cli"), [MagicMock()], "retries.txt", scheduled=True)
+
+        assert events_sent == [NotificationEvent.RUN_COMPLETED_WITH_ERRORS.value]
+    finally:
+        globals.plex = None
+        globals.config = None
+        globals.scrapes_running = 0
+        globals.cancel_scrape = False

--- a/tests/test_run_counters.py
+++ b/tests/test_run_counters.py
@@ -7,6 +7,7 @@ import pytest
 
 import core.globals as globals
 from artwork_uploader import parse_bulk_file_from_cli, process_bulk_import_from_ui
+from core.enums import RunOutcome
 from models.callbacks import ProcessingCallbacks
 from models.instance import Instance
 from services.artwork_processor import ArtworkProcessor
@@ -29,7 +30,7 @@ def test_record_result_reads_the_uploader_prefixes(result, expected):
     assert counters.record_result(result) == expected
 
 
-def test_record_result_is_a_no_op_without_counters():
+def test_record_result_reads_the_prefix_with_the_default_counters():
     assert ProcessingCallbacks().record_result("✅ A Movie | Poster updated") == "success"
 
 
@@ -89,14 +90,14 @@ def test_failed_uploads_are_counted_and_do_not_count_as_success():
     assert failed[0] == 1
 
 
-# Every counter on ProcessingCallbacks is a keyword argument that defaults to None, and each
-# of the increment methods checks for its list before touching it. Leaving one out of a call
-# to scrape_and_upload therefore raises nothing and logs nothing: the number simply stays at
-# zero. That has already happened once per counter. assets_processed, cached_counter,
+# Every counter on ProcessingCallbacks used to be a keyword argument defaulting to None, and
+# each of the increment methods checks for its list before touching it. Leaving one out of a
+# call to scrape_and_upload therefore raised nothing and logged nothing: the number simply
+# stayed at zero. That had already happened once per counter. assets_processed, cached_counter,
 # locked_counter and failed_counter were each added to the bulk import from the Bulk Import
 # tab and none of them reached the command line path, which was still passing only a
-# success_counter years later. These two check that both paths fill in every counter the
-# class declares, so the next one added cannot go quiet in one of them.
+# success_counter years later. The counters carry a real default now and the paths share one
+# tally, so these two can no longer fail. They stay as a guard on that default.
 
 def _counter_field_names():
     """Read the counters off the class rather than listing them here, so one added later
@@ -155,3 +156,58 @@ def test_the_bulk_import_tab_path_passes_every_counter(tmp_path, plex_configured
     )
 
     assert [name for name in _counter_field_names() if getattr(callbacks, name) is None] == []
+
+
+# The outcome ladder used to be written out once per path that records a run, and the copies
+# had drifted: the Bulk Import tab could not record skipped at all, so a file that processed
+# nothing was stored as a success while the same file from the scrape tab, a ZIP upload or the
+# command line was stored as skipped. It is worked out on the tally now, so there is one copy.
+
+def test_a_run_that_processed_something_cleanly_is_a_success():
+    tally = ProcessingCallbacks()
+    tally.assets(3)
+    tally.success(2)
+
+    assert tally.outcome() == RunOutcome.SUCCESS.value
+
+
+def test_a_run_that_processed_nothing_is_skipped():
+    assert ProcessingCallbacks().outcome() == RunOutcome.SKIPPED.value
+
+
+def test_an_upload_that_exhausted_its_retries_makes_the_run_partial():
+    tally = ProcessingCallbacks()
+    tally.assets(2)
+    tally.success(1)
+    tally.failed(1)
+
+    assert tally.outcome() == RunOutcome.PARTIAL.value
+    assert tally.errors() == 1
+
+
+def test_errors_the_caller_counted_itself_make_the_run_partial():
+    """A bulk import line that could not be scraped at all never reaches the uploader,
+    so the caller counts it and hands it over."""
+    tally = ProcessingCallbacks()
+    tally.assets(1)
+    tally.success(1)
+
+    assert tally.outcome(extra_errors=1) == RunOutcome.PARTIAL.value
+    assert tally.errors(1) == 1
+
+
+def test_stopped_beats_everything_else():
+    tally = ProcessingCallbacks()
+    tally.assets(1)
+    tally.failed(1)
+
+    assert tally.outcome(stopped=True) == RunOutcome.STOPPED.value
+
+
+def test_a_path_with_no_stop_button_never_reports_stopped():
+    """Only the paths that have a Stop button pass stopped, so a run started from the
+    command line cannot report it however the run went."""
+    tally = ProcessingCallbacks()
+    tally.assets(1)
+
+    assert tally.outcome() == RunOutcome.SUCCESS.value

--- a/tests/test_run_history_cli.py
+++ b/tests/test_run_history_cli.py
@@ -50,11 +50,10 @@ def _quiet():
 
 @pytest.mark.unit
 def test_successful_run_is_recorded_with_its_counters(history, bulk_file):
-    def fake_scrape(instance, url, options, bulk, success_counter, assets_processed,
-                    cached_counter=None, locked_counter=None, failed_counter=None):
-        assets_processed[0] += 1
-        success_counter[0] += 1
-        cached_counter[0] += 1
+    def fake_scrape(instance, url, options, bulk, tally=None):
+        tally.assets(1)
+        tally.success(1)
+        tally.cached(1)
 
     quiet_log, quiet_debug = _quiet()
     with patch("artwork_uploader.scrape_and_upload", side_effect=fake_scrape), quiet_log, quiet_debug:
@@ -84,11 +83,10 @@ def test_the_label_is_the_file_name_not_the_whole_path(history, bulk_file):
 @pytest.mark.unit
 def test_counters_survive_the_whole_file(history, bulk_file):
     """Every line adds to the same counters, rather than each line starting from zero."""
-    def fake_scrape(instance, url, options, bulk, success_counter, assets_processed,
-                    cached_counter=None, locked_counter=None, failed_counter=None):
-        assets_processed[0] += 2
-        success_counter[0] += 1
-        locked_counter[0] += 1
+    def fake_scrape(instance, url, options, bulk, tally=None):
+        tally.assets(2)
+        tally.success(1)
+        tally.locked(1)
 
     quiet_log, quiet_debug = _quiet()
     with patch("artwork_uploader.scrape_and_upload", side_effect=fake_scrape), quiet_log, quiet_debug:
@@ -116,10 +114,9 @@ def test_a_line_that_fails_to_scrape_is_recorded_as_partial(history, bulk_file):
 @pytest.mark.unit
 def test_an_upload_that_exhausted_its_retries_counts_as_an_error(history, bulk_file):
     """The line itself scraped fine, so only failed_counter says anything went wrong."""
-    def fake_scrape(instance, url, options, bulk, success_counter, assets_processed,
-                    cached_counter=None, locked_counter=None, failed_counter=None):
-        assets_processed[0] += 1
-        failed_counter[0] += 1
+    def fake_scrape(instance, url, options, bulk, tally=None):
+        tally.assets(1)
+        tally.failed(1)
 
     quiet_log, quiet_debug = _quiet()
     with patch("artwork_uploader.scrape_and_upload", side_effect=fake_scrape), quiet_log, quiet_debug:

--- a/tests/test_run_history_recording.py
+++ b/tests/test_run_history_recording.py
@@ -147,3 +147,30 @@ def test_no_filename_falls_back_to_the_default_bulk_file_name(history):
     runs = history.get_runs()
     assert len(runs) == 1
     assert runs[0]["label"] == "bulk_import.txt"
+
+
+@pytest.mark.unit
+def test_an_upload_that_exhausted_its_retries_is_counted_as_an_error(history):
+    """The outcome and the summary line both count an upload that exhausted its retries,
+    so the stored row has to count it too."""
+    globals.plex = MagicMock(tv_libraries=MagicMock(), movie_libraries=MagicMock())
+    globals.config = MagicMock(apprise_urls=[])
+
+    def fake_scrape(instance, url, options, bulk, success_counter, assets_processed,
+                    cached_counter=None, locked_counter=None, failed_counter=None):
+        assets_processed[0] += 1
+        failed_counter[0] += 1
+
+    with (
+        patch("artwork_uploader.scrape_and_upload", side_effect=fake_scrape),
+        patch("artwork_uploader.notify_web"),
+        patch("artwork_uploader.update_log"),
+        patch("artwork_uploader.update_status"),
+        patch("artwork_uploader.debug_me"),
+    ):
+        process_bulk_import_from_ui(Instance(mode="cli"), [MagicMock()], "retries.txt", scheduled=False)
+
+    runs = history.get_runs()
+    assert len(runs) == 1
+    assert runs[0]["outcome"] == OUTCOME_PARTIAL
+    assert runs[0]["error_count"] == 1

--- a/tests/test_run_history_recording.py
+++ b/tests/test_run_history_recording.py
@@ -44,10 +44,10 @@ def test_successful_run_is_recorded_with_its_counters(history):
     globals.plex = MagicMock(tv_libraries=MagicMock(), movie_libraries=MagicMock())
     globals.config = MagicMock(apprise_urls=[])
 
-    def fake_scrape(instance, url, options, bulk, success_counter, assets_processed, cached_counter=None, locked_counter=None, failed_counter=None):
-        assets_processed[0] += 1
-        success_counter[0] += 1
-        cached_counter[0] += 1
+    def fake_scrape(instance, url, options, bulk, tally=None):
+        tally.assets(1)
+        tally.success(1)
+        tally.cached(1)
 
     with (
         patch("artwork_uploader.scrape_and_upload", side_effect=fake_scrape),
@@ -149,17 +149,18 @@ def test_no_filename_falls_back_to_the_default_bulk_file_name(history):
     assert runs[0]["label"] == "bulk_import.txt"
 
 
+# Both of these describe a bulk import from the Bulk Import tab, which used to work out its
+# own outcome and pass its own error count to the history. It counted a line that could not be
+# scraped, but not an upload that exhausted its retries, and it had no skipped branch at all.
+
 @pytest.mark.unit
 def test_an_upload_that_exhausted_its_retries_is_counted_as_an_error(history):
-    """The outcome and the summary line both count an upload that exhausted its retries,
-    so the stored row has to count it too."""
     globals.plex = MagicMock(tv_libraries=MagicMock(), movie_libraries=MagicMock())
     globals.config = MagicMock(apprise_urls=[])
 
-    def fake_scrape(instance, url, options, bulk, success_counter, assets_processed,
-                    cached_counter=None, locked_counter=None, failed_counter=None):
-        assets_processed[0] += 1
-        failed_counter[0] += 1
+    def fake_scrape(instance, url, options, bulk, tally=None):
+        tally.assets(1)
+        tally.failed(1)
 
     with (
         patch("artwork_uploader.scrape_and_upload", side_effect=fake_scrape),
@@ -174,3 +175,23 @@ def test_an_upload_that_exhausted_its_retries_is_counted_as_an_error(history):
     assert len(runs) == 1
     assert runs[0]["outcome"] == OUTCOME_PARTIAL
     assert runs[0]["error_count"] == 1
+
+
+@pytest.mark.unit
+def test_a_run_that_processes_nothing_is_recorded_as_skipped(history):
+    globals.plex = MagicMock(tv_libraries=MagicMock(), movie_libraries=MagicMock())
+    globals.config = MagicMock(apprise_urls=[])
+
+    with (
+        patch("artwork_uploader.scrape_and_upload"),
+        patch("artwork_uploader.notify_web"),
+        patch("artwork_uploader.update_log"),
+        patch("artwork_uploader.update_status"),
+        patch("artwork_uploader.debug_me"),
+    ):
+        process_bulk_import_from_ui(Instance(mode="cli"), [MagicMock()], "nothing.txt", scheduled=False)
+
+    runs = history.get_runs()
+    assert len(runs) == 1
+    assert runs[0]["outcome"] == OUTCOME_SKIPPED
+    assert runs[0]["assets_processed"] == 0

--- a/tests/test_run_history_scrape.py
+++ b/tests/test_run_history_scrape.py
@@ -54,15 +54,14 @@ def configured_plex():
 
 
 def _scrape(**counts):
-    """A stand-in for scrape_and_upload that moves the counters it is handed."""
-    def fake_scrape(instance, url, options, bulk, success_counter, assets_processed=None,
-                    cached_counter=None, locked_counter=None, failed_counter=None):
-        counters = {
-            "assets": assets_processed, "success": success_counter,
-            "cached": cached_counter, "locked": locked_counter, "failed": failed_counter,
+    """A stand-in for scrape_and_upload that moves the counters on the tally it is handed."""
+    def fake_scrape(instance, url, options, bulk, tally=None):
+        movers = {
+            "assets": tally.assets, "success": tally.success, "cached": tally.cached,
+            "locked": tally.locked, "failed": tally.failed,
         }
         for name, count in counts.items():
-            counters[name][0] += count
+            movers[name](count)
         return "A Set", "someone"
     return fake_scrape
 


### PR DESCRIPTION
@Randrage proposed this in #102 and you said you would like to see it. The shape is his: one tally holding the counters, built once, handed to the scraper, and it decides the outcome too.

It is smaller than either of us described, because the tally already exists. `ProcessingCallbacks` holds all five counters, and the webhook path already passes it around as one tally. The other paths build the `[0]` lists by hand and hand them over as five separate arguments.

There are two commits, and the first is a bug fix that reads on its own.

### Count exhausted upload retries in the stored row and the event

`process_bulk_import_from_ui` works its outcome and its summary line out of `total_errors`. Two places nearby still read the scrape errors alone: the row handed to the run history, and the choice of notification event. So a bulk import whose only failure was an exhausted retry records this:

```
main          outcome=partial  error_count=0  event=run_completed
with the fix  outcome=partial  error_count=1  event=run_completed_with_errors
```

The row says partial with no errors in it, and the message reading "completed with 1 error(s)" goes out on `run_completed`. Both are mine, from #90 and #91. Two tests cover them and both fail on `main`.

### Work out the run outcome in one place

Four paths worked the outcome out for themselves and they had drifted. `process_bulk_import_from_ui` has no skipped branch, so a bulk import from the tab that processed nothing stored as **success**. The same file from the scrape tab, a ZIP upload or the command line stored as **skipped**.

That is the one behaviour this changes. Nothing processed now records skipped everywhere, which is the answer you gave on #102.

- The counters carry a real default instead of `None`. That is the root of the drift @Randrage found. Every increment method checks for its list first, so a path that leaves one out raises nothing and logs nothing.
- `scrape_and_upload` takes the tally instead of five loose lists. `dataclasses.replace` copies the UI callbacks onto it, so the lists stay shared across a whole run.
- `outcome()` and `errors()` live on the tally. A caller passes `stopped` only if it has a Stop button. It hands over errors it counted itself, such as a bulk line the scraper could not read. Each keeps its own logging, trigger and notifications.

The webhook path keeps its own ladder. It applies one item from the cache, so "every item failed" is a real outcome there. No other path can reach it.

The two counter tests from #102 can no longer fail, because a counter can no longer be `None`. They stay as a guard on the default.

### Verified

`225 passed` with pytest against the tree.
