### PR TITLE
Enhance scheduler behavior

### DIFF
--- a/artwork_uploader.py
+++ b/artwork_uploader.py
@@ -1,5 +1,5 @@
 import uuid, os, re, threading, sys, time
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from core import globals
 
 # plexapi builds its X-Plex-Client-Identifier from uuid.getnode(), which can be
@@ -52,12 +52,12 @@ from core.enums import InstanceMode, NotificationEvent, StatusColor, RunType, Ru
 from services import (
     BulkFileService,
     ImageService,
-    SchedulerService,
     WebhookService,
     UtilityService,
     RunHistory
 )
 from services.artwork_processor import ArtworkProcessor
+from services.scheduler_service import SchedulerService, BulkSchedule
 from models.callbacks import ProcessingCallbacks
 from services.update_service import UpdateService
 
@@ -137,8 +137,12 @@ def parse_bulk_file_from_cli(instance: Instance, file_path):
         print("File not found. Please enter a valid file path.")
         now = datetime.now(timezone.utc).isoformat()
         RunHistory().add_run(
-            RunType.BULK.value, display_filename, started_at, now,
-            RunTrigger.CLI.value, RunOutcome.FAILED.value
+            run_type=RunType.BULK.value,
+            label=display_filename,
+            started_at=started_at,
+            ended_at=now,
+            trigger=RunTrigger.CLI.value,
+            outcome=RunOutcome.FAILED.value
         )
         return
 
@@ -190,10 +194,17 @@ def parse_bulk_file_from_cli(instance: Instance, file_path):
 
     finally:
         RunHistory().add_run(
-            RunType.BULK.value, display_filename, started_at, datetime.now(timezone.utc).isoformat(),
-            RunTrigger.CLI.value, outcome,
-            assets_processed[0], success_counter[0], cached_counter[0], locked_counter[0],
-            errors + failed_counter[0]
+            run_type=RunType.BULK.value,
+            label=display_filename,
+            started_at=started_at,
+            ended_at=datetime.now(timezone.utc).isoformat(),
+            trigger=RunTrigger.CLI.value,
+            outcome=outcome,
+            assets_processed=assets_processed[0],
+            success_count=success_counter[0],
+            cached_count=cached_counter[0],
+            locked_count=locked_counter[0],
+            error_count=errors + failed_counter[0]
         )
 
 # ---------------------- GUI FUNCTIONS ----------------------
@@ -282,9 +293,17 @@ def process_scrape_url_from_web(instance: Instance, url: str) -> None:
         # makes the browser reload the history table, so a record written afterwards would
         # miss its own refresh and only appear the next time somebody opened the tab.
         RunHistory().add_run(
-            RunType.SCRAPE.value, label, started_at, datetime.now(timezone.utc).isoformat(),
-            RunTrigger.MANUAL.value, outcome,
-            assets_processed[0], success_counter[0], cached_counter[0], locked_counter[0], failed_counter[0]
+            run_type=RunType.SCRAPE.value,
+            label=label,
+            started_at=started_at,
+            ended_at=datetime.now(timezone.utc).isoformat(),
+            trigger=RunTrigger.MANUAL.value,
+            outcome=outcome,
+            assets_processed=assets_processed[0],
+            success_count=success_counter[0],
+            cached_count=cached_counter[0],
+            locked_count=locked_counter[0],
+            error_count=failed_counter[0]
         )
         globals.scrapes_running -= 1
         if globals.scrapes_running <= 0:
@@ -293,7 +312,7 @@ def process_scrape_url_from_web(instance: Instance, url: str) -> None:
             notify_web(instance, "scrape_state", { "running": False, "type": globals.scrape_type })
             globals.scrape_type = "stopped"
 
-def run_bulk_import_scrape_in_thread(instance: Instance, web_list = None, filename = None, scheduled: bool = False, notify: bool = False) -> None:
+def run_bulk_import_scrape_in_thread(instance: Instance, web_list = None, filename = None, schedule_id: str = None, notify: bool = False) -> None:
 
     """Run the bulk import scrape in a separate thread."""
 
