### PR TITLE
Reload the page when the backend version changes under an open tab

### DIFF
--- a/static/web_interface.js
+++ b/static/web_interface.js
@@ -511,8 +511,21 @@ function detectEnvironment() {
     socket.emit("check_for_update", { instance_id: instanceId });
 }
 
+// Backend version this page was loaded against, learned from the first version_check
+let knownBackendVersion = null;
+
 socket.on("version_check", function(data) {
     if(validResponse(data, true)){
+        if (knownBackendVersion === null) {
+            knownBackendVersion = data.current_version;
+        } else if (data.current_version !== knownBackendVersion) {
+            // The backend was updated while this page was open, so this JS is stale
+            updateStatus("Backend updated, refreshing frontend too...", "warning", true, true, "arrow-counterclockwise")
+            setTimeout(() => {
+                location.reload();
+            }, 3000);
+            return;
+        }
         if (data.new_version) {
             // Show update notifier
             document.getElementById("latest_version").innerText = data.new_version;
@@ -2774,6 +2787,13 @@ socket.on("backend_restarting", function() {
     setTimeout(() => {
         location.reload();  // Reload the page
     }, 3000);  // Delay for 3 seconds to ensure restart
+});
+
+// After a reconnect the backend may have been updated while this page was open
+socket.on("connect", function() {
+    if (knownBackendVersion !== null) {
+        socket.emit("check_for_update", { instance_id: instanceId });
+    }
 });
 
 // Detect when the WebSocket connection is lost


### PR DESCRIPTION
### Problem

A tab left open across a backend update keeps running the old frontend JS. The app already self-heals by reloading on disconnect, but that reload does not always fire: in a background tab on a sleeping machine the throttled timer never runs, and Socket.IO still reconnects quietly on wake. The stale JS then keeps driving the new backend.

Real case from today, 1.0.3 to 1.0.4 via an overnight Watchtower pull: the run history labels now arrive as HTML, but the 1.0.3 JS still rendered them with `textContent`, so the Run column showed raw markup.

To reproduce: open the UI, restart the container on a different version, let the socket reconnect, then use the UI without reloading.

### Fix

Twenty lines in `web_interface.js`, no backend changes:

- Remember `current_version` from the first `version_check`.
- On every `connect` after that, emit `check_for_update` again.
- If the version came back different, show the usual status toast and reload, same pattern as `backend_restarting`.

First connects and reconnects to an unchanged backend behave exactly as before, so network blips and laptop sleep do not cause extra reloads.
