### PR TITLE
RunHistory UI enhancements

### DIFF
--- a/core/constants.py
+++ b/core/constants.py
@@ -207,3 +207,31 @@ DEFAULT_NOTIFICATION_EVENTS = [
     NotificationEvent.RUN_COMPLETED_WITH_ERRORS.value,
     NotificationEvent.RUN_CANCELLED.value,
 ]
+
+# RunHistory URL source and type maps for RunHistory UI
+URL_SOURCE_MAP = {
+    "mediux.pro": "MediUX",
+    "theposterdb.com": "TPDb"
+}
+URL_TYPE_MAP = {
+    "set": {
+        "icon": "brush",
+        "label": "Set"
+    },
+    "sets": {
+        "icon": "brush",
+        "label": "Set"
+    },
+    "boxsets": {
+        "icon": "box-seam",
+        "label": "Boxset"
+    },
+    "user": {
+        "icon": "person-circle",
+        "label": "User"
+    },
+    "poster": {
+        "icon": "file-image",
+        "label": "Poster"
+    }
+}

--- a/static/web_interface.css
+++ b/static/web_interface.css
@@ -249,6 +249,10 @@ h1 {
     /* font-size: 0.875rem; Slightly smaller font size often looks cleaner for long token strings */
 }
 
+.text-monospace {
+    font-family: 'JetBrains Mono', "Courier New", "Liberation Mono", Consolas, Monaco, Menlo, SFMono-Regular, monospace !important;
+}
+
 /* Remove Bootstrap's validation checkmark icon on small numeric inputs */
 .was-validated .d-inline-block.form-control:valid,
 .was-validated .d-inline-block.form-control:invalid {
@@ -947,4 +951,17 @@ Theme Switcher Dropdown Icons (Fix dark mode SVG fills)
 
 .text-orange {
     color: #fd7e14 !important; /* Standard Bootstrap orange shade */
+}
+
+/* Apply vertical text mode only on mobile viewports below 768px */
+@media (max-width: 767.98px) {
+    th.th-vertical {
+        writing-mode: vertical-rl;
+        transform: rotate(180deg);
+        white-space: nowrap;
+        padding: 8px 0px !important;
+        height: 90px;
+        vertical-align: middle;
+        text-align: left !important;
+    }
 }

--- a/static/web_interface.js
+++ b/static/web_interface.js
@@ -1670,6 +1670,13 @@ const RUN_HISTORY_TYPE_LABELS = {
     webhook: "Webhook"
 };
 
+const RUN_HISTORY_TYPE_ICONS = {
+    bulk: "journal-text",
+    scrape: "arrow-repeat",
+    upload: "cloud-arrow-up",
+    webhook: "globe2"
+};
+
 const RUN_HISTORY_TRIGGER_LABELS = {
     manual: "Manual",
     scheduled: "Scheduled",
@@ -1677,6 +1684,14 @@ const RUN_HISTORY_TRIGGER_LABELS = {
     radarr: "Radarr",
     sonarr: "Sonarr"
 };
+
+const RUN_HISTORY_TRIGGER_ICONS = {
+    manual: "hand-index-thumb",
+    scheduled: "alarm",
+    cli: "code-square",
+    radarr: "film",
+    sonarr: "tv"
+}
 
 function formatRunDuration(startedAt, endedAt) {
     const start = new Date(startedAt);
@@ -1692,6 +1707,26 @@ document.addEventListener("DOMContentLoaded", () => {
     if (typeFilter) {
         typeFilter.addEventListener("change", loadRunHistory);
     }
+});
+
+document.addEventListener("DOMContentLoaded", () => {
+    const popoverBtn = document.getElementById("legendPopover");
+    if (!popoverBtn) return;
+
+    const popover = new bootstrap.Popover(popoverBtn, { 
+        trigger: "click",
+        container: "body"
+    });
+
+    // Dismiss when tapping/clicking anywhere outside the popover or button
+    document.addEventListener("click", (e) => {
+        const isBtn = popoverBtn.contains(e.target);
+        const isPopover = e.target.closest(".popover");
+
+        if (!isBtn && !isPopover) {
+            popover.hide();
+        }
+    });
 });
 
 function loadRunHistory() {
@@ -1723,28 +1758,34 @@ function loadRunHistory() {
         runs.forEach((run) => {
             const row = document.createElement("tr");
             const outcome = RUN_HISTORY_OUTCOME_LABELS[run.outcome] || { text: run.outcome, className: "" };
+            const triggerIcon = RUN_HISTORY_TRIGGER_ICONS[run.trigger] || "question-circle";
+            const triggerLabel = RUN_HISTORY_TRIGGER_LABELS[run.trigger] || "unknown";
+            const typeIcon = RUN_HISTORY_TYPE_ICONS[run.run_type] || "question-circle";
+            const typeLabel = RUN_HISTORY_TYPE_LABELS[run.run_type] || "unknown";
 
             const cells = [
-                new Date(run.started_at).toLocaleString(),
-                RUN_HISTORY_TYPE_LABELS[run.run_type] || run.run_type,
+                formatDateTime(run.started_at),
+                `<i class="bi bi-${typeIcon}" title="${typeLabel}"></i>`, // Run Type
                 run.label,
-                RUN_HISTORY_TRIGGER_LABELS[run.trigger] || run.trigger,
-                outcome.text,
-                run.assets_processed,
-                run.success_count,
-                run.cached_count,
-                run.locked_count,
-                run.error_count,
-                formatRunDuration(run.started_at, run.ended_at)
+                `<i class="bi bi-${triggerIcon}" title="${triggerLabel}"></i>`, // Run Trigger
+                `<i class="bi bi-${outcome.icon}" title="${outcome.text}"></i>`, // Run Outcome
+                `<span class="text-monospace">${run.assets_processed}</span>`,
+                `<span class="text-monospace">${run.success_count}</span>`,
+                `<span class="text-monospace">${run.cached_count}</span>`,
+                `<span class="text-monospace">${run.locked_count}</span>`,
+                `<span class="text-monospace">${run.error_count}</span>`,
+                `<span class="text-monospace">${formatRunDuration(run.started_at, run.ended_at)}</span>`,
             ];
 
             // Indexes match the header row: detail columns collapse on narrow screens
-            const narrowHidden = [3, 5, 6, 7, 8, 10];
+            const centeredIndexes = [1, 3, 4, 5, 6, 7, 8, 9, 10];
             cells.forEach((value, index) => {
                 const cell = document.createElement("td");
-                cell.textContent = value;
-                if (index === 4) { cell.className = outcome.className; }
-                if (narrowHidden.includes(index)) { cell.classList.add("d-none", "d-md-table-cell"); }
+                cell.innerHTML = value;
+                if (index === 4) { cell.className = `text-${outcome.iconColor}`; }
+                if (centeredIndexes.includes(index)) {
+                    cell.classList.add("text-center");
+                }
                 row.appendChild(cell);
             });
 

--- a/templates/web_interface.html
+++ b/templates/web_interface.html
@@ -1211,28 +1211,103 @@
                         <option value="upload">Uploads</option>
                         <option value="webhook">Webhook imports</option>
                     </select>
+                    <button type="button" 
+                            class="btn btn-sm btn-outline-secondary border-0 p-1" 
+                            id="legendPopover" 
+                            data-bs-toggle="popover" 
+                            data-bs-html="true" 
+                            data-bs-content='
+                                <div class="small">
+                                <div class="fw-bold text-muted mb-1">Type</div>
+                                <div><i class="bi bi-journal-text me-1"></i> Bulk import</div>
+                                <div><i class="bi bi-arrow-repeat me-1"></i> Scrape</div>
+                                <div><i class="bi bi-cloud-arrow-up me-1"></i> Upload</div>
+                                <div><i class="bi bi-globe2 me-1"></i> Webhook</div>
+
+                                <div class="fw-bold text-muted mt-2">URL Type</div>
+                                <div><i class="bi bi-brush me-1"></i> Set</div>
+                                <div><i class="bi bi-file-image me-1"></i> Poster</div>
+                                <div><i class="bi bi-box-seam me-1"></i> Boxset</div>
+                                <div><i class="bi bi-person-circle me-1"></i> User</div>
+                                
+                                <div class="fw-bold text-muted mt-2 mb-1">Trigger</div>
+                                <div><i class="bi bi-hand-index-thumb me-1"></i> Manual</div>
+                                <div><i class="bi bi-alarm me-1"></i> Scheduled</div>
+                                <div><i class="bi bi-code-square me-1"></i> CLI</div>
+                                <div><i class="bi bi-film me-1"></i> Radarr</div>
+                                <div><i class="bi bi-tv me-1"></i> Sonarr</div>
+
+                                <div class="fw-bold text-muted mt-2 mb-1">Outcome</div>
+                                <div><i class="bi text-success bi-check-circle-fill me-1"></i> Completed</div>
+                                <div><i class="bi text-warning bi-exclamation-circle-fill me-1"></i> Completed with errors</div>
+                                <div><i class="bi text-orange bi-stop-circle-fill me-1"></i> Stopped</div>
+                                <div><i class="bi text-danger bi-x-circle-fill me-1"></i> Failed</div>
+                                <div><i class="bi text-info bi-fast-forward-circle-fill me-1"></i> Skipped</div>
+                                </div>
+                            '>
+                        <i class="bi bi-question-circle"></i>
+                    </button>
                 </div>
                 <div class="mt-3 table-responsive">
                     <table class="table table-sm align-middle">
                         <thead>
                             <tr>
                                 <th>Started</th>
-                                <th>Type</th>
+                                <th class="th-vertical text-center">Type</th>
                                 <th>Run</th>
-                                <th class="d-none d-md-table-cell">Trigger</th>
-                                <th>Outcome</th>
-                                <th class="d-none d-md-table-cell">Processed</th>
-                                <th class="d-none d-md-table-cell">Updated</th>
-                                <th class="d-none d-md-table-cell">Cached</th>
-                                <th class="d-none d-md-table-cell">Locked</th>
-                                <th>Errors</th>
-                                <th class="d-none d-md-table-cell">Duration</th>
+                                <th class="th-vertical text-center">Trigger</th>
+                                <th class="th-vertical text-center">Outcome</th>
+                                <th class="th-vertical text-center">Processed</th>
+                                <th class="th-vertical text-center">Updated</th>
+                                <th class="th-vertical text-center">Cached</th>
+                                <th class="th-vertical text-center">Locked</th>
+                                <th class="th-vertical text-center">Errors</th>
+                                <th class="th-vertical text-center">Duration</th>
                             </tr>
                         </thead>
                         <tbody id="run_history_body">
                             <tr><td colspan="11" class="text-muted">No runs recorded yet.</td></tr>
                         </tbody>
                     </table>
+                </div>
+                <div class="sticky-bottom pb-3 z-3 d-flex justify-content-end align-items-center gap-2">
+                    <div class="dropdown">
+                        <button class="btn btn-secondary shadow rounded-pill d-flex align-items-center gap-2 dropdown-toggle fab-collapse collapsed"
+                                id="bd-theme"
+                                type="button"
+                                aria-expanded="false"
+                                data-bs-toggle="dropdown"
+                                aria-label="Toggle theme (auto)">
+                            <svg class="bi my-1 theme-icon-active text-white" width="1em" height="1em"><use href="#circle-half"></use></svg>
+                            <span class="caret-wrapper d-inline-flex align-items-center">
+                                <i class="bi bi-caret-down-fill" style="font-size: 0.65rem;"></i>
+                            </span>
+                            <span class="visually-hidden" id="bd-theme-text">Toggle theme</span>
+                        </button>
+                        <ul class="dropdown-menu dropdown-menu-end shadow" aria-labelledby="bd-theme-text">
+                            <li>
+                                <button type="button" class="dropdown-item d-flex align-items-center" data-bs-theme-value="light" aria-pressed="false">
+                                    <svg class="bi me-2 opacity-50 theme-icon" width="1em" height="1em"><use href="#sun-fill"></use></svg>
+                                    Light
+                                    <svg class="bi ms-auto d-none" width="1em" height="1em"><use href="#check2"></use></svg>
+                                </button>
+                            </li>
+                            <li>
+                                <button type="button" class="dropdown-item d-flex align-items-center" data-bs-theme-value="dark" aria-pressed="false">
+                                    <svg class="bi me-2 opacity-50 theme-icon" width="1em" height="1em"><use href="#moon-stars-fill"></use></svg>
+                                    Dark
+                                    <svg class="bi ms-auto d-none" width="1em" height="1em"><use href="#check2"></use></svg>
+                                </button>
+                            </li>
+                            <li>
+                                <button type="button" class="dropdown-item d-flex align-items-center active" data-bs-theme-value="auto" aria-pressed="true">
+                                    <svg class="bi me-2 opacity-50 theme-icon" width="1em" height="1em"><use href="#circle-half"></use></svg>
+                                    Auto
+                                    <svg class="bi ms-auto d-none" width="1em" height="1em"><use href="#check2"></use></svg>
+                                </button>
+                            </li>
+                        </ul>
+                    </div>
                 </div>
             </div>
 

--- a/web_routes.py
+++ b/web_routes.py
@@ -28,7 +28,7 @@ from processors.media_metadata import parse_title
 from utils.notifications import update_log, update_status, notify_web, debug_me
 from services import UtilityService, AuthenticationService, RunHistory
 from services.webhook_service import parse_event
-from core.constants import UPLOAD_CHUNK_SIZE, UPLOAD_CHUNK_TIMEOUT, WEBHOOK_TOKEN_HEADER
+from core.constants import UPLOAD_CHUNK_SIZE, UPLOAD_CHUNK_TIMEOUT, WEBHOOK_TOKEN_HEADER, URL_SOURCE_MAP, URL_TYPE_MAP
 
 def login_required(f):
     """Decorator to require authentication for routes."""
@@ -368,6 +368,24 @@ def setup_socket_handlers(
         if run_type not in RunType:
             run_type = None
         runs = RunHistory().get_runs(limit=50, run_type=run_type)
+        for run in runs:
+            label = run.get("label", "")
+            if label and "https" in label:
+                clean_url = label.replace("https://", "").strip()
+                parts = [p for p in clean_url.split("/") if p]
+                if len(parts) >= 3:
+                    domain, asset_type, id = parts[0], parts[1], parts[2]
+                    source = URL_SOURCE_MAP.get(domain, "Unknown")
+                    type = URL_TYPE_MAP.get(asset_type, { "icon": "question-circle", "label": "Unknown URL type" })
+                    run["label"] = (
+                        f'<a href="{label}" target="_blank" rel="noopener noreferrer" '
+                        f"class='text-decoration-none text-reset' title='{label}'>{source} "
+                        f"<i class='bi bi-{type.get("icon", "question-circle")}' title='{type.get("label", "Unknown URL type")}'></i> "
+                        f"<span class='input-monospace' style='font-size: 0.8rem;'>{id}</span></span>"
+                    )
+                else:
+                    run["label"] = f"<i class='bi bi-x-octagon text-danger' title='{label}'>&nbsp;Error parsing URL</i>"
+
         notify_web(instance, "load_run_history", {"runs": runs, "run_type": run_type or "all"})
 
     @globals.web_socket.on("load_bulk_import")


### PR DESCRIPTION
- Redesigned some UI elements to take less horizontal space in general and not have to sacrifice columns in mobile view
- Uses icons for Type, Trigger and Outcome columns
- Use the same status icons from the bulk schedule configuration popover for the Outcome column
- Uses relative date format (Today at 17:47, Yesterday at 12:00, Aug 14, 05:44)
- Heading labels turn vertical on narrow displays
- Parse URLs for individual scrape runs to produce a symbolic representation of a URL to save space, with link to open URL in new tab
- Provide a legend as a drop-down popover next to the run type selectbox