### PR TITLE
Fix the test suite for the schedule_id rename, and run it in CI

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,37 @@
+name: Docker build
+
+# The image is only built when a tag is pushed, so a Dockerfile that no longer
+# builds is found during a release rather than before one. This builds it on
+# the way in, and never pushes.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # amd64 only. The release builds arm64 as well, under QEMU, and that is
+      # slow enough that a check on every pull request would not be worth it.
+      - name: Build the image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          platforms: linux/amd64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,13 @@ permissions:
   pull-requests: read  # Required for --generate-notes to read PR metadata
 
 jobs:
+  # Publishing a tag with a failing suite is the one mistake a release workflow
+  # can make that nobody can undo, so the tests gate everything below.
+  test:
+    uses: ./.github/workflows/tests.yml
+
   create-release:
+    needs: test
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,47 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  # Lets the release workflow run this same job before it publishes anything.
+  workflow_call:
+
+permissions:
+  contents: read
+
+# A new push to the same branch makes the run in flight irrelevant.
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # 3.14 is what the Dockerfile ships, so it is the version users run.
+        # 3.13 is here to catch anything that quietly depends on the newest
+        # interpreter, which is how the lock tests drifted.
+        python-version: ['3.13', '3.14']
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Run tests
+        run: pytest

--- a/tests/test_bulk_import_single_flight.py
+++ b/tests/test_bulk_import_single_flight.py
@@ -10,6 +10,7 @@ queue) a second run while the lock is held.
 """
 
 import threading
+import uuid
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -17,6 +18,11 @@ import pytest
 import core.globals as globals
 from artwork_uploader import process_bulk_import_from_ui
 from models.instance import Instance
+
+
+# A run counts as scheduled when it carries a schedule id. The value itself is
+# not read by anything under test here, only its presence.
+SCHEDULE_ID = str(uuid.uuid4())
 
 
 @pytest.mark.unit
@@ -47,7 +53,7 @@ def test_second_bulk_import_is_refused_while_one_is_running():
             patch("artwork_uploader.notify_web"),
             patch("artwork_uploader.debug_me"),
         ):
-            process_bulk_import_from_ui(instance, parsed_urls, "test_bulk.txt", scheduled=False)
+            process_bulk_import_from_ui(instance, parsed_urls, "test_bulk.txt")
 
         mock_scrape_and_upload.assert_not_called()
         mock_send_notification.assert_not_called()  # not scheduled, so no notification is sent
@@ -86,7 +92,7 @@ def test_refused_scheduled_bulk_import_sends_a_notification():
             patch("artwork_uploader.notify_web"),
             patch("artwork_uploader.debug_me"),
         ):
-            process_bulk_import_from_ui(instance, parsed_urls, "test_bulk.txt", scheduled=True)
+            process_bulk_import_from_ui(instance, parsed_urls, "test_bulk.txt", schedule_id=SCHEDULE_ID)
 
         mock_scrape_and_upload.assert_not_called()
         mock_send_notification.assert_called_once()
@@ -120,7 +126,7 @@ def test_bulk_import_releases_the_lock_so_the_next_run_can_start():
             patch("artwork_uploader.notify_web"),
             patch("artwork_uploader.debug_me"),
         ):
-            process_bulk_import_from_ui(instance, parsed_urls, "test_bulk.txt", scheduled=False)
+            process_bulk_import_from_ui(instance, parsed_urls, "test_bulk.txt")
 
         mock_scrape_and_upload.assert_called_once()
         assert not globals.bulk_import_lock.locked(), "the lock must be released once the run ends"
@@ -157,7 +163,7 @@ def test_bulk_import_releases_the_lock_when_plex_is_not_configured():
             patch("artwork_uploader.notify_web"),
             patch("artwork_uploader.debug_me"),
         ):
-            process_bulk_import_from_ui(instance, parsed_urls, "test_bulk.txt", scheduled=False)
+            process_bulk_import_from_ui(instance, parsed_urls, "test_bulk.txt")
 
         mock_scrape_and_upload.assert_not_called()
         mock_update_status.assert_called_once()

--- a/tests/test_bulk_import_single_flight.py
+++ b/tests/test_bulk_import_single_flight.py
@@ -109,7 +109,7 @@ def test_bulk_import_releases_the_lock_so_the_next_run_can_start():
     """A completed bulk import must release globals.bulk_import_lock, otherwise every
     run after the first would be refused forever."""
     try:
-        globals.bulk_import_lock = type(globals.bulk_import_lock)()  # fresh, unlocked lock
+        globals.bulk_import_lock = threading.Lock()  # fresh, unlocked lock
         globals.scrapes_running = 0
         globals.cancel_scrape = False
         globals.plex = MagicMock(tv_libraries=MagicMock(), movie_libraries=MagicMock())
@@ -147,7 +147,7 @@ def test_bulk_import_releases_the_lock_when_plex_is_not_configured():
     if Plex is unreachable. It must still release the lock, or a single misconfigured run
     would permanently jam every bulk import after it."""
     try:
