### PR TITLE
Skip collection set artwork for movies that are not in the collection

### DIFF
--- a/scrapers/mediux_scraper.py
+++ b/scrapers/mediux_scraper.py
@@ -368,8 +368,16 @@ class MediuxScraper:
                 
                 # If it's a collection set, we obtain movie title and year from the collection map we built earlier
                 elif collection_data:
-                    title = collection_map[movie_id]["title"]
-                    year = collection_map[movie_id]["year"]
+                    # A set can include artwork for a related movie that is not part of the
+                    # collection itself, in which case it won't be in the collection map
+                    movie_info = collection_map.get(movie_id)
+                    if movie_info is None:
+                        self.callbacks.debug(f"⏩ Skipping movie asset - movie {movie_id} is not part of this collection")
+                        self.callbacks.log(f"⚠️ {self.title} • {self.author} | Skipping movie asset - not part of this collection")
+                        self.errored += 1
+                        continue
+                    title = movie_info["title"]
+                    year = movie_info["year"]
 
                 else:
                     self.callbacks.debug(f"⏩ Skipping asset - missing metadata")

--- a/tests/test_mediux_scraper_collection.py
+++ b/tests/test_mediux_scraper_collection.py
@@ -6,6 +6,9 @@ literal word "Collection" raised:
     UnboundLocalError: cannot access local variable 'year' ...
 because collection artwork was mis-routed into the movie branch (which references
 `year`, only set for individual-movie artwork).
+
+Also covers the bug where a collection set including artwork for a movie outside
+the collection raised KeyError and abandoned the whole set.
 """
 
 from unittest.mock import patch
@@ -63,3 +66,53 @@ def test_collection_with_word_collection_in_name_still_works():
     scraper._process_set(_collection_poster_set("James Bond Collection"))
     assert len(scraper.collection_artwork) == 1
     assert scraper.collection_artwork[0]["title"] == "James Bond Collection"
+
+
+def _movie_poster(image_id, movie_id):
+    return {
+        "movie_id": {"id": movie_id},
+        "collection_id": None,
+        "show_id": None,
+        "show_id_backdrop": None,
+        "episode_id": None,
+        "season_id": None,
+        "id": image_id,
+        "fileType": "poster",
+    }
+
+
+def _collection_set_with_orphan_movie():
+    """A collection of two movies, plus artwork for a third movie outside it."""
+    files = [
+        {
+            "movie_id": None,
+            "collection_id": {"id": 1},
+            "show_id": None,
+            "show_id_backdrop": None,
+            "episode_id": None,
+            "season_id": None,
+            "id": "img-collection",
+            "fileType": "poster",
+        },
+        _movie_poster("img-first", "101"),
+        _movie_poster("img-orphan", "999"),  # not in the collection's movie list
+        _movie_poster("img-second", "102"),
+    ]
+    collection = {
+        "collection_name": "Example Collection",
+        "movies": [
+            {"id": "101", "title": "First Movie", "release_date": "1994-02-04"},
+            {"id": "102", "title": "Second Movie", "release_date": "1995-11-10"},
+        ],
+    }
+    return {"files": files, "collection": collection}
+
+
+@pytest.mark.unit
+def test_movie_outside_collection_is_skipped_without_losing_the_set():
+    # Regression: this used to raise KeyError('999') and lose every asset in the set.
+    scraper = _make_scraper()
+    scraper._process_set(_collection_set_with_orphan_movie())
+    assert [a["title"] for a in scraper.movie_artwork] == ["First Movie", "Second Movie"]
+    assert len(scraper.collection_artwork) == 1
+    assert scraper.errored == 1


### PR DESCRIPTION
Fixes #118

A MediUX collection set can include artwork for a related movie that is not part of the collection itself. `collection_map` only covers the collection's own movies, so the lookup for such a file raised KeyError and the whole set failed to scrape, valid assets included. Live example: https://mediux.pro/sets/49921 carries a fourth poster for Ace Ventura Jr, which is not in the Ace Ventura collection, and the set scrapes zero assets.

The fix looks the movie up with `.get()` and, when it is missing, skips just that asset using the same pattern as the existing season and episode metadata guards: debug + log, `errored += 1`, `continue`. Skipped assets surface in the existing "Skipped N asset(s)" summary.

Also adds a regression test to `tests/test_mediux_scraper_collection.py` with a crafted payload (no network): the orphan movie sits between two valid ones, and the test asserts both valid movie posters and the collection poster survive with `errored == 1`.

Verified against the live set with the container's Python (collect only, no uploads):

```
stock  v1.0.3: ScraperException: Can't scrape from MediUX: '15338'
patched      : OK  movie=2 collection=1 errored=1
```

Full test suite passes (241 tests).