@@ -321,23 +340,27 @@ def run_bulk_import_scrape_in_thread(instance: Instance, web_list = None, filena
         update_status(instance, "No valid bulk import entries found. Check logs for details", color=StatusColor.DANGER.value, icon="x-circle")
         now = datetime.now(timezone.utc).isoformat()
         RunHistory().add_run(
-            RunType.BULK.value, filename if filename else "bulk_import.txt", now, now,
-            RunTrigger.SCHEDULED.value if scheduled else RunTrigger.MANUAL.value, RunOutcome.SKIPPED.value
+            run_type=RunType.BULK.value,
+            label=filename if filename else "bulk_import.txt",
+            started_at=now,
+            ended_at=now,
+            trigger=RunTrigger.SCHEDULED.value if schedule_id else RunTrigger.MANUAL.value,
+            outcome=RunOutcome.SKIPPED.value
         )
-        if scheduled or notify:
-            prefix = "Scheduled b" if scheduled else "B"
+        if schedule_id or notify:
+            prefix = "Scheduled b" if schedule_id else "B"
             display_filename = filename if filename else "bulk_import.txt"
             send_notification(instance, f"⏭️ {prefix}ulk import of '{display_filename}' skipped • no valid entries found", event=NotificationEvent.RUN_SKIPPED.value)
         return
 
     # Pass the processing of the parsed URLs off to a thread
     try:
-        process_bulk_import_from_ui(instance, parsed_urls, filename, scheduled, notify)
+        process_bulk_import_from_ui(instance, parsed_urls, filename, schedule_id, notify)
     except Exception:
         raise
 
 
-def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename: str = None, scheduled: bool = False, notify: bool = False) -> None:
+def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename: str = None, schedule_id: str = None, notify: bool = False) -> None:
 
     """
     Process the bulk import scrape, based on the contents of the Bulk Import tab in the GUI.
@@ -360,14 +383,14 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
         message = f"⚠️ Bulk import of '{display_filename}' refused - another bulk import is already running"
         update_log(instance, message)
         update_status(instance, "Bulk import refused: another bulk import is already running", color=StatusColor.WARNING.value)
-        if scheduled:
+        if schedule_id:
             send_notification(instance, message)
         return
 
-    if scheduled and filename:
+    if schedule_id and filename:
         # Stamp the run only once it holds the lock: a refused run has not run,
         # and stamping it would hide the miss from catch-up.
-        record_schedule_run(filename)
+        record_schedule_run(schedule_id)
 
     # Track successful poster uploads (those with ✅ or ♻️)
     success_counter = [0]
@@ -377,9 +400,8 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
     failed_counter = [0]  # Uploads that failed after exhausting their retries
     errors = 0
     started_at = datetime.now(timezone.utc).isoformat()
-    trigger = RunTrigger.SCHEDULED.value if scheduled else RunTrigger.MANUAL.value
-    notify_enabled = scheduled or notify
-    display_filename = filename if filename else "bulk_import.txt"
+    trigger = RunTrigger.SCHEDULED.value if schedule_id else RunTrigger.MANUAL.value
+    notify_enabled = schedule_id or notify
 
     try:
 
@@ -388,8 +410,12 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
             update_status(instance, "Plex setup incomplete. Please check the settings.", color=StatusColor.DANGER.value)
             now = datetime.now(timezone.utc).isoformat()
             RunHistory().add_run(
-                RunType.BULK.value, filename if filename else "bulk_import.txt",
-                started_at, now, trigger, RunOutcome.FAILED.value
+                run_type=RunType.BULK.value,
+                label=filename if filename else "bulk_import.txt",
+                started_at=started_at,
+                ended_at=now,
+                trigger=trigger,
+                outcome=RunOutcome.FAILED.value
             )
             if notify_enabled:
                 send_notification(instance, f"🔴 Bulk import of '{display_filename}' failed to start • Plex setup incomplete", event=NotificationEvent.RUN_FAILED_TO_START.value)
@@ -444,7 +470,7 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
         if globals.cancel_scrape:
             message = (
                 "🛑 "
-                + ("Scheduled b" if scheduled else "B")
+                + ("Scheduled b" if schedule_id else "B")
                 + f"ulk import of '{display_filename}' stopped by user • "
                 + f"{assets_processed[0]} asset(s) processed • "
                 + (f"{cached_counter[0]} new in cache • " if cached_counter[0] else "")
@@ -460,7 +486,7 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
         else:
             message = (
                 ("🏁 " if total_errors == 0 else "⚠️ ")
-                + ("Scheduled b" if scheduled else "B")
+                + ("Scheduled b" if schedule_id else "B")
                 + f"ulk import of '{display_filename}' completed "
                 + (f"successfully in {elapsed} • " if total_errors == 0 else f"with {total_errors} error(s) in {elapsed}, check logs for details • ")
                 + f"{assets_processed[0]} asset(s) processed • "
@@ -476,9 +502,17 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
                 debug_me(f"Sending '{event}' notifications to {len(globals.config.apprise_urls)} configured notification channel(s).")
                 send_notification(instance, message, event=event)
         RunHistory().add_run(
-            RunType.BULK.value, filename if filename else "bulk_import.txt",
-            started_at, datetime.now(timezone.utc).isoformat(), trigger, outcome,
-            assets_processed[0], success_counter[0], cached_counter[0], locked_counter[0], errors
+            run_type=RunType.BULK.value,
+            label=filename if filename else "bulk_import.txt",
+            started_at=started_at,
+            ended_at=datetime.now(timezone.utc).isoformat(),
+            trigger=trigger,
+            outcome=outcome,
+            assets_processed=assets_processed[0],
+            success_count=success_counter[0],
+            cached_count=cached_counter[0],
+            locked_count=locked_counter[0],
+            error_count=errors
         )
         update_log(instance, message)
 
@@ -486,9 +520,17 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
         notify_web(instance, "progress_bar", { "percent": 100, "bar_type": "bulk" })
         update_status(instance, f"Error during bulk import: {bulk_import_exception}", color=StatusColor.DANGER.value)
         RunHistory().add_run(
-            RunType.BULK.value, filename if filename else "bulk_import.txt",
-            started_at, datetime.now(timezone.utc).isoformat(), trigger, RunOutcome.FAILED.value,
-            assets_processed[0], success_counter[0], cached_counter[0], locked_counter[0], errors
+            run_type=RunType.BULK.value,
+            label=filename if filename else "bulk_import.txt",
+            started_at=started_at,
+            ended_at=datetime.now(timezone.utc).isoformat(),
+            trigger=trigger,
+            outcome=RunOutcome.FAILED.value,
+            assets_processed=assets_processed[0],
+            success_count=success_counter[0],
+            cached_count=cached_counter[0],
+            locked_count=locked_counter[0],
+            error_count=errors
         )
         if notify_enabled:
             # scrape_and_upload only shields the loop from ScraperException - a PlexConnectorException
@@ -646,9 +688,17 @@ def process_uploaded_artwork(instance: Instance, file_list, skipped, zip_title, 
             outcome = RunOutcome.SKIPPED.value
     finally:
         RunHistory().add_run(
-            RunType.UPLOAD.value, label, started_at, datetime.now(timezone.utc).isoformat(),
-            RunTrigger.MANUAL.value, outcome,
-            assets_processed[0], success_counter[0], 0, locked_counter[0], failed_counter[0]
+            run_type=RunType.UPLOAD.value,
+            label=label,
+            started_at=started_at,
+            ended_at=datetime.now(timezone.utc).isoformat(),
+            trigger=RunTrigger.MANUAL.value,
+            outcome=outcome,
+            assets_processed=assets_processed[0],
+            success_count=success_counter[0],
+            cached_count=0,
+            locked_count=locked_counter[0],
+            error_count=failed_counter[0]
         )
 
 
@@ -788,7 +838,7 @@ def get_latest_version():
     """Fetch the latest release version from GitHub."""
     return globals.update_service.get_latest_version() if globals.update_service else None
 
-def add_file_to_schedule_thread(instance: Instance, filename):
+def add_file_to_schedule_thread(instance: Instance, filename, schedule_id):
     if not instance:
         return
 
@@ -800,33 +850,41 @@ def add_file_to_schedule_thread(instance: Instance, filename):
         return
 
     try:
-        threading.Thread(target=process_bulk_file_on_schedule, args=(instance, filename,)).start()
+        threading.Thread(target=process_bulk_file_on_schedule, args=(instance, filename, schedule_id,)).start()
     except Exception as e:
         # The guard must not leak, and an error here must not kill the scheduler thread
         if globals.scheduler_service:
             globals.scheduler_service.finish(filename)
         update_log(instance, f"🔴 Could not start scheduled bulk import for '{filename}' ({e})")
 
-def record_schedule_run(filename):
+def record_schedule_run(schedule_id):
     """Record that a scheduled run for this bulk file has just started, so a future
     restart can tell whether a run was missed.
 
     A run executes the whole file, so every schedule the file carries gets the
     stamp. Stamping only the first would leave the file's other daily schedules
     with no last_run, which disables catch-up for them."""
+
     if globals.config is None:
         return
     try:
         for each_schedule in globals.config.schedules:
-            if each_schedule.get("file") == filename:
+            if each_schedule.get("id") == schedule_id:
                 each_schedule["last_run"] = datetime.now().isoformat()
+                job = globals.scheduler_service.scheduled_jobs.get(schedule_id)
+                if job and hasattr(job, "next_run") and job.next_run:
+                    each_schedule["next_run"] = job.next_run.isoformat()
+                else:
+                    sched = BulkSchedule(**each_schedule)
+                    each_schedule["nex_trun"] = sched.compute_next_run()
+
         globals.config.save()
     except Exception as e:
         # A failed stamp costs one catch-up decision; letting it propagate would
         # kill the scheduler thread, which costs every future run.
-        debug_me(f"Could not record schedule run for '{filename}': {e}")
+        debug_me(f"Could not record schedule run for job ID '{schedule_id}': {e}")
 
-def process_bulk_file_on_schedule(instance: Instance, filename):
+def process_bulk_file_on_schedule(instance: Instance, filename, schedule_id):
 
     instance.broadcast = True
 
@@ -839,28 +897,56 @@ def process_bulk_file_on_schedule(instance: Instance, filename):
                 update_log(instance, f"🕘 Scheduled bulk import started for '{filename}'")
                 debug_me(f"Scheduled import started for instance {instance.id} mode {instance.mode}")
                 send_notification(instance, f"🕘 Scheduled bulk import started for '{filename}'", event=NotificationEvent.RUN_STARTED.value)
-                run_bulk_import_scrape_in_thread(instance, content, filename, scheduled=True)
+                run_bulk_import_scrape_in_thread(instance, content, filename, schedule_id=schedule_id)
             else:
                 update_log(instance, f"⏭️ Scheduled bulk import of '{filename}' skipped • file is empty")
                 now = datetime.now(timezone.utc).isoformat()
-                RunHistory().add_run(RunType.BULK.value, filename, now, now, RunTrigger.SCHEDULED.value, RunOutcome.SKIPPED.value)
+                RunHistory().add_run(
+                    run_type=RunType.BULK.value,
+                    label=filename,
+                    started_at=now,
+                    ended_at=now,
+                    trigger=RunTrigger.SCHEDULED.value,
+                    outcome=RunOutcome.SKIPPED.value
+                )
                 send_notification(instance, f"⏭️ Scheduled bulk import of '{filename}' skipped • file is empty", event=NotificationEvent.RUN_SKIPPED.value)
         else:
             update_log(instance, f"🔴 Bulk file does not exist: {filename}")
             now = datetime.now(timezone.utc).isoformat()
-            RunHistory().add_run(RunType.BULK.value, filename, now, now, RunTrigger.SCHEDULED.value, RunOutcome.FAILED.value)
+            RunHistory().add_run(
+                run_type=RunType.BULK.value,
+                label=filename,
+                started_at=now,
+                ended_at=now,
+                trigger=RunTrigger.SCHEDULED.value,
+                outcome=RunOutcome.FAILED.value
+            )
             send_notification(instance, f"🔴 Scheduled bulk import of '{filename}' failed to start • file does not exist", event=NotificationEvent.RUN_FAILED_TO_START.value)
             return
     except FileNotFoundError:
         update_log(instance, f"🔴 Scheduled bulk import failed due to missing file ({filename})")
         now = datetime.now(timezone.utc).isoformat()
-        RunHistory().add_run(RunType.BULK.value, filename, now, now, RunTrigger.SCHEDULED.value, RunOutcome.FAILED.value)
+        RunHistory().add_run(
+            run_type=RunType.BULK.value,
+            label=filename,
+            started_at=now,
+            ended_at=now,
+            trigger=RunTrigger.SCHEDULED.value,
+            outcome=RunOutcome.FAILED.value
+        )
         send_notification(instance, f"🔴 Scheduled bulk import of '{filename}' failed to start • file not found", event=NotificationEvent.RUN_FAILED_TO_START.value)
     except Exception as e:
         update_log(instance, f"🔴 Scheduled bulk import unexpectedly failed ({str(e)})")
         send_notification(instance, f"🔴 Scheduled bulk import of '{filename}' failed to start • {e}", event=NotificationEvent.RUN_FAILED_TO_START.value)
         now = datetime.now(timezone.utc).isoformat()
-        RunHistory().add_run(RunType.BULK.value, filename, now, now, RunTrigger.SCHEDULED.value, RunOutcome.FAILED.value)
+        RunHistory().add_run(
+            run_type=RunType.BULK.value,
+            label=filename,
+            started_at=now,
+            ended_at=now,
+            trigger=RunTrigger.SCHEDULED.value,
+            outcome=RunOutcome.FAILED.value
+        )
     finally:
         if globals.scheduler_service:
             globals.scheduler_service.finish(filename)
@@ -882,12 +968,12 @@ def setup_scheduler_on_first_load(instance: Instance):
     # If there are no scheduled jobs already...
     if not globals.scheduler_service.has_schedules():
         for each_schedule in globals.config.schedules:
-            schedule_id = each_schedule.get("id")
-            schedule_file = each_schedule.get("file")
+            new_schedule = BulkSchedule(**each_schedule)
+            new_schedule.compute_next_run()
 
             # Create the callback for this schedule
-            def schedule_callback(filename=schedule_file):
-                add_file_to_schedule_thread(instance, filename)
+            def schedule_callback(filename=new_schedule.file, schedule_id=new_schedule.id):
+                add_file_to_schedule_thread(instance, filename, schedule_id)
 
             # Add to scheduler service, reusing the id already stored in
             # config so the schedule keeps the same identity across reloads.
@@ -895,15 +981,15 @@ def setup_scheduler_on_first_load(instance: Instance):
             # config.json must not stop the app starting.
             try:
                 globals.scheduler_service.add_schedule(
-                    schedule_file,
-                    schedule_callback,
-                    schedule_id=schedule_id,
-                    time=each_schedule.get("time"),
-                    interval_value=each_schedule.get("interval_value"),
-                    interval_unit=each_schedule.get("interval_unit"),
+                    sched=new_schedule,
+                    callback=schedule_callback
                 )
+                if new_schedule.time:
+                    debug_me(f"Added schedule ID '{new_schedule.id}' for '{new_schedule.file}': Every day at {new_schedule.time} | Last run: {new_schedule.last_run} | Next run: {new_schedule.next_run}")
+                elif new_schedule.interval_value:
+                    debug_me(f"Added schedule ID '{new_schedule.id}' for '{new_schedule.file}': Every {new_schedule.interval_value} {new_schedule.interval_unit} | Last run: {new_schedule.last_run} | Next run: {new_schedule.next_run}")
             except ValueError as e:
-                update_log(instance, f"🔴 Skipping invalid schedule for '{schedule_file}': {e}")
+                update_log(instance, f"🔴 Skipping invalid schedule for '{new_schedule.file}': {e}")
                 debug_me(f"Skipping invalid schedule entry {each_schedule}: {e}")
 
 
@@ -912,10 +998,11 @@ def setup_scheduler_on_first_load(instance: Instance):
             debug_me("Scheduler started.")
 
         debug_me(globals.config.schedules)
+        debug_me(globals.scheduler_service.schedule_meta)
 
 
 def catch_up_missed_schedules(instance: Instance):
-    """Run any daily schedule that was due while the app was not running.
+    """Run any schedule (daily or interval) that was due while the app was not running.
 
     Called from main only after the Plex libraries are connected: a catch-up run
     fired before that point executes against empty libraries, fails every item,
@@ -923,10 +1010,13 @@ def catch_up_missed_schedules(instance: Instance):
     if globals.config is None:
         return
     for each_schedule in globals.config.schedules:
-        catch_up_missed_schedule(instance, each_schedule.get("file"), each_schedule.get("time"), each_schedule.get("last_run"))
+        catch_up_missed_schedule(
+            instance=instance,
+            sched=BulkSchedule(**each_schedule)
+        )
 
 
-def catch_up_missed_schedule(instance: Instance, filename, schedule_time, last_run):
+def catch_up_missed_schedule(instance: Instance, sched: BulkSchedule):
     """
     Run a scheduled bulk import that was due while the app was not running, if it falls
     inside the configured catch-up window. Otherwise, just log that it was skipped.