-        globals.bulk_import_lock = type(globals.bulk_import_lock)()  # fresh, unlocked lock
+        globals.bulk_import_lock = threading.Lock()  # fresh, unlocked lock
         globals.scrapes_running = 0
         globals.cancel_scrape = False
         globals.plex = MagicMock(tv_libraries=None, movie_libraries=None)
@@ -185,7 +185,7 @@ def test_lock_actually_serializes_concurrent_bulk_imports():
     increment where two threads can both pass the check - that is the exact bug this ticket
     is about, and a test that only pre-locks before calling would not catch it coming back."""
     try:
-        globals.bulk_import_lock = type(globals.bulk_import_lock)()  # fresh, unlocked lock
+        globals.bulk_import_lock = threading.Lock()  # fresh, unlocked lock
         globals.scrapes_running = 0
         globals.cancel_scrape = False
         globals.plex = MagicMock(tv_libraries=MagicMock(), movie_libraries=MagicMock())

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -8,6 +8,7 @@ Covers:
 - utils.notifications.send_notification() only notifying channels subscribed to the given event.
 """
 
+import uuid
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -19,6 +20,11 @@ from core.constants import DEFAULT_NOTIFICATION_EVENTS
 from core.enums import NotificationEvent
 from models.instance import Instance
 from utils.notifications import send_notification
+
+
+# A run counts as scheduled when it carries a schedule id. The value itself is
+# not read by anything under test here, only its presence.
+SCHEDULE_ID = str(uuid.uuid4())
 
 
 @pytest.mark.unit
@@ -150,7 +156,7 @@ def test_scheduled_run_with_missing_bulk_file_fires_failed_to_start():
         patch("artwork_uploader.send_notification", side_effect=fake_send_notification),
         patch("artwork_uploader.update_log"),
     ):
-        process_bulk_file_on_schedule(Instance(mode="cli"), "missing.txt")
+        process_bulk_file_on_schedule(Instance(mode="cli"), "missing.txt", SCHEDULE_ID)
 
     assert events_sent == [NotificationEvent.RUN_FAILED_TO_START.value]
 
@@ -173,7 +179,7 @@ def test_scheduled_run_with_empty_bulk_file_fires_skipped(tmp_path):
         patch("artwork_uploader.update_log"),
         patch("artwork_uploader.run_bulk_import_scrape_in_thread") as mock_run,
     ):
-        process_bulk_file_on_schedule(Instance(mode="cli"), "empty.txt")
+        process_bulk_file_on_schedule(Instance(mode="cli"), "empty.txt", SCHEDULE_ID)
 
     assert events_sent == [NotificationEvent.RUN_SKIPPED.value]
     mock_run.assert_not_called()
@@ -187,14 +193,14 @@ def test_manual_run_with_no_valid_entries_stays_silent_unless_notify_opted_in():
         patch("artwork_uploader.send_notification") as mock_send_notification,
         patch("artwork_uploader.update_status"),
     ):
-        run_bulk_import_scrape_in_thread(Instance(mode="cli"), "# just a comment\n", "bulk.txt", scheduled=False, notify=False)
+        run_bulk_import_scrape_in_thread(Instance(mode="cli"), "# just a comment\n", "bulk.txt", notify=False)
     mock_send_notification.assert_not_called()
 
     with (
         patch("artwork_uploader.send_notification") as mock_send_notification,
         patch("artwork_uploader.update_status"),
     ):
