### PR TITLE
Resolve the Plex libraries per run instead of once at start-up

### DIFF
--- a/artwork_uploader.py
+++ b/artwork_uploader.py
@@ -233,8 +233,8 @@ def process_scrape_url_from_web(instance: Instance, url: str) -> None:
     tally = ProcessingCallbacks()
 
     try:
-        # Check if the Plex TV and movie libraries are configured
-        if globals.plex.tv_libraries is None or globals.plex.movie_libraries is None:
+        # Stop a run that has no Plex libraries, resolving them first if we're holding none
+        if not globals.plex.ensure_libraries():
             update_status(instance, "Plex setup incomplete. Please configure your settings.", color=StatusColor.WARNING.value)
             return
 
@@ -368,8 +368,8 @@ def process_bulk_import_from_ui(instance: Instance, parsed_urls: list, filename:
 
     try:
 
-        # Check if plex setup returned valid values
-        if globals.plex.tv_libraries is None or globals.plex.movie_libraries is None:
+        # Stop a run that has no Plex libraries, resolving them first if we're holding none
+        if not globals.plex.ensure_libraries():
             update_status(instance, "Plex setup incomplete. Please check the settings.", color=StatusColor.DANGER.value)
             now = datetime.now(timezone.utc).isoformat()
             RunHistory().add_run(

--- a/plex/plex_connector.py
+++ b/plex/plex_connector.py
@@ -130,6 +130,51 @@ class PlexConnector:
         return self.movie_libraries
 
 
+    def has_libraries(self) -> bool:
+        """
+        Checks whether any Plex library has been resolved.
+
+        Returns:
+            True if at least one movie or TV library is set.
+        """
+        return bool(self.movie_libraries or self.tv_libraries)
+
+
+    def ensure_libraries(self, config: Optional[Config] = None) -> bool:
+        """
+        Resolves the configured libraries if none are held, so that a run recovers from a Plex
+        that was unreachable at start-up instead of needing the app restarted.
+
+        An empty library list matches nothing, and it looks exactly like a library that doesn't
+        hold the title, so a run made on one finds nothing, raises nothing and reports success.
+
+        Args:
+            config: Where to read the library names from. Defaults to the loaded config.
+
+        Returns:
+            True if at least one library is set by the time this returns. Never raises, so the
+            caller decides what an empty result means.
+        """
+        if self.has_libraries():
+            return True
+
+        config = config if config is not None else globals.config
+        if config is None:
+            return False
+
+        try:
+            self.set_tv_libraries(config.tv_library)
+        except Exception as e:
+            debug_me(f"Could not resolve the TV libraries: {e}")
+
+        try:
+            self.set_movie_libraries(config.movie_library)
+        except Exception as e:
+            debug_me(f"Could not resolve the movie libraries: {e}")
+
+        return self.has_libraries()
+
+
     # Find a specific collection in the movies library
     def find_collection(self, collection_title: str, fuzzy: bool = False) -> Optional[List[Collection]]:
 

--- a/tests/test_bulk_import_single_flight.py
+++ b/tests/test_bulk_import_single_flight.py
@@ -150,7 +150,8 @@ def test_bulk_import_releases_the_lock_when_plex_is_not_configured():
         globals.bulk_import_lock = threading.Lock()  # fresh, unlocked lock
         globals.scrapes_running = 0
         globals.cancel_scrape = False
-        globals.plex = MagicMock(tv_libraries=None, movie_libraries=None)
+        globals.plex = MagicMock(tv_libraries=[], movie_libraries=[])
+        globals.plex.ensure_libraries.return_value = False
 
         instance = Instance(mode="cli")
         parsed_urls = [MagicMock()]

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -280,7 +280,8 @@ def test_plex_setup_incomplete_notifies_failed_to_start_only_when_notify_enabled
     failed_to_start when notifications are enabled for it, and stay silent otherwise -
     this is the earliest exit point in the function, easy to forget when wiring events."""
     try:
-        globals.plex = MagicMock(tv_libraries=None, movie_libraries=None)
+        globals.plex = MagicMock(tv_libraries=[], movie_libraries=[])
+        globals.plex.ensure_libraries.return_value = False
         instance = Instance(mode="cli")
 
         with (

--- a/tests/test_plex_library_recovery.py
+++ b/tests/test_plex_library_recovery.py
@@ -1,0 +1,99 @@
+"""
+Tests that a run re-resolves the Plex libraries when it is holding none.
+
+Libraries are resolved once, at start-up. A Plex that is unreachable at that moment leaves
+both lists empty for the life of the process, and an empty list matches nothing, so every
+later run finds no titles and reports success having done nothing. These cover the recovery
+that stops a restart being the only way out.
+"""
+
+import pytest
+
+from core import globals
+from core.exceptions import LibraryNotFound, PlexConnectorException
+from plex.plex_connector import PlexConnector
+
+
+class _FakeConfig:
+    def __init__(self, tv_library=None, movie_library=None):
+        self.tv_library = tv_library if tv_library is not None else []
+        self.movie_library = movie_library if movie_library is not None else []
+
+
+@pytest.fixture
+def connector():
+    return PlexConnector("http://plex.example:32400", "token")
+
+
+@pytest.mark.unit
+def test_libraries_already_held_are_not_resolved_again(connector, monkeypatch):
+    """The happy path runs on every single run, so it has to cost nothing."""
+    connector.tv_libraries = [object()]
+
+    def _fail(_names):
+        raise AssertionError("libraries were re-resolved when some were already held")
+
+    monkeypatch.setattr(connector, "set_tv_libraries", _fail)
+    monkeypatch.setattr(connector, "set_movie_libraries", _fail)
+
+    assert connector.ensure_libraries(_FakeConfig(["TV Shows"], ["Movies"])) is True
+
+
+@pytest.mark.unit
+def test_empty_libraries_are_resolved_again(connector, monkeypatch):
+    monkeypatch.setattr(connector, "set_tv_libraries", lambda names: connector.tv_libraries.extend(names))
+    monkeypatch.setattr(connector, "set_movie_libraries", lambda names: connector.movie_libraries.extend(names))
+
+    assert connector.ensure_libraries(_FakeConfig(["TV Shows"], ["Movies"])) is True
+    assert connector.tv_libraries == ["TV Shows"]
+    assert connector.movie_libraries == ["Movies"]
+
+
+@pytest.mark.unit
+def test_a_plex_that_is_still_down_reports_no_libraries(connector, monkeypatch):
+    def _down(_names):
+        raise PlexConnectorException("Unable to connect to Plex server")
+
+    monkeypatch.setattr(connector, "set_tv_libraries", _down)
+    monkeypatch.setattr(connector, "set_movie_libraries", _down)
+
+    assert connector.ensure_libraries(_FakeConfig(["TV Shows"], ["Movies"])) is False
+
+
+@pytest.mark.unit
+def test_a_movies_only_configuration_has_libraries(connector, monkeypatch):
+    """An empty tv_library is a valid setup, not a failure, so it must not fail the run."""
+    monkeypatch.setattr(connector, "set_tv_libraries", lambda names: connector.tv_libraries.extend(names))
+    monkeypatch.setattr(connector, "set_movie_libraries", lambda names: connector.movie_libraries.extend(names))
+
+    assert connector.ensure_libraries(_FakeConfig([], ["Movies"])) is True
+
+
+@pytest.mark.unit
+def test_movies_are_still_resolved_when_the_tv_library_is_missing(connector, monkeypatch):
+    """set_tv_libraries raises on a renamed library. That must not cost us the movies."""
+    def _missing(_names):
+        raise LibraryNotFound('TV library named "TV Shows" not found.')
+
+    monkeypatch.setattr(connector, "set_tv_libraries", _missing)
+    monkeypatch.setattr(connector, "set_movie_libraries", lambda names: connector.movie_libraries.extend(names))
+
+    assert connector.ensure_libraries(_FakeConfig(["TV Shows"], ["Movies"])) is True
+    assert connector.movie_libraries == ["Movies"]
+
+
+@pytest.mark.unit
+def test_the_loaded_config_is_used_when_none_is_passed(connector, monkeypatch):
+    monkeypatch.setattr(globals, "config", _FakeConfig(["TV Shows"], []))
+    monkeypatch.setattr(connector, "set_tv_libraries", lambda names: connector.tv_libraries.extend(names))
+    monkeypatch.setattr(connector, "set_movie_libraries", lambda names: connector.movie_libraries.extend(names))
+
+    assert connector.ensure_libraries() is True
+    assert connector.tv_libraries == ["TV Shows"]
+
+
+@pytest.mark.unit
+def test_no_config_at_all_reports_no_libraries(connector, monkeypatch):
+    monkeypatch.setattr(globals, "config", None)
+
+    assert connector.ensure_libraries() is False

--- a/tests/test_run_history_recording.py
+++ b/tests/test_run_history_recording.py
@@ -91,7 +91,8 @@ def test_run_with_scraper_errors_is_recorded_as_partial(history):
 
 @pytest.mark.unit
 def test_plex_not_configured_is_recorded_as_failed_without_scraping(history):
-    globals.plex = MagicMock(tv_libraries=None, movie_libraries=None)
+    globals.plex = MagicMock(tv_libraries=[], movie_libraries=[])
+    globals.plex.ensure_libraries.return_value = False
     globals.config = MagicMock(apprise_urls=[])
 
     with (
@@ -105,6 +106,34 @@ def test_plex_not_configured_is_recorded_as_failed_without_scraping(history):
     assert len(runs) == 1
     assert runs[0]["outcome"] == OUTCOME_FAILED
     assert runs[0]["assets_processed"] == 0
+
+
+@pytest.mark.unit
+def test_a_run_proceeds_once_the_libraries_come_back(history):
+    """Plex was down at start-up and is up now, so the run resolves the libraries itself
+    rather than needing the container restarted."""
+    plex = MagicMock(tv_libraries=[], movie_libraries=[])
+
+    def _resolve():
+        plex.tv_libraries = ["TV Shows"]
+        return True
+
+    plex.ensure_libraries.side_effect = _resolve
+    globals.plex = plex
+    globals.config = MagicMock(apprise_urls=[])
+
+    with (
+        patch("artwork_uploader.scrape_and_upload") as mock_scrape,
+        patch("artwork_uploader.notify_web"),
+        patch("artwork_uploader.update_log"),
+        patch("artwork_uploader.update_status"),
+        patch("artwork_uploader.debug_me"),
+    ):
+        process_bulk_import_from_ui(Instance(mode="cli"), [MagicMock()], "recovered.txt")
+
+    plex.ensure_libraries.assert_called_once()
+    mock_scrape.assert_called_once()
+    assert history.get_runs()[0]["outcome"] != OUTCOME_FAILED
 
 
 @pytest.mark.unit

--- a/tests/test_run_history_scrape.py
+++ b/tests/test_run_history_scrape.py
@@ -160,7 +160,8 @@ def test_a_scraper_error_is_recorded_as_failed(history, configured_plex):
 
 @pytest.mark.unit
 def test_plex_not_configured_is_recorded_as_failed_without_scraping(history):
-    globals.plex = MagicMock(tv_libraries=None, movie_libraries=None)
+    globals.plex = MagicMock(tv_libraries=[], movie_libraries=[])
+    globals.plex.ensure_libraries.return_value = False
 
     with (
         patch("artwork_uploader.scrape_and_upload") as mock_scrape,

--- a/web_routes.py
+++ b/web_routes.py
@@ -169,7 +169,7 @@ def setup_routes(web_app, config: Config):
             return {"status": "test ok"}, 200
         if event is None:
             return {"status": "ignored"}, 200
-        if globals.plex is None or not (globals.plex.movie_libraries or globals.plex.tv_libraries):
+        if globals.plex is None or not globals.plex.has_libraries():
             update_log(Instance(broadcast=True), "⛔ Webhook received but Plex libraries are not configured")
             return {"status": "plex not configured"}, 503
         if not globals.config.webhook_tpdb_users:


### PR DESCRIPTION
In web mode the app resolves the Plex libraries once, at start-up. If Plex is not answering then,
both lists stay empty for the life of the process and nothing re-resolves them. An empty list
matches nothing, and it looks exactly like a library that does not hold the title. So every later
run finds nothing, raises nothing and reports success. Only a restart clears it. I hit this when a
compose stack brought the uploader up half a second before Plex. Six scheduled runs did no work
across two days.

## Why the existing guards miss it

Both run paths already check for this:

```python
if globals.plex.tv_libraries is None or globals.plex.movie_libraries is None:
```

`PlexConnector` assigns `[]` in `__init__` and again in `set_tv_libraries`, so the attribute is
never `None` and neither guard has ever fired. The webhook check in `web_routes.py` tests
truthiness, which is why that one path already behaves correctly.

## The change

`PlexConnector` gains `has_libraries()` and `ensure_libraries()`. The bulk and scrape paths call
`ensure_libraries()` at the start of a run, so the next run picks up a Plex that has come back,
with no restart needed. A run that still holds none stops and records itself as failed.

`has_libraries()` is an OR, so a movies-only or TV-only setup still passes. The webhook guard calls
it but does not re-resolve, because that would put a blocking Plex connect on the request thread.

## Tests

240 pass, up from 232. `tests/test_plex_library_recovery.py` covers the connector, including a Plex
that is still down, a movies-only configuration, and a missing TV library not costing the movies.
Four existing tests mocked the empty state as `tv_libraries=None`, which the connector never
produces. They now mock what it does.