@@ -939,9 +1029,7 @@ def catch_up_missed_schedule(instance: Instance, filename, schedule_time, last_r
     """
     window_minutes = globals.config.catch_up_window_minutes if globals.config else 0
 
-    due, within_window = globals.scheduler_service.get_missed_run(
-        schedule_time, last_run, datetime.now(), window_minutes
-    )
+    due, within_window = globals.scheduler_service.get_missed_run(sched=sched, window=window_minutes)
 
     if due is None:
         return
@@ -949,12 +1037,12 @@ def catch_up_missed_schedule(instance: Instance, filename, schedule_time, last_r
     due_display = due.strftime("%Y-%m-%d %H:%M")
 
     if within_window:
-        update_log(instance, f"⏰ Catching up missed scheduled run for '{filename}' (was due {due_display})")
-        debug_me(f"Catch-up run for '{filename}', due {due.isoformat()}, window {window_minutes} minutes")
-        add_file_to_schedule_thread(instance, filename)
+        update_log(instance, f"⏰ Catching up missed scheduled run for '{sched.file}' (was due {due_display})")
+        debug_me(f"Catch-up run for '{sched.file}', due {due.isoformat()}, window {window_minutes} minutes")
+        add_file_to_schedule_thread(instance, sched.file, sched.id)
     else:
-        update_log(instance, f"⚠️ Scheduled run for '{filename}' was missed and is outside the catch-up window (was due {due_display})")
-        debug_me(f"Missed scheduled run for '{filename}', due {due.isoformat()}, outside catch-up window of {window_minutes} minutes")
+        update_log(instance, f"⚠️ Scheduled run for '{sched.file}' was missed and is outside the catch-up window (was due {due_display})")
+        debug_me(f"Missed scheduled run for '{sched.file}', due {due.isoformat()}, outside catch-up window of {window_minutes} minutes")
 
 
 # Kept as a hook for the "load_config" socket event. There is nothing to
@@ -987,18 +1075,20 @@ if __name__ == "__main__":
     cli_command = args.command
 
     # Store the options passed as arguments
-    cli_options = Options(add_posters=args.add_posters,
-                          add_sets=args.add_sets,
-                          force=args.force,
-                          skip_locked=args.skip_locked,
-                          allow_artist_updates=args.allow_artist_updates,
-                          filters=args.filters,
-                          exclude=args.exclude,
-                          year=args.year,
-                          kometa=args.kometa,
-                          stage=args.stage,
-                          temp=args.temp,
-                          no_cache=args.no_cache)  # Arguments per url to process
+    cli_options = Options(
+        add_posters=args.add_posters,
+        add_sets=args.add_sets,
+        force=args.force,
+        skip_locked=args.skip_locked,
+        allow_artist_updates=args.allow_artist_updates,
+        filters=args.filters,
+        exclude=args.exclude,
+        year=args.year,
+        kometa=args.kometa,
+        stage=args.stage,
+        temp=args.temp,
+        no_cache=args.no_cache
+    )  # Arguments per url to process
 
     # Create config as a global object
     config = Config()

--- a/core/enums.py
+++ b/core/enums.py
@@ -117,3 +117,7 @@ class RunOutcome(str, Enum):
 class WebhookSource(str, Enum):
     RADARR = "radarr"
     SONARR = "sonarr"
+
+class IntervalUnit(str, Enum):
+    DAYS = "days"
+    HOURS = "hours"

--- a/models/bulk_schedule.py
+++ b/models/bulk_schedule.py
@@ -1,0 +1,55 @@
+import uuid
+from typing import Optional
+from datetime import datetime, timedelta
+
+class BulkSchedule:
+    def __init__(
+            self,
+            id: Optional[str] = None,
+            file: str = "",
+            time: Optional[str] = None,
+            interval_value: Optional[int] = None,
+            interval_unit: Optional[str] = None,
+            last_run: Optional[str] = None,
+            next_run: Optional[str] = None,
+            **kwargs
+        ) -> None:
+        self.id = id or str(uuid.uuid4())
+        self.file = file
+        self.time = time
+        self.interval_value = interval_value
+        self.interval_unit = interval_unit
+        self.last_run = last_run
+        self.next_run = next_run
+
+    def compute_next_run(self):
+        """ Helper function to compute the next run time for any schedule """
+
+        if not self.time and not (self.interval_value and self.interval_unit):
+            return None
+
+        interval_value = self.interval_value or 1
+        interval_unit = self.interval_unit or "days"
+
+        now = datetime.now().replace(microsecond=0)
+        next_run_at: Optional[datetime] = None
+
+        if self.last_run: # If there's a recorded last run, next run time is calculated based on the interval and units (days=1 for daily schedules)
+            last_run_at = datetime.fromisoformat(self.last_run)
+            next_run_at = last_run_at + timedelta(**{interval_unit: interval_value})
+
+        elif self.time: # If not and it's a daily schedule, set the next run to the defined time
+            hour, minute = (int(part) for part in self.time.split(":"))
+            next_run_at = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
+
+        elif self.interval_value:
+            next_run_at = now + timedelta(**{interval_unit: interval_value})
+
+        if next_run_at is None:
+            return None
+
+        while next_run_at < now:
+            next_run_at += timedelta(**{interval_unit: interval_value})
+
+        self.next_run = next_run_at.isoformat()
+        return self.next_run

--- a/services/scheduler_service.py
+++ b/services/scheduler_service.py
@@ -5,12 +5,11 @@ Extracted from artwork_uploader.py to reduce file size and improve
 maintainability.
 """
 
-import threading, schedule, time, uuid
+import threading, schedule, time
 from datetime import datetime, timedelta
 from typing import Dict, Callable, List, Optional, Set, Tuple
-
-VALID_INTERVAL_UNITS = ("hours", "days")
-
+from models.bulk_schedule import BulkSchedule
+from core.enums import IntervalUnit
 
 class SchedulerService:
     """Handles scheduling of bulk import jobs.
@@ -38,15 +37,7 @@ class SchedulerService:
         self._running_lock = threading.Lock()
         self._running_files: Set[str] = set()
 
-    def add_schedule(
-        self,
-        filename: str,
-        callback: Callable[[str], None],
-        schedule_id: Optional[str] = None,
-        time: Optional[str] = None,
-        interval_value: Optional[int] = None,
-        interval_unit: Optional[str] = None,
-    ) -> str:
+    def add_schedule(self, sched: BulkSchedule, callback: Callable[[str], None]) -> str:
         """
         Add a new scheduled job, either a daily time or a repeating interval.
 
@@ -67,7 +58,7 @@ class SchedulerService:
         Raises:
             ValueError: If neither a time nor a valid interval is given
         """
-        job_id = schedule_id or str(uuid.uuid4())
+        job_id = sched.id
 
         # The callback reads the filename from schedule_meta at run time
         # (rather than capturing it in the closure) so that renaming a
@@ -77,15 +68,39 @@ class SchedulerService:
             if meta:
                 callback(meta["file"])
 
-        if time:
-            job = schedule.every().day.at(time).do(run_job)
-            meta = {"file": filename, "time": time}
-        elif interval_value and interval_unit in VALID_INTERVAL_UNITS:
-            interval_job = getattr(schedule.every(interval_value), interval_unit)
+        if sched.time:
+            job = schedule.every().day.at(sched.time).do(run_job)
+            sched.next_run = job.next_run.isoformat()
+            meta = {
+                "file": sched.file,
+                "time": sched.time,
+                "last_run": sched.last_run,
+                "next_run": sched.next_run
+            }
+
+        elif sched.interval_value and sched.interval_unit in [u.value for u in IntervalUnit]:
+            interval_job = getattr(schedule.every(sched.interval_value), sched.interval_unit)
             job = interval_job.do(run_job)
-            meta = {"file": filename, "interval_value": interval_value, "interval_unit": interval_unit}
+            if sched.next_run:
+                try:
+                    job.next_run = datetime.fromisoformat(sched.next_run)
+                except (ValueError, TypeError):
+                    pass
+            else:
+                sched.next_run = job.next_run
+            meta = {
+                "file": sched.file,
+                "interval_value": sched.interval_value,
+                "interval_unit": sched.interval_unit,
+                "last_run": sched.last_run,
+                "next_run": sched.next_run
+            }
+
         else:
             raise ValueError("A schedule needs either a daily time or an interval_value with a valid interval_unit")
+
+        if sched.last_run:
+            job.last_run = datetime.fromisoformat(sched.last_run)
 
         self.scheduled_jobs[job_id] = job
         self.schedule_meta[job_id] = meta
@@ -227,48 +242,54 @@ class SchedulerService:
             self._running_files.discard(filename)
 
     @staticmethod
-    def get_missed_run(
-        schedule_time: str,
-        last_run: Optional[str],
-        now: datetime,
-        window_minutes: int
-    ) -> Tuple[Optional[datetime], bool]:
+    def get_missed_run(sched: BulkSchedule, window: int) -> Tuple[Optional[datetime], bool]:
         """
-        Work out whether a daily schedule missed its most recent run.
+        Work out whether a schedule (daily or interval) missed its most recent run.
 
         A run is only considered missed if we have a recorded last run time that
-        predates it - a schedule with no recorded run yet (brand new, or never run
-        under a build that tracked this) is never treated as having missed anything.
+        predates it - a schedule with no recorded run yet is never treated as having missed anything.
 
         Args:
-            schedule_time: Time of day the schedule runs, as "HH:MM"
-            last_run: ISO timestamp of the last time this schedule ran, or None
-            now: Current time
-            window_minutes: How late a missed run can be and still count as catchable
+            sched: The BulkSchedule instance to check
+            window: How late a missed run can be (in minutes) to still count as catchable
 
         Returns:
             A (due, within_window) tuple. due is None if nothing was missed.
             within_window is True if the miss is inside the catch-up window.
         """
-        if not last_run:
+        now = datetime.now()
+
+        if not sched.last_run:
             return None, False
 
         try:
-            hour, minute = (int(part) for part in schedule_time.split(":"))
-            due = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
-        except (ValueError, AttributeError, TypeError):
-            return None, False
-
-        if due > now:
-            due -= timedelta(days=1)
-
-        try:
-            last_run_at = datetime.fromisoformat(last_run)
+            last_run_at = datetime.fromisoformat(sched.last_run)
         except (ValueError, TypeError):
-            last_run_at = None
-
-        if last_run_at is not None and last_run_at >= due:
             return None, False
 
-        within_window = (now - due) <= timedelta(minutes=window_minutes)
+        due: Optional[datetime] = None
+
+        if sched.time:
+            try:
+                hour, minute = (int(part) for part in sched.time.split(":"))
+                due = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
+                if due > now:
+                    due -= timedelta(days=1)
+            except (ValueError, AttributeError, TypeError):
+                return None, False
+
+        elif sched.interval_value and sched.interval_unit in IntervalUnit:
+            try:
+                delta = timedelta(**{sched.interval_unit: sched.interval_value})
+                due = last_run_at + delta
+            except (ValueError, TypeError):
+                return None, False
+
+        else:
+            return None, False
+
+        if due > now or last_run_at >= due:
+            return None, False
+
+        within_window = (now - due) <= timedelta(minutes=window)
         return due, within_window

--- a/static/web_interface.css
+++ b/static/web_interface.css
@@ -937,3 +937,8 @@ Theme Switcher Dropdown Icons (Fix dark mode SVG fills)
 .wide-tooltip .tooltip-inner {
     max-width: 320px !important;
 }
+
+/* Custom z-index for all tooltips so they show in front of any other UI element */
+.tooltip {
+    z-index: 9999 !important;
+}

--- a/static/web_interface.js
+++ b/static/web_interface.js
@@ -21,13 +21,15 @@ const instanceId = getInstanceId();
 const bootstrapColors = ['primary', 'secondary', 'success', 'danger', 'warning', 'info', 'light', 'dark'];
 const CHUNK_SIZE = 1024 * 512; // 512 KB per chunk for uploads
 
-const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]')
-tooltipTriggerList.forEach(tooltipTriggerEl => {
+function initInteractiveTooltip(tooltipTriggerEl) {
+    if (!tooltipTriggerEl || bootstrap.Tooltip.getInstance(tooltipTriggerEl)) return; // Already initialized
+
     let hideTimeout = null;
 
     const tooltip = new bootstrap.Tooltip(tooltipTriggerEl, {
         html: true,
         sanitize: false,
+        container: 'body',
         delay: { show: 100, hide: 250 } // 250ms buffer to cross the gap
     });
 
@@ -57,6 +59,10 @@ tooltipTriggerList.forEach(tooltipTriggerEl => {
             if (instance) instance.hide();
         });
     });
+};
+
+document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => {
+    initInteractiveTooltip(el);
 });
 
 // UI References
@@ -72,6 +78,8 @@ const scheduleIntervalValueInput = document.getElementById("schedule_interval_va
 const scheduleIntervalUnitSelect = document.getElementById("schedule_interval_unit");
 const scheduleListEl = document.getElementById("schedule_list");
 const timeSelectBox = document.getElementById("time_select_box");
+const runNowLabel = document.getElementById("run_now_label");
+const runNowCheckbox = document.getElementById("run_now_checkbox");
 const bulkFileSwitcher = document.getElementById("switch_bulk_file");
 
 // Event listeners
@@ -2371,19 +2379,40 @@ socket.on("upload_complete", function (data) {
     let editingScheduleId = null; // Set while the form is editing an existing schedule rather than adding a new one
 
     function describeSchedule(s) {
+        let text = "";
         if (s.time) {
-            return `Daily at ${s.time}`;
+            text = `Daily at ${s.time}`;
+        } else {
+            const unit = s.interval_value === 1 ? s.interval_unit.replace(/s$/, "") : s.interval_unit;
+            text = `Every ${s.interval_value} ${unit}`;
         }
-        const unit = s.interval_value === 1 ? s.interval_unit.replace(/s$/, "") : s.interval_unit;
-        return `Every ${s.interval_value} ${unit}`;
+
+        if (s.next_run) {
+            const formattedNextRun = formatNextRun(s.next_run);
+            if (formattedNextRun){
+                return `${text} <span class="badge text-body-secondary bg-body-tertiary border ms-2 fw-normal fs-7">${formattedNextRun}</span>`;
+            }
+        }
+        return text;
     }
 
     function getSchedulesForFile(fileName) {
         return schedules.filter(s => s.file === fileName);
     }
 
+    socket.on("get_schedules", (data) => {
+        if (validResponse(data, true)) {
+            schedules = data.schedules
+            renderScheduleList();
+            updateSchedulerIcon();
+        } else {
+            console.log("Unable to obtain schedules from backend")
+        }
+    });
+
     // Show the time selector when the clock icon is clicked
     scheduleIcon.addEventListener("click", function () {
+        socket.emit("get_schedules", {instance_id: instanceId})
 
         const iconRect = scheduleIcon.getBoundingClientRect();
         const boxWidth = timeSelectBox.offsetWidth || 300; // Fallback width
@@ -2423,8 +2452,30 @@ socket.on("upload_complete", function (data) {
     // Toggle between the "daily at a time" and "every N hours/days" inputs
     scheduleTypeSelect.addEventListener("change", function () {
         const isDaily = scheduleTypeSelect.value === "daily";
+
         scheduleTimeGroup.classList.toggle("d-none", !isDaily);
         scheduleIntervalGroup.classList.toggle("d-none", isDaily);
+        runNowLabel.classList.toggle("d-none", isDaily);
+        runNowCheckbox.checked = !isDaily;
+        
+        // Initialize tooltip if switching to interval schedule
+        if (!isDaily) {
+            const tooltipIcon = document.getElementById("run_now_info_icon");
+            if (tooltipIcon) {
+                // Dispose of any old/stale instance created while hidden
+                const existingInstance = bootstrap.Tooltip.getInstance(tooltipIcon);
+                if (existingInstance) {
+                    existingInstance.dispose();
+                }
+                // Create fresh instance NOW that the element has non-zero dimensions!
+                new bootstrap.Tooltip(tooltipIcon, {
+                    html: true,
+                    sanitize: false,
+                    container: 'body', // Appends to <body> so z-index/popover clipping is bypassed
+                    trigger: 'hover'
+                });
+            }
+        }
     });
 
     function resetScheduleForm() {
@@ -2446,6 +2497,8 @@ socket.on("upload_complete", function (data) {
         scheduleTimeInput.value = "";
         scheduleIntervalValueInput.value = 1;
         scheduleIntervalUnitSelect.value = "hours";
+        runNowLabel.classList.add("d-none");
+        runNowCheckbox.checked = true;
     }
 
     function editSchedule(s) {
@@ -2458,12 +2511,15 @@ socket.on("upload_complete", function (data) {
             scheduleTimeGroup.classList.remove("d-none");
             scheduleIntervalGroup.classList.add("d-none");
             scheduleTimeInput.value = s.time;
+            runNowLabel.classList.add("d-none");
         } else {
             scheduleTypeSelect.value = "interval";
             scheduleTimeGroup.classList.add("d-none");
             scheduleIntervalGroup.classList.remove("d-none");
             scheduleIntervalValueInput.value = s.interval_value;
             scheduleIntervalUnitSelect.value = s.interval_unit;
+            runNowLabel.classList.remove("d-none");
+            runNowCheckbox.checked = true;
         }
     }
 
@@ -2482,6 +2538,7 @@ socket.on("upload_complete", function (data) {
             if (!intervalValue || intervalValue < 1) return;
             payload.interval_value = intervalValue;
             payload.interval_unit = scheduleIntervalUnitSelect.value;
+            payload.run_now = runNowCheckbox.checked
         }
 
         socket.emit("add_schedule", payload);
@@ -2496,7 +2553,8 @@ socket.on("upload_complete", function (data) {
                         file: data.file,
                         time: data.time,
                         interval_value: data.interval_value,
-                        interval_unit: data.interval_unit
+                        interval_unit: data.interval_unit,
+                        next_run: data.next_run
                     });
                     updateSchedulerIcon();
                 }
@@ -2516,6 +2574,42 @@ socket.on("upload_complete", function (data) {
                 updateSchedulerIcon();
             }
         });
+    }
+
+    function formatNextRun(isoString) {
+        if (!isoString) return "";
+        
+        try {
+            const date = new Date(isoString);
+            if (isNaN(date.getTime())) return "";
+
+            const today = new Date();
+            const tomorrow = new Date(today);
+            tomorrow.setDate(tomorrow.getDate() + 1);
+            const isToday = date.toDateString() === today.toDateString();
+            const isTomorrow = date.toDateString() === tomorrow.toDateString();
+
+            // Format time as HH:MM
+            const hours = String(date.getHours()).padStart(2, '0');
+            const minutes = String(date.getMinutes()).padStart(2, '0');
+            const timeStr = `${hours}:${minutes}`;
+
+            if (isToday) {
+                return `Today at ${timeStr}`;
+            } else if (isTomorrow) {
+                return `Tomorrow at ${timeStr}`;
+            }
+
+            // Format date as "Aug 14, 23:58"
+            const monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+            const month = monthNames[date.getMonth()];
+            const day = date.getDate();
+
+            return `${month} ${day}, ${timeStr}`;
+        } catch (e) {
+            // Fallback: strip ISO microseconds and timezone if regex/date fails
+            return isoString.replace("T", " ").replace(/\.\d+/, "").slice(0, 16);
+        }
     }
 
     function renderScheduleList() {
@@ -2541,7 +2635,7 @@ socket.on("upload_complete", function (data) {
             if (isLast) item.classList.add("mb-2", "rounded-bottom");
 
             const label = document.createElement("span");
-            label.textContent = describeSchedule(s);
+            label.innerHTML = describeSchedule(s);
             label.setAttribute("role", "button");
             label.addEventListener("click", () => {
                 if (s.id != editingScheduleId) {

--- a/templates/web_interface.html
+++ b/templates/web_interface.html
@@ -681,9 +681,23 @@
                     <!-- Existing schedules for the current bulk file -->
                     <ul id="schedule_list" class="list-group mb-0"></ul>
 
-                    <label class="form-label mb-1 fw-medium text-body d-flex align-items-center">
-                        <i class="bi bi-alarm"></i>&ensp;Schedule a bulk import
-                    </label>
+                    <div class="d-flex align-items-center justify-content-between my-2">
+                        <label class="form-label mb-0 fw-medium text-body d-flex align-items-center">
+                            <i class="bi bi-alarm"></i>&ensp;Schedule a bulk import
+                        </label>
+                        <label id="run_now_label" class="form-check-label d-flex align-items-center gap-1 fs-7 cursor-pointer mb-0 d-none fw-medium">
+                            <i class="bi bi-info-circle"
+                                id="run_now_info_icon"
+                                style="pointer-events: auto; cursor: help;"
+                                onclick="event.preventDefault(); event.stopPropagation();"
+                                data-bs-toggle="tooltip"
+                                data-ps-placement="top"
+                                data-bs-title="Runs immediately after creation (within a 2 minute window), then every configured interval after that">
+                            </i>
+                            <span class="fw-medium">Run now</span>
+                            <input class="form-check-input mt-0 ms-1" type="checkbox" id="run_now_checkbox" checked>
+                        </label>
+                    </div>
 
                     <div class="d-flex align-items-center gap-2">
                         <!-- Dropdown -->

--- a/tests/test_schedule_catchup.py
+++ b/tests/test_schedule_catchup.py
@@ -7,15 +7,23 @@ those primitives together: recording a run, skipping a run that would collide wi
 already in flight, and choosing whether a missed run is caught up or just logged.
 """
 
+from datetime import datetime as real_datetime
 from unittest.mock import MagicMock, patch
+import uuid
+import schedule
 
 import pytest
 
 import core.globals as globals
-from artwork_uploader import add_file_to_schedule_thread, catch_up_missed_schedule, record_schedule_run, setup_scheduler_on_first_load
+from artwork_uploader import (
+    add_file_to_schedule_thread,
+    catch_up_missed_schedule,
+    record_schedule_run,
+    setup_scheduler_on_first_load,
+)
+from models.bulk_schedule import BulkSchedule
 from models.instance import Instance
 from services.scheduler_service import SchedulerService
-
 
 pytestmark = pytest.mark.unit
 
@@ -40,32 +48,36 @@ def scheduler():
 
 
 def test_record_schedule_run_stamps_last_run_and_saves(scheduler):
-    config = FakeConfig(schedules=[{"file": "bulk_import.txt", "time": "02:00"}])
+    schedule_id = str(uuid.uuid4())
+    config = FakeConfig(schedules=[{"id": schedule_id, "file": "bulk_import.txt", "time": "02:00"}])
     globals.config = config
 
-    record_schedule_run("bulk_import.txt")
+    record_schedule_run(schedule_id=schedule_id)
 
     assert "last_run" in config.schedules[0]
     assert config.schedules[0]["last_run"]  # non-empty ISO timestamp
     config.save.assert_called_once()
 
 
-def test_record_schedule_run_is_a_no_op_for_an_unknown_file(scheduler):
-    config = FakeConfig(schedules=[{"file": "bulk_import.txt", "time": "02:00"}])
+def test_record_schedule_run_is_a_no_op_for_an_unknown_id(scheduler):
+    schedule_id = str(uuid.uuid4())
+    config = FakeConfig(schedules=[{"id": schedule_id, "file": "bulk_import.txt", "time": "02:00"}])
     globals.config = config
 
-    record_schedule_run("some_other_file.txt")
+    some_other_id = str(uuid.uuid4())
+    record_schedule_run(schedule_id=some_other_id)
 
     assert "last_run" not in config.schedules[0]
     config.save.assert_called_once()
 
 
 def test_add_file_to_schedule_thread_starts_the_run_and_marks_it_running(scheduler):
-    globals.config = FakeConfig(schedules=[{"file": "bulk_import.txt", "time": "02:00"}])
+    schedule_id = str(uuid.uuid4())
+    globals.config = FakeConfig(schedules=[{"id": schedule_id, "file": "bulk_import.txt", "time": "02:00"}])
     instance = Instance(mode="cli")
 
     with patch("artwork_uploader.threading.Thread") as mock_thread:
-        add_file_to_schedule_thread(instance, "bulk_import.txt")
+        add_file_to_schedule_thread(instance, "bulk_import.txt", schedule_id)
 
     mock_thread.assert_called_once()
     assert scheduler.try_start("bulk_import.txt") is False  # still marked running
@@ -73,51 +85,69 @@ def test_add_file_to_schedule_thread_starts_the_run_and_marks_it_running(schedul
 
 
 def test_add_file_to_schedule_thread_skips_when_a_run_is_already_in_progress(scheduler):
-    globals.config = FakeConfig(schedules=[{"file": "bulk_import.txt", "time": "02:00"}])
+    schedule_id = str(uuid.uuid4())
+    globals.config = FakeConfig(schedules=[{"id": schedule_id, "file": "bulk_import.txt", "time": "02:00"}])
     instance = Instance(mode="cli")
     scheduler.try_start("bulk_import.txt")  # simulate a run already in flight
 
     with patch("artwork_uploader.threading.Thread") as mock_thread:
-        add_file_to_schedule_thread(instance, "bulk_import.txt")
+        add_file_to_schedule_thread(instance, "bulk_import.txt", schedule_id)
 
     mock_thread.assert_not_called()
     assert globals.config.schedules[0].get("last_run") is None  # no run was recorded
 
 
 def test_add_file_to_schedule_thread_is_a_no_op_without_an_instance(scheduler):
-    globals.config = FakeConfig(schedules=[{"file": "bulk_import.txt", "time": "02:00"}])
+    schedule_id = str(uuid.uuid4())
+    globals.config = FakeConfig(schedules=[{"id": schedule_id, "file": "bulk_import.txt", "time": "02:00"}])
 
     with patch("artwork_uploader.threading.Thread") as mock_thread:
-        add_file_to_schedule_thread(None, "bulk_import.txt")
+        add_file_to_schedule_thread(None, "bulk_import.txt", schedule_id)
 
     mock_thread.assert_not_called()
 
 
 def test_catch_up_missed_schedule_triggers_a_run_inside_the_window(scheduler):
+    schedule_id = str(uuid.uuid4())
     globals.config = FakeConfig(catch_up_window_minutes=1440)
     instance = Instance(mode="cli")
     last_run_yesterday = "2026-08-08T02:00:00"
 
-    with patch("artwork_uploader.datetime") as mock_datetime, \
-         patch("artwork_uploader.add_file_to_schedule_thread") as mock_add:
-        from datetime import datetime as real_datetime
-        mock_datetime.now.return_value = real_datetime(2026, 8, 9, 3, 0)
-        catch_up_missed_schedule(instance, "bulk_import.txt", "02:00", last_run_yesterday)
+    sched = BulkSchedule(
+        id=schedule_id,
+        file="bulk_import.txt",
+        time="02:00",
+        last_run=last_run_yesterday
+    )
 
-    mock_add.assert_called_once_with(instance, "bulk_import.txt")
+    with patch("services.scheduler_service.datetime") as mock_datetime, \
+         patch("artwork_uploader.add_file_to_schedule_thread") as mock_add:
+        mock_datetime.now.return_value = real_datetime(2026, 8, 9, 3, 0)
+        mock_datetime.fromisoformat = real_datetime.fromisoformat
+        catch_up_missed_schedule(instance, sched)
+
+    mock_add.assert_called_once_with(instance, "bulk_import.txt", schedule_id)
 
 
 def test_catch_up_missed_schedule_only_logs_when_outside_the_window(scheduler):
+    schedule_id = str(uuid.uuid4())
     globals.config = FakeConfig(catch_up_window_minutes=30)
     instance = Instance(mode="cli")
     last_run_yesterday = "2026-08-08T02:00:00"
 
-    with patch("artwork_uploader.datetime") as mock_datetime, \
+    sched = BulkSchedule(
+        id=schedule_id,
+        file="bulk_import.txt",
+        time="02:00",
+        last_run=last_run_yesterday
+    )
+
+    with patch("services.scheduler_service.datetime") as mock_datetime, \
          patch("artwork_uploader.add_file_to_schedule_thread") as mock_add, \
          patch("artwork_uploader.update_log") as mock_log:
-        from datetime import datetime as real_datetime
         mock_datetime.now.return_value = real_datetime(2026, 8, 9, 7, 30)
-        catch_up_missed_schedule(instance, "bulk_import.txt", "02:00", last_run_yesterday)
+        mock_datetime.fromisoformat = real_datetime.fromisoformat
+        catch_up_missed_schedule(instance, sched)
 
     mock_add.assert_not_called()
     assert mock_log.call_count == 1
@@ -127,16 +157,150 @@ def test_catch_up_missed_schedule_only_logs_when_outside_the_window(scheduler):
 
 
 def test_catch_up_missed_schedule_does_nothing_for_a_never_run_schedule(scheduler):
+    schedule_id = str(uuid.uuid4())
     globals.config = FakeConfig(catch_up_window_minutes=1440)
     instance = Instance(mode="cli")
 
+    sched = BulkSchedule(
+        id=schedule_id,
+        file="bulk_import.txt",
+        time="02:00",
+        last_run=None
+    )
+
     with patch("artwork_uploader.add_file_to_schedule_thread") as mock_add, \
          patch("artwork_uploader.update_log") as mock_log:
-        catch_up_missed_schedule(instance, "bulk_import.txt", "02:00", None)
+        catch_up_missed_schedule(instance, sched)
 
     mock_add.assert_not_called()
     mock_log.assert_not_called()
 
+
+def test_catch_up_missed_interval_schedule_triggers_a_run_inside_the_window(scheduler):
+    schedule_id = str(uuid.uuid4())
+    globals.config = FakeConfig(catch_up_window_minutes=120)  # 2-hour window
+    instance = Instance(mode="cli")
+    last_run_6h_ago = "2026-08-09T02:00:00"
+
+    sched = BulkSchedule(
+        id=schedule_id,
+        file="bulk_import.txt",
+        interval_value=6,
+        interval_unit="hours",
+        last_run=last_run_6h_ago
+    )
+
+    with patch("services.scheduler_service.datetime") as mock_datetime, \
+         patch("artwork_uploader.add_file_to_schedule_thread") as mock_add:
+        # Current time is 08:30 (missed by 30 mins, well within 120-min window)
+        mock_datetime.now.return_value = real_datetime(2026, 8, 9, 8, 30)
+        mock_datetime.fromisoformat = real_datetime.fromisoformat
+        catch_up_missed_schedule(instance, sched)
+
+    mock_add.assert_called_once_with(instance, "bulk_import.txt", schedule_id)
+
+
+def test_catch_up_missed_interval_schedule_only_logs_when_outside_the_window(scheduler):
+    schedule_id = str(uuid.uuid4())
+    globals.config = FakeConfig(catch_up_window_minutes=30)  # 30-min window
+    instance = Instance(mode="cli")
+    last_run = "2026-08-09T02:00:00"
+
+    sched = BulkSchedule(
+        id=schedule_id,
+        file="bulk_import.txt",
+        interval_value=6,
+        interval_unit="hours",
+        last_run=last_run
+    )
+
+    with patch("services.scheduler_service.datetime") as mock_datetime, \
+         patch("artwork_uploader.add_file_to_schedule_thread") as mock_add, \
+         patch("artwork_uploader.update_log") as mock_log:
+        # Current time is 09:30 (missed by 1.5 hours, outside 30-min window)
+        mock_datetime.now.return_value = real_datetime(2026, 8, 9, 9, 30)
+        mock_datetime.fromisoformat = real_datetime.fromisoformat
+        catch_up_missed_schedule(instance, sched)
+
+    mock_add.assert_not_called()
+    assert mock_log.call_count == 1
+    logged_message = mock_log.call_args[0][1]
+    assert "missed" in logged_message.lower()
+
+
+def test_catch_up_missed_interval_schedule_does_nothing_for_never_run_schedule(scheduler):
+    schedule_id = str(uuid.uuid4())
+    globals.config = FakeConfig(catch_up_window_minutes=120)
+    instance = Instance(mode="cli")
+
+    sched = BulkSchedule(
+        id=schedule_id,
+        file="bulk_import.txt",
+        interval_value=6,
+        interval_unit="hours",
+        last_run=None
+    )
+
+    with patch("artwork_uploader.add_file_to_schedule_thread") as mock_add, \
+         patch("artwork_uploader.update_log") as mock_log:
+        catch_up_missed_schedule(instance, sched)
+
+    mock_add.assert_not_called()
+    mock_log.assert_not_called()
+
+
+def test_setup_scheduler_aligns_next_run_on_startup(scheduler):
+    """Verifies that starting up aligns job.next_run to the computed next run target 
+    instead of naively resetting to now + interval.
+    """
+    schedule_interval_id = str(uuid.uuid4())
+    schedule_daily_id = str(uuid.uuid4())
+
+    globals.config = FakeConfig(schedules=[
+        {
+            "id": schedule_interval_id,
+            "file": "interval_task.txt",
+            "interval_value": 6,
+            "interval_unit": "hours",
+            "last_run": "2026-08-09T02:00:00"
+        },
+        {
+            "id": schedule_daily_id,
+            "file": "daily_task.txt",
+            "time": "02:00",
+            "last_run": "2026-08-09T02:00:00"
+        }
+    ])
+    instance = Instance(mode="cli")
+
+    fake_now = real_datetime(2026, 8, 9, 5, 0)
+
+    class MockDateTime(real_datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fake_now
+
+    with patch.object(schedule.datetime, "datetime", MockDateTime), \
+         patch("artwork_uploader.datetime", MockDateTime), \
+         patch("services.scheduler_service.datetime", MockDateTime), \
+         patch("models.bulk_schedule.datetime", MockDateTime), \
+         patch("artwork_uploader.update_log"), \
+         patch("artwork_uploader.debug_me"):
+
+        try:
+            setup_scheduler_on_first_load(instance)
+
+            # 1. Interval task: last_run 02:00 + 6h -> expected 08:00 on 2026-08-09
+            interval_job = scheduler.scheduled_jobs[schedule_interval_id]
+            assert interval_job.next_run == real_datetime(2026, 8, 9, 8, 0, 0)
+
+            # 2. Daily task: time 02:00 (already passed at 05:00) -> expected 02:00 on 2026-08-10
+            daily_job = scheduler.scheduled_jobs[schedule_daily_id]
+            assert daily_job.next_run == real_datetime(2026, 8, 10, 2, 0, 0)
+
+        finally:
+            scheduler.stop()
+            scheduler.clear_all_schedules()
 
 def test_setup_scheduler_skips_an_invalid_persisted_schedule(scheduler):
     """One malformed entry in config.json must not stop the app starting or

--- a/tests/test_scheduler_service.py
+++ b/tests/test_scheduler_service.py
@@ -3,11 +3,13 @@ config.json schedule migration, missed-run catch-up logic and the overlap guard.
 
 import json
 from datetime import datetime
+from unittest.mock import patch
 
 import pytest
 import schedule
 
 from core.config import Config
+from models.bulk_schedule import BulkSchedule
 from services.scheduler_service import SchedulerService
 
 
@@ -34,7 +36,8 @@ def run_job(service, job_id):
 @pytest.mark.unit
 def test_daily_schedule_runs_with_its_filename(service):
     calls = []
-    job_id = service.add_schedule("bulk_a.txt", calls.append, time="02:00")
+    sched = BulkSchedule(file="bulk_a.txt", time="02:00")
+    job_id = service.add_schedule(sched, calls.append)
 
     run_job(service, job_id)
 
@@ -44,43 +47,53 @@ def test_daily_schedule_runs_with_its_filename(service):
 @pytest.mark.unit
 def test_interval_schedule_in_hours(service):
     calls = []
-    job_id = service.add_schedule("bulk_a.txt", calls.append, interval_value=6, interval_unit="hours")
+    sched = BulkSchedule(file="bulk_a.txt", interval_value=6, interval_unit="hours")
+    job_id = service.add_schedule(sched, calls.append)
 
     run_job(service, job_id)
 
     assert calls == ["bulk_a.txt"]
-    assert service.schedule_meta[job_id] == {"file": "bulk_a.txt", "interval_value": 6, "interval_unit": "hours"}
+    assert service.schedule_meta[job_id]["file"] == "bulk_a.txt"
+    assert service.schedule_meta[job_id]["interval_value"] == 6
+    assert service.schedule_meta[job_id]["interval_unit"] == "hours"
 
 
 @pytest.mark.unit
 def test_interval_schedule_in_days(service):
-    job_id = service.add_schedule("bulk_a.txt", lambda f: None, interval_value=2, interval_unit="days")
+    sched = BulkSchedule(file="bulk_a.txt", interval_value=2, interval_unit="days")
+    job_id = service.add_schedule(sched, lambda f: None)
     assert service.schedule_meta[job_id]["interval_unit"] == "days"
 
 
 @pytest.mark.unit
 def test_add_schedule_requires_a_time_or_a_valid_interval(service):
     with pytest.raises(ValueError):
-        service.add_schedule("bulk_a.txt", lambda f: None)
+        invalid_sched1 = BulkSchedule(file="bulk_a.txt")
+        service.add_schedule(invalid_sched1, lambda f: None)
 
     with pytest.raises(ValueError):
-        service.add_schedule("bulk_a.txt", lambda f: None, interval_value=3, interval_unit="fortnights")
+        invalid_sched2 = BulkSchedule(file="bulk_a.txt", interval_value=3, interval_unit="fortnights")
+        service.add_schedule(invalid_sched2, lambda f: None)
 
 
 @pytest.mark.unit
 def test_a_file_can_carry_more_than_one_schedule(service):
-    """The original bug: a bulk file could only ever hold one schedule."""
-    first = service.add_schedule("bulk_a.txt", lambda f: None, time="02:00")
-    second = service.add_schedule("bulk_a.txt", lambda f: None, interval_value=6, interval_unit="hours")
+    """A bulk file can carry multiple distinct schedules."""
+    sched1 = BulkSchedule(file="bulk_a.txt", time="02:00")
+    sched2 = BulkSchedule(file="bulk_a.txt", interval_value=6, interval_unit="hours")
+
+    first = service.add_schedule(sched1, lambda f: None)
+    second = service.add_schedule(sched2, lambda f: None)
 
     assert first != second
-    assert service.get_all_job_ids() == [first, second] or set(service.get_all_job_ids()) == {first, second}
+    assert set(service.get_all_job_ids()) == {first, second}
     assert set(service.get_jobs_for_file("bulk_a.txt")) == {first, second}
 
 
 @pytest.mark.unit
 def test_add_schedule_reuses_a_given_id(service):
-    job_id = service.add_schedule("bulk_a.txt", lambda f: None, schedule_id="my-id", time="02:00")
+    sched = BulkSchedule(id="my-id", file="bulk_a.txt", time="02:00")
+    job_id = service.add_schedule(sched, lambda f: None)
     assert job_id == "my-id"
     assert "my-id" in service.scheduled_jobs
 
@@ -89,8 +102,11 @@ def test_add_schedule_reuses_a_given_id(service):
 
 @pytest.mark.unit
 def test_remove_schedule_only_removes_the_one_job(service):
-    keep = service.add_schedule("bulk_a.txt", lambda f: None, time="02:00")
-    remove = service.add_schedule("bulk_a.txt", lambda f: None, time="12:30")
+    sched_keep = BulkSchedule(file="bulk_a.txt", time="02:00")
+    sched_remove = BulkSchedule(file="bulk_a.txt", time="12:30")
+
+    keep = service.add_schedule(sched_keep, lambda f: None)
+    remove = service.add_schedule(sched_remove, lambda f: None)
 
     assert service.remove_schedule(remove) is True
 
@@ -109,9 +125,9 @@ def test_remove_schedule_returns_false_when_not_found(service):
 @pytest.mark.unit
 def test_rename_file_moves_every_schedule_for_that_file(service):
     calls = []
-    a = service.add_schedule("old.txt", calls.append, time="02:00")
-    b = service.add_schedule("old.txt", calls.append, interval_value=6, interval_unit="hours")
-    other = service.add_schedule("unrelated.txt", calls.append, time="09:00")
+    a = service.add_schedule(BulkSchedule(file="old.txt", time="02:00"), calls.append)
+    b = service.add_schedule(BulkSchedule(file="old.txt", interval_value=6, interval_unit="hours"), calls.append)
+    other = service.add_schedule(BulkSchedule(file="unrelated.txt", time="09:00"), calls.append)
 
     renamed_ids = service.rename_file("old.txt", "new.txt")
 
@@ -124,7 +140,7 @@ def test_rename_file_moves_every_schedule_for_that_file(service):
 @pytest.mark.unit
 def test_rename_file_does_not_recreate_the_underlying_job(service):
     """Renaming should only touch metadata - the schedule library job stays the same object."""
-    job_id = service.add_schedule("old.txt", lambda f: None, time="02:00")
+    job_id = service.add_schedule(BulkSchedule(file="old.txt", time="02:00"), lambda f: None)
     job_before = service.scheduled_jobs[job_id]
 
     service.rename_file("old.txt", "new.txt")
@@ -135,7 +151,7 @@ def test_rename_file_does_not_recreate_the_underlying_job(service):
 @pytest.mark.unit
 def test_renamed_schedule_calls_back_with_the_new_filename(service):
     calls = []
-    job_id = service.add_schedule("old.txt", calls.append, time="02:00")
+    job_id = service.add_schedule(BulkSchedule(file="old.txt", time="02:00"), calls.append)
 
     service.rename_file("old.txt", "new.txt")
     run_job(service, job_id)
@@ -148,14 +164,14 @@ def test_renamed_schedule_calls_back_with_the_new_filename(service):
 @pytest.mark.unit
 def test_has_schedules(service):
     assert service.has_schedules() is False
-    service.add_schedule("bulk_a.txt", lambda f: None, time="02:00")
+    service.add_schedule(BulkSchedule(file="bulk_a.txt", time="02:00"), lambda f: None)
     assert service.has_schedules() is True
 
 
 @pytest.mark.unit
 def test_clear_all_schedules(service):
-    service.add_schedule("bulk_a.txt", lambda f: None, time="02:00")
-    service.add_schedule("bulk_b.txt", lambda f: None, interval_value=1, interval_unit="days")
+    service.add_schedule(BulkSchedule(file="bulk_a.txt", time="02:00"), lambda f: None)
+    service.add_schedule(BulkSchedule(file="bulk_b.txt", interval_value=1, interval_unit="days"), lambda f: None)
 
     service.clear_all_schedules()
 
@@ -202,10 +218,6 @@ def test_migration_keeps_an_existing_id_stable(tmp_path):
 
 @pytest.mark.unit
 def test_migrated_ids_are_written_back_to_disk_and_stay_stable(tmp_path):
-    """A minted id that only lives in memory is useless: every socket handler
-    calls config.load() again before matching by id, so if the id were not
-    persisted, a fresh (different) one would be minted on the next load and
-    nothing would ever match again."""
     config_path = tmp_path / "config.json"
     config_path.write_text(json.dumps({
         "schedules": [{"file": "bulk_a.txt", "time": "02:00"}],
@@ -225,9 +237,6 @@ def test_migrated_ids_are_written_back_to_disk_and_stay_stable(tmp_path):
 
 @pytest.mark.unit
 def test_deleting_a_migrated_schedule_stays_deleted_after_reload(tmp_path):
-    """Regression test for web_routes.delete_task_from_scheduler: it loads
-    config again and then filters by id, which only works if the id survives
-    that reload unchanged."""
     config_path = tmp_path / "config.json"
     config_path.write_text(json.dumps({
         "schedules": [{"file": "bulk_a.txt", "time": "02:00"}],
@@ -248,9 +257,6 @@ def test_deleting_a_migrated_schedule_stays_deleted_after_reload(tmp_path):
 
 @pytest.mark.unit
 def test_editing_a_migrated_schedule_updates_in_place_after_reload(tmp_path):
-    """Regression test for web_routes.update_or_add_schedule: matching an
-    existing entry by id has to actually find it, or an edit turns into a
-    second schedule alongside the original."""
     config_path = tmp_path / "config.json"
     config_path.write_text(json.dumps({
         "schedules": [{"file": "bulk_a.txt", "time": "02:00"}],
@@ -278,9 +284,6 @@ def test_editing_a_migrated_schedule_updates_in_place_after_reload(tmp_path):
 
 @pytest.mark.unit
 def test_renaming_a_migrated_schedules_file_survives_reload(tmp_path):
-    """Regression test for web_routes.rename_bulk_file: the ids handed back
-    by SchedulerService.rename_file only match config entries whose id is
-    still the same one the scheduler was built from."""
     config_path = tmp_path / "config.json"
     config_path.write_text(json.dumps({
         "schedules": [{"file": "old.txt", "time": "02:00"}],
@@ -326,73 +329,139 @@ def test_multiple_schedules_for_one_file_survive_a_save_and_reload(tmp_path):
     assert by_id["b"]["interval_unit"] == "hours"
 
 
-pytestmark = pytest.mark.unit
+# ------------------------------- get_missed_run -------------------------------
 
-
+@pytest.mark.unit
 def test_no_catch_up_when_never_run_before():
     """A schedule with no recorded last run is never treated as having missed one."""
-    now = datetime(2026, 8, 9, 7, 30)
-    due, within_window = SchedulerService.get_missed_run("02:00", None, now, window_minutes=60)
+    mock_now = datetime(2026, 8, 9, 7, 30)
+    sched = BulkSchedule(time="02:00", last_run=None)
+
+    with patch("services.scheduler_service.datetime") as mock_datetime:
+        mock_datetime.now.return_value = mock_now
+        mock_datetime.fromisoformat = datetime.fromisoformat
+
+        due, within_window = SchedulerService.get_missed_run(sched, window=60)
+
     assert due is None
     assert within_window is False
 
 
+@pytest.mark.unit
 def test_missed_run_within_the_catch_up_window():
-    now = datetime(2026, 8, 9, 2, 15)
+    mock_now = datetime(2026, 8, 9, 2, 15)
     last_run = datetime(2026, 8, 8, 2, 0).isoformat()
-    due, within_window = SchedulerService.get_missed_run("02:00", last_run, now, window_minutes=30)
+    sched = BulkSchedule(time="02:00", last_run=last_run)
+
+    with patch("services.scheduler_service.datetime") as mock_datetime:
+        mock_datetime.now.return_value = mock_now
+        mock_datetime.fromisoformat = datetime.fromisoformat
+
+        due, within_window = SchedulerService.get_missed_run(sched, window=30)
+
     assert due == datetime(2026, 8, 9, 2, 0)
     assert within_window is True
 
 
+@pytest.mark.unit
 def test_missed_run_outside_the_catch_up_window():
-    now = datetime(2026, 8, 9, 7, 30)
+    mock_now = datetime(2026, 8, 9, 7, 30)
     last_run = datetime(2026, 8, 8, 2, 0).isoformat()
-    due, within_window = SchedulerService.get_missed_run("02:00", last_run, now, window_minutes=60)
+    sched = BulkSchedule(time="02:00", last_run=last_run)
+
+    with patch("services.scheduler_service.datetime") as mock_datetime:
+        mock_datetime.now.return_value = mock_now
+        mock_datetime.fromisoformat = datetime.fromisoformat
+
+        due, within_window = SchedulerService.get_missed_run(sched, window=60)
+
     assert due == datetime(2026, 8, 9, 2, 0)
     assert within_window is False
 
 
+@pytest.mark.unit
 def test_zero_window_never_catches_up():
-    now = datetime(2026, 8, 9, 2, 5)
+    mock_now = datetime(2026, 8, 9, 2, 5)
     last_run = datetime(2026, 8, 8, 2, 0).isoformat()
-    due, within_window = SchedulerService.get_missed_run("02:00", last_run, now, window_minutes=0)
+    sched = BulkSchedule(time="02:00", last_run=last_run)
+
+    with patch("services.scheduler_service.datetime") as mock_datetime:
+        mock_datetime.now.return_value = mock_now
+        mock_datetime.fromisoformat = datetime.fromisoformat
+
+        due, within_window = SchedulerService.get_missed_run(sched, window=0)
+
     assert due == datetime(2026, 8, 9, 2, 0)
     assert within_window is False
 
 
+@pytest.mark.unit
 def test_already_ran_today_is_not_a_miss():
-    now = datetime(2026, 8, 9, 7, 30)
+    mock_now = datetime(2026, 8, 9, 7, 30)
     last_run = datetime(2026, 8, 9, 2, 0).isoformat()
-    due, within_window = SchedulerService.get_missed_run("02:00", last_run, now, window_minutes=60)
+    sched = BulkSchedule(time="02:00", last_run=last_run)
+
+    with patch("services.scheduler_service.datetime") as mock_datetime:
+        mock_datetime.now.return_value = mock_now
+        mock_datetime.fromisoformat = datetime.fromisoformat
+
+        due, within_window = SchedulerService.get_missed_run(sched, window=60)
+
     assert due is None
     assert within_window is False
 
 
+@pytest.mark.unit
 def test_due_time_is_still_ahead_today_uses_yesterdays_occurrence():
     """If it's not yet 02:00 today, the most recent due time was yesterday's run."""
-    now = datetime(2026, 8, 9, 1, 0)
+    mock_now = datetime(2026, 8, 9, 1, 0)
     last_run = datetime(2026, 8, 7, 2, 0).isoformat()
-    due, within_window = SchedulerService.get_missed_run("02:00", last_run, now, window_minutes=1440)
+    sched = BulkSchedule(time="02:00", last_run=last_run)
+
+    with patch("services.scheduler_service.datetime") as mock_datetime:
+        mock_datetime.now.return_value = mock_now
+        mock_datetime.fromisoformat = datetime.fromisoformat
+
+        due, within_window = SchedulerService.get_missed_run(sched, window=1440)
+
     assert due == datetime(2026, 8, 8, 2, 0)
     assert within_window is True
 
 
+@pytest.mark.unit
 def test_malformed_schedule_time_is_not_a_miss():
-    now = datetime(2026, 8, 9, 7, 30)
+    mock_now = datetime(2026, 8, 9, 7, 30)
     last_run = datetime(2026, 8, 8, 2, 0).isoformat()
-    due, within_window = SchedulerService.get_missed_run("not-a-time", last_run, now, window_minutes=60)
+    sched = BulkSchedule(time="not-a-time", last_run=last_run)
+
+    with patch("services.scheduler_service.datetime") as mock_datetime:
+        mock_datetime.now.return_value = mock_now
+        mock_datetime.fromisoformat = datetime.fromisoformat
+
+        due, within_window = SchedulerService.get_missed_run(sched, window=60)
+
     assert due is None
     assert within_window is False
 
 
-def test_malformed_last_run_is_treated_as_missed():
-    now = datetime(2026, 8, 9, 2, 5)
-    due, within_window = SchedulerService.get_missed_run("02:00", "not-a-timestamp", now, window_minutes=60)
-    assert due == datetime(2026, 8, 9, 2, 0)
-    assert within_window is True
+@pytest.mark.unit
+def test_malformed_last_run_is_not_a_miss():
+    mock_now = datetime(2026, 8, 9, 2, 5)
+    sched = BulkSchedule(time="02:00", last_run="not-a-timestamp")
+
+    with patch("services.scheduler_service.datetime") as mock_datetime:
+        mock_datetime.now.return_value = mock_now
+        mock_datetime.fromisoformat = datetime.fromisoformat
+
+        due, within_window = SchedulerService.get_missed_run(sched, window=60)
+
+    assert due is None
+    assert within_window is False
 
 
+# ------------------------------- overlap guard -------------------------------
+
+@pytest.mark.unit
 def test_overlap_guard_blocks_a_second_start_for_the_same_file():
     service = SchedulerService()
     assert service.try_start("bulk_import.txt") is True
@@ -402,6 +471,7 @@ def test_overlap_guard_blocks_a_second_start_for_the_same_file():
     assert service.try_start("bulk_import.txt") is True
 
 
+@pytest.mark.unit
 def test_overlap_guard_is_independent_per_file():
     service = SchedulerService()
     assert service.try_start("a.txt") is True

--- a/web_routes.py
+++ b/web_routes.py
@@ -11,6 +11,7 @@ The routes are organized into:
 """
 
 import os, logging, flask.cli, sys, re, base64, hmac, tempfile, zipfile, subprocess, threading, uuid
+from datetime import datetime, timedelta
 from pathlib import Path
 from packaging import version
 from plexapi.server import PlexServer
@@ -18,10 +19,11 @@ from flask import render_template, send_from_directory, request, redirect, url_f
 from functools import wraps
 from core import globals
 from services.notify_service import NotifyService
-from utils import utils
+from utils.utils import calculate_file_md5, get_host_path
 from models.instance import Instance
+from models.bulk_schedule import BulkSchedule
 from core.config import Config, normalize_notification_channels
-from core.enums import FileType, MediaType, ScraperSource, StatusColor, RunType
+from core.enums import FileType, MediaType, ScraperSource, StatusColor, RunType, IntervalUnit
 from processors.media_metadata import parse_title
 from utils.notifications import update_log, update_status, notify_web, debug_me
 from services import UtilityService, AuthenticationService, RunHistory
@@ -418,7 +420,6 @@ def setup_socket_handlers(
         """Create a new bulk import file."""
         instance = Instance(data.get("instance_id"), "web")
 
-        from datetime import datetime
         timestamp = datetime.now().strftime("%d %b %Y %H:%M:%S")
 
         # Generate a unique filename
@@ -683,66 +684,80 @@ def setup_socket_handlers(
                     notify_web(instance, "delete_schedule", {"deleted": False, "id": schedule_id})
                     return {"id": schedule_id, "deleted": False}
 
+    @globals.web_socket.on("get_schedules")
+    def get_schedules(data):
+        """ Gets the list of schedules from the config file and sends it to the frontend """
+        instance = Instance(data.get("instance_id"), "web", broadcast=True)
+
+        scheduled_jobs = globals.scheduler_service.scheduled_jobs
+        for job_id, job in scheduled_jobs.items():
+            debug_me(f"Job ID: {job_id}, Last run: {job.last_run}, next run: {job.next_run}")
+        
+        config.load()
+        schedules = config.schedules
+        for schedule in schedules:
+            next_run_at = getattr(scheduled_jobs.get(schedule["id"]), "next_run", None)
+            if next_run_at:
+                schedule["next_run"] = datetime.isoformat(next_run_at)
+        notify_web(
+            instance=instance,
+            event="get_schedules",
+            data_to_include={ "schedules": schedules }
+        )
+
     @globals.web_socket.on("add_schedule")
     def add_tasks_to_scheduler(data):
         """Add a new scheduled task, or update an existing one if an id is given."""
         try:
             # Schedule bulk import task
-            if data.get("instance_id"):
-                instance = Instance(data.get("instance_id"), "web")
-                schedule_id = data.get("id")
-                schedule_file = data.get("file")
-                schedule_time = data.get("time")
-                interval_value = data.get("interval_value")
-                interval_unit = data.get("interval_unit")
+            instance_id = data.pop("instance_id", None)
+            run_now = data.pop("run_now", False)
+            if instance_id:
+                instance = Instance(instance_id, "web")
+                new_schedule = BulkSchedule(**data)
+                if run_now:
+                    new_schedule.next_run = ((datetime.now() + timedelta(minutes=2)).replace(second=0, microsecond=0)).isoformat()
+                else:
+                    new_schedule.compute_next_run()
 
                 # Validate the shape before anything is persisted or removed: a bad
                 # payload written to config.json would raise on every startup.
-                from services.scheduler_service import VALID_INTERVAL_UNITS
-                if not schedule_time and not (interval_value and interval_unit in VALID_INTERVAL_UNITS):
-                    update_log(instance, f"🔴 Rejected invalid schedule for '{schedule_file}': needs a daily time or a valid interval")
-                    notify_web(instance, "add_schedule", {"added": False, "file": schedule_file})
-                    return {"added": False, "file": schedule_file}
+                if not new_schedule.time and not (new_schedule.interval_value and new_schedule.interval_unit in IntervalUnit):
+                    update_log(instance, f"🔴 Rejected invalid schedule for '{new_schedule.file}': needs a daily time or a valid interval")
+                    notify_web(instance, "add_schedule", {"added": False, "file": new_schedule.file})
+                    return {"added": False, "file": new_schedule.file}
 
                 # Editing an existing schedule replaces its job under the same id
-                if schedule_id:
-                    globals.scheduler_service.remove_schedule(schedule_id)
+                if new_schedule.id:
+                    globals.scheduler_service.remove_schedule(new_schedule.id)
 
                 # Make sure the schedule is saved as part of the config
                 config.load()
-                schedule_id = update_or_add_schedule(
-                    schedule_id, schedule_file, schedule_time, interval_value, interval_unit
-                )
+                schedule_id = update_or_add_schedule(new_schedule)
                 config.save()
 
                 try:
                     # Create the callback for this schedule
-                    def schedule_callback(filename=schedule_file):
-                        add_file_to_schedule_thread(instance, filename)
+                    def schedule_callback(filename=new_schedule.file, schedule_id=new_schedule.id):
+                        add_file_to_schedule_thread(instance, filename, schedule_id)
 
                     # Add to scheduler service, keeping the id from config
-                    globals.scheduler_service.add_schedule(
-                        schedule_file,
-                        schedule_callback,
-                        schedule_id=schedule_id,
-                        time=schedule_time,
-                        interval_value=interval_value,
-                        interval_unit=interval_unit,
-                    )
+                    globals.scheduler_service.add_schedule(new_schedule, schedule_callback)
 
-                    description = f"every day at {schedule_time}" if schedule_time else f"every {interval_value} {interval_unit}"
+                    description = f"every day at {new_schedule.time}" if new_schedule.time else f"every {new_schedule.interval_value} {new_schedule.interval_unit}"
                     notify_web(instance, "add_schedule", {
                         "added": True,
                         "id": schedule_id,
-                        "file": schedule_file,
-                        "time": schedule_time,
-                        "interval_value": interval_value,
-                        "interval_unit": interval_unit,
+                        "file": new_schedule.file,
+                        "time": new_schedule.time,
+                        "interval_value": new_schedule.interval_value,
+                        "interval_unit": new_schedule.interval_unit,
+                        "next_run": new_schedule.next_run
                     })
-                    update_log(instance, f"⏰ Scheduled task '{schedule_file}' {description}")
-                    debug_me(f"Scheduled task '{schedule_file}' {description} with job ID '{schedule_id}'")
+                    update_log(instance, f"⏰ Scheduled task '{new_schedule.file}' {description}")
+                    debug_me(f"Scheduled task '{new_schedule.file}' {description} with job ID '{new_schedule.id}'")
                 except Exception as e:
-                    update_log(instance, f"🔴 Failed to add scheduled task '{schedule_file}'")
+                    update_log(instance, f"🔴 Failed to add scheduled task '{new_schedule.file}'")
                     debug_me(f"Error adding schedule: {e}")
                     raise
 
@@ -753,26 +768,31 @@ def setup_socket_handlers(
             debug_me(f"Error in scheduler setup: {e}")
             raise
 
-    def update_or_add_schedule(schedule_id, file_name, schedule_time, interval_value, interval_unit):
+    def update_or_add_schedule(sched: BulkSchedule):
         """Helper function to update or add a schedule in config. Returns the schedule's id."""
-        entry = {"file": file_name}
-        if schedule_time:
-            entry["time"] = schedule_time
+        entry = {"file": sched.file}
+        if sched.time:
+            entry["time"] = sched.time
         else:
-            entry["interval_value"] = interval_value
-            entry["interval_unit"] = interval_unit
+            entry["interval_value"] = sched.interval_value
+            entry["interval_unit"] = sched.interval_unit
+        if sched.last_run:
+            entry["last_run"] = sched.last_run
+        entry["next_run"] = sched.next_run
 
         for each_schedule in config.schedules:
-            if each_schedule.get("id") == schedule_id:
+            if each_schedule.get("id") == sched.id:
                 # Update existing schedule in place, clearing out fields from the old type
                 each_schedule.pop("time", None)
                 each_schedule.pop("interval_value", None)
                 each_schedule.pop("interval_unit", None)
+                each_schedule.pop("last_run", None)
+                each_schedule.pop("next_run", None)
                 each_schedule.update(entry)
-                return schedule_id
+                return sched.id
 
         # Add new schedule if not found
-        new_id = schedule_id or str(uuid.uuid4())
+        new_id = sched.id or str(uuid.uuid4())
         config.schedules.append({"id": new_id, **entry})
         return new_id
 
@@ -781,8 +801,8 @@ def setup_socket_handlers(
         """Detects whether app is running in docker and informs frontend"""
         instance = Instance(data.get("instance_id"), "web")
         if globals.docker:
-            kometa_base = utils.get_host_path("/assets")
-            temp_dir = utils.get_host_path("/temp")
+            kometa_base = get_host_path("/assets")
+            temp_dir = get_host_path("/temp")
             update_log(instance, f"🐳 Docker environment detected")
             debug_me(f"Docker detected, Kometa asset path mapped to '{kometa_base}', temp dir mapped to '{temp_dir}'")
             if kometa_base == "(not defined)":
@@ -1201,7 +1221,7 @@ def extract_and_list_zip(
                 with zip_ref.open(zip_info) as source, open(full_path, "wb") as target:
                     target.write(source.read())
 
-                md5 = utils.calculate_file_md5(full_path)
+                md5 = calculate_file_md5(full_path)
 
                 # Obtain artwork title, year, media type, season, episode and artwork type by parsing the filename
                 debug_me(f"Parsing artwork metadata from filename: {filename}")


### PR DESCRIPTION
- Fix issue #104 - Call `record_schedule_run` on a schedule_id instead of a file name so that if a single file has multiple schedules only the schedule that has  actually started gets its last run timestamp updated
- Implement #105 - Track next_run time to keep the previously scheduled next run time for a given schedule anchored on app restart
- Implement #106 - Provide a "Run now" checkbox in the UI when creating interval schedules so that the new schedule doesn't have to wait a full interval to run for the first time. If the checkbox is checked the first run will happen within a 2 minute window
- Extended the missed schedule catchup feature to interval schedules (previously only supported for daily fixed-time schedules)
- Created BulkSchedule class in models/bulk_schedule.py to make passing schedule arguments between functions much simpler
- Hardened the logic to keep track ot last_run and next_run times
- Updated tests to support the new data structures and features