-        run_bulk_import_scrape_in_thread(Instance(mode="cli"), "# just a comment\n", "bulk.txt", scheduled=False, notify=True)
+        run_bulk_import_scrape_in_thread(Instance(mode="cli"), "# just a comment\n", "bulk.txt", notify=True)
     mock_send_notification.assert_called_once()
     assert mock_send_notification.call_args.kwargs["event"] == NotificationEvent.RUN_SKIPPED.value
     # A manual run must not claim to be a scheduled one in the message it sends.
@@ -210,7 +216,7 @@ def test_scheduled_run_with_no_valid_entries_keeps_scheduled_wording():
         patch("artwork_uploader.send_notification") as mock_send_notification,
         patch("artwork_uploader.update_status"),
     ):
-        run_bulk_import_scrape_in_thread(Instance(mode="cli"), "# just a comment\n", "bulk.txt", scheduled=True, notify=False)
+        run_bulk_import_scrape_in_thread(Instance(mode="cli"), "# just a comment\n", "bulk.txt", schedule_id=SCHEDULE_ID, notify=False)
 
     mock_send_notification.assert_called_once()
     assert mock_send_notification.call_args.kwargs["event"] == NotificationEvent.RUN_SKIPPED.value
@@ -243,7 +249,7 @@ def test_clean_and_errored_completions_notify_different_events():
             patch("artwork_uploader.notify_web"),
             patch("artwork_uploader.debug_me"),
         ):
-            process_bulk_import_from_ui(instance, [MagicMock()], "clean.txt", scheduled=True)
+            process_bulk_import_from_ui(instance, [MagicMock()], "clean.txt", schedule_id=SCHEDULE_ID)
 
         assert events_sent == [NotificationEvent.RUN_COMPLETED.value]
 
@@ -258,7 +264,7 @@ def test_clean_and_errored_completions_notify_different_events():
             patch("artwork_uploader.notify_web"),
             patch("artwork_uploader.debug_me"),
         ):
-            process_bulk_import_from_ui(instance, [MagicMock()], "errored.txt", scheduled=True)
+            process_bulk_import_from_ui(instance, [MagicMock()], "errored.txt", schedule_id=SCHEDULE_ID)
 
         assert events_sent == [NotificationEvent.RUN_COMPLETED_WITH_ERRORS.value]
     finally:
@@ -281,14 +287,14 @@ def test_plex_setup_incomplete_notifies_failed_to_start_only_when_notify_enabled
             patch("artwork_uploader.send_notification") as mock_send_notification,
             patch("artwork_uploader.update_status"),
         ):
-            process_bulk_import_from_ui(instance, [MagicMock()], "test.txt", scheduled=False, notify=False)
+            process_bulk_import_from_ui(instance, [MagicMock()], "test.txt", notify=False)
         mock_send_notification.assert_not_called()
 
         with (
             patch("artwork_uploader.send_notification") as mock_send_notification,
             patch("artwork_uploader.update_status"),
         ):
-            process_bulk_import_from_ui(instance, [MagicMock()], "test.txt", scheduled=True, notify=False)
+            process_bulk_import_from_ui(instance, [MagicMock()], "test.txt", schedule_id=SCHEDULE_ID, notify=False)
         mock_send_notification.assert_called_once_with(
             instance,
             "🔴 Bulk import of 'test.txt' failed to start • Plex setup incomplete",
@@ -318,7 +324,7 @@ def test_cancelled_run_notifies_run_cancelled_specifically():
             patch("artwork_uploader.notify_web"),
             patch("artwork_uploader.debug_me"),
         ):
-            process_bulk_import_from_ui(instance, [MagicMock()], "cancelled.txt", scheduled=True)
+            process_bulk_import_from_ui(instance, [MagicMock()], "cancelled.txt", schedule_id=SCHEDULE_ID)
 
         mock_scrape_and_upload.assert_not_called()
         mock_send_notification.assert_called_once()
@@ -363,7 +369,7 @@ def test_mid_run_crash_after_processing_is_not_reported_as_failed_to_start():
             patch("artwork_uploader.notify_web"),
             patch("artwork_uploader.debug_me"),
         ):
-            process_bulk_import_from_ui(instance, [MagicMock(), MagicMock()], "nightly.txt", scheduled=True)
+            process_bulk_import_from_ui(instance, [MagicMock(), MagicMock()], "nightly.txt", schedule_id=SCHEDULE_ID)
 
         mock_send_notification.assert_called_once()
         assert mock_send_notification.call_args.kwargs["event"] == NotificationEvent.RUN_COMPLETED_WITH_ERRORS.value
@@ -398,7 +404,7 @@ def test_mid_run_crash_before_any_processing_is_reported_as_failed_to_start():
             patch("artwork_uploader.notify_web"),
             patch("artwork_uploader.debug_me"),
         ):
-            process_bulk_import_from_ui(instance, [MagicMock()], "nightly.txt", scheduled=True)
+            process_bulk_import_from_ui(instance, [MagicMock()], "nightly.txt", schedule_id=SCHEDULE_ID)
 
         mock_send_notification.assert_called_once()
         assert mock_send_notification.call_args.kwargs["event"] == NotificationEvent.RUN_FAILED_TO_START.value
@@ -437,7 +443,7 @@ def test_an_upload_that_exhausted_its_retries_sends_completed_with_errors():
             patch("artwork_uploader.notify_web"),
             patch("artwork_uploader.debug_me"),
         ):
-            process_bulk_import_from_ui(Instance(mode="cli"), [MagicMock()], "retries.txt", scheduled=True)
+            process_bulk_import_from_ui(Instance(mode="cli"), [MagicMock()], "retries.txt", schedule_id=SCHEDULE_ID)
 
         assert events_sent == [NotificationEvent.RUN_COMPLETED_WITH_ERRORS.value]
     finally:

--- a/tests/test_run_history_recording.py
+++ b/tests/test_run_history_recording.py
@@ -56,7 +56,7 @@ def test_successful_run_is_recorded_with_its_counters(history):
         patch("artwork_uploader.update_status"),
         patch("artwork_uploader.debug_me"),
     ):
-        process_bulk_import_from_ui(Instance(mode="cli"), [MagicMock()], "ok.txt", scheduled=False)
+        process_bulk_import_from_ui(Instance(mode="cli"), [MagicMock()], "ok.txt")
 
     runs = history.get_runs()
     assert len(runs) == 1
@@ -81,7 +81,7 @@ def test_run_with_scraper_errors_is_recorded_as_partial(history):
         patch("artwork_uploader.update_status"),
         patch("artwork_uploader.debug_me"),
     ):
-        process_bulk_import_from_ui(Instance(mode="cli"), [MagicMock()], "errors.txt", scheduled=False)
+        process_bulk_import_from_ui(Instance(mode="cli"), [MagicMock()], "errors.txt")
 
     runs = history.get_runs()
     assert len(runs) == 1
@@ -98,7 +98,7 @@ def test_plex_not_configured_is_recorded_as_failed_without_scraping(history):
         patch("artwork_uploader.scrape_and_upload") as mock_scrape,
         patch("artwork_uploader.update_status"),
     ):
-        process_bulk_import_from_ui(Instance(mode="cli"), [MagicMock()], "unconfigured.txt", scheduled=False)
+        process_bulk_import_from_ui(Instance(mode="cli"), [MagicMock()], "unconfigured.txt")
 
     mock_scrape.assert_not_called()
     runs = history.get_runs()
@@ -120,7 +120,7 @@ def test_unexpected_exception_mid_run_is_recorded_as_failed(history):
         patch("artwork_uploader.debug_me"),
         patch("artwork_uploader.elapsed_time", side_effect=RuntimeError("boom")),
     ):
-        process_bulk_import_from_ui(Instance(mode="cli"), [MagicMock()], "crash.txt", scheduled=False)
+        process_bulk_import_from_ui(Instance(mode="cli"), [MagicMock()], "crash.txt")
 
     runs = history.get_runs()
     assert len(runs) == 1
@@ -130,7 +130,7 @@ def test_unexpected_exception_mid_run_is_recorded_as_failed(history):
 @pytest.mark.unit
 def test_no_valid_urls_in_the_file_is_recorded_as_skipped(history):
     with patch("artwork_uploader.update_status"):
-        run_bulk_import_scrape_in_thread(Instance(mode="cli"), "# just a comment\n", "no_urls.txt", scheduled=False)
+        run_bulk_import_scrape_in_thread(Instance(mode="cli"), "# just a comment\n", "no_urls.txt")
 
     runs = history.get_runs()
     assert len(runs) == 1
@@ -142,7 +142,7 @@ def test_no_valid_urls_in_the_file_is_recorded_as_skipped(history):
 def test_no_filename_falls_back_to_the_default_bulk_file_name(history):
     """A None filename must not land in the history (and the UI table) as the string 'null'."""
     with patch("artwork_uploader.update_status"):
-        run_bulk_import_scrape_in_thread(Instance(mode="cli"), "# just a comment\n", None, scheduled=False)
+        run_bulk_import_scrape_in_thread(Instance(mode="cli"), "# just a comment\n", None)
 
     runs = history.get_runs()
     assert len(runs) == 1
@@ -169,7 +169,7 @@ def test_an_upload_that_exhausted_its_retries_is_counted_as_an_error(history):
         patch("artwork_uploader.update_status"),
         patch("artwork_uploader.debug_me"),
     ):
-        process_bulk_import_from_ui(Instance(mode="cli"), [MagicMock()], "retries.txt", scheduled=False)
+        process_bulk_import_from_ui(Instance(mode="cli"), [MagicMock()], "retries.txt")
 
     runs = history.get_runs()
     assert len(runs) == 1
@@ -189,7 +189,7 @@ def test_a_run_that_processes_nothing_is_recorded_as_skipped(history):
         patch("artwork_uploader.update_status"),
         patch("artwork_uploader.debug_me"),
     ):
-        process_bulk_import_from_ui(Instance(mode="cli"), [MagicMock()], "nothing.txt", scheduled=False)
+        process_bulk_import_from_ui(Instance(mode="cli"), [MagicMock()], "nothing.txt")
 
     runs = history.get_runs()
     assert len(runs) == 1

--- a/tests/test_run_history_scheduling.py
+++ b/tests/test_run_history_scheduling.py
@@ -5,6 +5,7 @@ record. Otherwise the answer to "did last night's run do anything" stays "check 
 logs" for exactly the runs that did the least.
 """
 
+import uuid
 from unittest.mock import patch
 
 import pytest
@@ -18,6 +19,11 @@ OUTCOME_FAILED = RunOutcome.FAILED.value
 OUTCOME_SKIPPED = RunOutcome.SKIPPED.value
 
 
+# A run counts as scheduled when it carries a schedule id. The value itself is
+# not read by anything under test here, only its presence.
+SCHEDULE_ID = str(uuid.uuid4())
+
+
 @pytest.fixture
 def history(tmp_path, monkeypatch):
     real_history = RunHistory(str(tmp_path / "run_history.json"))
@@ -28,7 +34,7 @@ def history(tmp_path, monkeypatch):
 @pytest.mark.unit
 def test_missing_bulk_file_is_recorded_as_failed(history):
     with patch("artwork_uploader.find_bulk_file", return_value=None):
-        process_bulk_file_on_schedule(Instance(mode="cli"), "missing.txt")
+        process_bulk_file_on_schedule(Instance(mode="cli"), "missing.txt", SCHEDULE_ID)
 
     runs = history.get_runs()
     assert len(runs) == 1
@@ -43,7 +49,7 @@ def test_empty_bulk_file_is_recorded_as_skipped(history, tmp_path):
     empty_file.write_text("", encoding="utf-8")
 
     with patch("artwork_uploader.find_bulk_file", return_value=str(empty_file)):
-        process_bulk_file_on_schedule(Instance(mode="cli"), "empty.txt")
+        process_bulk_file_on_schedule(Instance(mode="cli"), "empty.txt", SCHEDULE_ID)
 
     runs = history.get_runs()
     assert len(runs) == 1
@@ -53,7 +59,7 @@ def test_empty_bulk_file_is_recorded_as_skipped(history, tmp_path):
 @pytest.mark.unit
 def test_unexpected_failure_before_parsing_is_recorded(history):
     with patch("artwork_uploader.find_bulk_file", side_effect=RuntimeError("boom")):
-        process_bulk_file_on_schedule(Instance(mode="cli"), "broken.txt")
+        process_bulk_file_on_schedule(Instance(mode="cli"), "broken.txt", SCHEDULE_ID)
 
     runs = history.get_runs()
     assert len(runs) == 1

--- a/tests/test_stop_scrape.py
+++ b/tests/test_stop_scrape.py
@@ -10,6 +10,7 @@ loop and ArtworkProcessor's upload loops must both stop, rather than letting a
 partial harvest reach Plex.
 """
 
+import uuid
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -25,6 +26,10 @@ from core.enums import RunOutcome
 from models.callbacks import ProcessingCallbacks
 
 OUTCOME_STOPPED = RunOutcome.STOPPED.value
+
+# A run counts as scheduled when it carries a schedule id. The value itself is
+# not read by anything under test here, only its presence.
+SCHEDULE_ID = str(uuid.uuid4())
 
 
 @pytest.mark.unit
@@ -119,7 +124,7 @@ def test_cancelled_bulk_run_reports_stopped_not_success(tmp_path, monkeypatch):
     finished run gets. This drives the real process_bulk_import_from_ui
     reporting branch (with the Plex-config check and the actual scrape
     stubbed out) so the assertions exercise real branch logic on
-    globals.cancel_scrape, not a mock of it. scheduled=True so the
+    globals.cancel_scrape, not a mock of it. schedule_id=SCHEDULE_ID so the
     notification branch runs too - a suppressed notification on a cancelled
     scheduled run would leave a dangling "started" with no terminal event.
 
@@ -158,7 +163,7 @@ def test_cancelled_bulk_run_reports_stopped_not_success(tmp_path, monkeypatch):
             patch("artwork_uploader.notify_web") as mock_notify_web,
             patch("artwork_uploader.debug_me"),
         ):
-            process_bulk_import_from_ui(instance, parsed_urls, "test_bulk.txt", scheduled=True)
+            process_bulk_import_from_ui(instance, parsed_urls, "test_bulk.txt", schedule_id=SCHEDULE_ID)
 
         mock_scrape_and_upload.assert_not_called()
 


### PR DESCRIPTION
The test suite on `main` fails at `d49b159` (v1.0.1): **26 failed, 206 passed**. This fixes it, and
adds the workflow that would have shown it on the pull request that introduced it.

## The failures

#108 renamed `scheduled: bool` to `schedule_id: str` on `process_bulk_import_from_ui`,
`run_bulk_import_scrape_in_thread` and `process_bulk_file_on_schedule`. The application passes the
new argument at every call site, so v1.0.1 ships working code. Five test files still passed the old
one and failed at the call:

```
TypeError: process_bulk_import_from_ui() got an unexpected keyword argument 'scheduled'.
Did you mean 'schedule_id'?
TypeError: process_bulk_file_on_schedule() missing 1 required positional argument: 'schedule_id'
```

| File | Failures |
|---|---|
| `tests/test_notifications.py` | 10 |
| `tests/test_run_history_recording.py` | 8 |
| `tests/test_bulk_import_single_flight.py` | 4 |
| `tests/test_run_history_scheduling.py` | 3 |
| `tests/test_stop_scrape.py` | 1 |

There was no merge conflict, because the two sides changed different lines. The mismatch is in the
meaning, so nothing flagged it.

## Three commits

**The call sites.** A scheduled run carries an id and a manual run carries none, so `scheduled=True`
becomes `schedule_id=SCHEDULE_ID` and `scheduled=False` drops out. The three
`process_bulk_file_on_schedule` calls take the id as their third argument. `SCHEDULE_ID` is a module
level `str(uuid.uuid4())`, matching `tests/test_schedule_catchup.py`. No test behaviour changes and
no assertion moves.

**The lock.** Three tests in `tests/test_bulk_import_single_flight.py` built a fresh lock with
`type(globals.bulk_import_lock)()`, which is a TypeError before Python 3.13. The published image is
on 3.14, so it never showed. It pinned the suite to the newest interpreter for no reason.
`core/globals.py` builds the lock with `threading.Lock()`, and the tests now do the same.

**The CI.** `tests.yml` runs the suite on pushes to `main` and on pull requests, on 3.13 and on the
3.14 the Dockerfile ships, installing `requirements-dev.txt`. Your `pytest.ini` already sets the
paths and the output flags, so there is nothing to configure. Anything older than 3.13 is untested
rather than unsupported: pick the floor you want and the matrix follows it.

`docker-build.yml` builds the image on the same events, amd64 only and never pushed. The release
builds arm64 as well under QEMU, which is slow enough that a check on every pull request would not
earn its keep. Today only a tag push builds the image. A Dockerfile that stops building therefore
surfaces during a release rather than before one.

`tests.yml` also carries `workflow_call`, and `release.yml` now runs it before it publishes.
**That is the one behavioural change here:** a tag whose suite is red goes no further.
